### PR TITLE
Update to support dynamic map bounds. 

### DIFF
--- a/config/example.config.php
+++ b/config/example.config.php
@@ -22,6 +22,17 @@ use Medoo\Medoo;
 $startingLat = 52.084992;                                          // Starting latitude
 $startingLng = 5.302366;                                           // Starting longitude
 
+/* Map Boundary settings */
+/* Set NW lat, lng (top left corner) and SE lat, lng (bottom right corner) of viewable map area. */
+/* Notheast -90,-180 Southwest 90,180 = full boundary of planet or no boundaries */
+/* fixes max zoom out leaving grey border in browser and multiple tiling of planet */
+
+$boundslatNW = -90; //default -90 = no bounds
+$boundslngNW = -180; //default -180 = no bounds
+$boundslatSE = 90; //default 90 = no bounds
+$boundslngSE = 180; //default 180 = no bounds
+
+
 /* Zoom and Cluster Settings */
 
 $maxLatLng = 1;                                                     // Max latitude and longitude size (1 = ~110km, 0 to disable)

--- a/pre-index.php
+++ b/pre-index.php
@@ -218,7 +218,7 @@ if ( $blockIframe ) {
     <link rel="stylesheet" href="node_modules/leaflet/dist/leaflet.css" />
     <link rel="stylesheet" href="static/dist/css/app.min.css">
     <?php if ( file_exists( 'static/css/custom.css' ) ) {
-        echo '<link rel="stylesheet" href="static/css/custom.css">';
+        echo '<link rel="stylesheet" href="static/css/custom.css?' . time() . '">';
     } ?>
     <link rel="stylesheet" href="node_modules/leaflet.markercluster/dist/MarkerCluster.css" />
     <link rel="stylesheet" href="node_modules/leaflet.markercluster/dist/MarkerCluster.Default.css" />
@@ -1934,6 +1934,10 @@ if ( $blockIframe ) {
 <script>
     var centerLat = <?= $startingLat; ?>;
     var centerLng = <?= $startingLng; ?>;
+    var boundslatNW = <?= $boundslatNW; ?>;
+    var boundslngNW = <?= $boundslngNW; ?>;
+    var boundslatSE = <?= $boundslatSE; ?>;
+    var boundslngSE = <?= $boundslngSE; ?>;
     var locationSet = <?= $locationSet; ?>;
     var motd = <?php echo $noMotd ? 'false' : 'true' ?>;
     var zoom<?php echo $zoom ? " = " . $zoom : null; ?>;

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -319,7 +319,7 @@ function createServiceWorkerReceiver() {
 }
 
 function initMap() { // eslint-disable-line no-unused-vars
-    bounds = new L.LatLngBounds(new L.LatLng(boundslatNW, boundslngNW), new L.LatLng(boundslatSE, boundslngSE)); //create boundary
+    bounds = new L.LatLngBounds(new L.LatLng(boundslatNW, boundslngNW), new L.LatLng(boundslatSE, boundslngSE)) // create boundary
     map = L.map('map', {
         center: [centerLat, centerLng],
         zoom: zoom == null ? Store.get('zoomLevel') : zoom,
@@ -328,12 +328,12 @@ function initMap() { // eslint-disable-line no-unused-vars
         zoomControl: false,
         preferCanvas: true,
         layers: [weatherLayerGroup, exLayerGroup, gymLayerGroup, stopLayerGroup, scanAreaGroup, nestLayerGroup],
-        maxBounds: bounds //set boudary after layers defined 
+        maxBounds: bounds // set boudary after layers defined
     })
-    latlngs = L.rectangle(bounds).getLatLngs();
-		L.polyline(latlngs[0].concat(latlngs[0][0])).addTo(map); //add boundary to map
-		map.setMaxBounds(bounds);	// Should not enter infinite recursion //add
-    
+    latlngs = L.rectangle(bounds).getLatLngs()
+        L.polyline(latlngs[0].concat(latlngs[0][0])).addTo(map) // add boundary to map
+        map.setMaxBounds(bounds)	// Should not enter infinite recursion
+
     setTileLayer(Store.get('map_style'))
     markers = L.markerClusterGroup({
         disableClusteringAtZoom: disableClusteringAtZoom,

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -71,6 +71,10 @@ var numberOfPokemon = 493
 var numberOfItem = 1405
 var bounds
 var latlngs
+var boundslatNW
+var boundslngNW
+var boundslatSE
+var boundslngSE
 var L
 var map
 var markers
@@ -331,8 +335,8 @@ function initMap() { // eslint-disable-line no-unused-vars
         maxBounds: bounds // set boudary after layers defined
     })
     latlngs = L.rectangle(bounds).getLatLngs()
-        L.polyline(latlngs[0].concat(latlngs[0][0])).addTo(map) // add boundary to map
-        map.setMaxBounds(bounds)	// Should not enter infinite recursion
+    L.polyline(latlngs[0].concat(latlngs[0][0])).addTo(map) // add boundary to map
+    map.setMaxBounds(bounds)	// Should not enter infinite recursion
 
     setTileLayer(Store.get('map_style'))
     markers = L.markerClusterGroup({

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -69,6 +69,8 @@ var reloaddustamount
 
 var numberOfPokemon = 493
 var numberOfItem = 1405
+var bounds
+var latlngs
 var L
 var map
 var markers
@@ -317,6 +319,7 @@ function createServiceWorkerReceiver() {
 }
 
 function initMap() { // eslint-disable-line no-unused-vars
+    bounds = new L.LatLngBounds(new L.LatLng(boundslatNW, boundslngNW), new L.LatLng(boundslatSE, boundslngSE)); //create boundary
     map = L.map('map', {
         center: [centerLat, centerLng],
         zoom: zoom == null ? Store.get('zoomLevel') : zoom,
@@ -324,9 +327,13 @@ function initMap() { // eslint-disable-line no-unused-vars
         maxZoom: maxZoom,
         zoomControl: false,
         preferCanvas: true,
-        layers: [weatherLayerGroup, exLayerGroup, gymLayerGroup, stopLayerGroup, scanAreaGroup, nestLayerGroup]
+        layers: [weatherLayerGroup, exLayerGroup, gymLayerGroup, stopLayerGroup, scanAreaGroup, nestLayerGroup],
+        maxBounds: bounds //set boudary after layers defined 
     })
-
+    latlngs = L.rectangle(bounds).getLatLngs();
+		L.polyline(latlngs[0].concat(latlngs[0][0])).addTo(map); //add boundary to map
+		map.setMaxBounds(bounds);	// Should not enter infinite recursion //add
+    
     setTileLayer(Store.get('map_style'))
     markers = L.markerClusterGroup({
         disableClusteringAtZoom: disableClusteringAtZoom,

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -336,7 +336,7 @@ function initMap() { // eslint-disable-line no-unused-vars
     })
     latlngs = L.rectangle(bounds).getLatLngs()
     L.polyline(latlngs[0].concat(latlngs[0][0])).addTo(map) // add boundary to map
-    map.setMaxBounds(bounds)	// Should not enter infinite recursion
+    map.setMaxBounds(bounds) // Should not enter infinite recursion
 
     setTileLayer(Store.get('map_style'))
     markers = L.markerClusterGroup({


### PR DESCRIPTION
Limit viewable map area to boundaries. Solves multiple tile display on max zoom out. Follows format and works with access-config and can be configured for multiple areas. 
--Added versioning logic to pre-index.php to force no-cache of custom.css. 