### PR TITLE
Fix `Quests only` unresponsiveness with large Pokéstop payload on eve…

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -5000,8 +5000,8 @@ function processPokestops(i, item, lastMidnight) {
     }
 }
 
-function pokestopMeetsQuestFilter(value, lastMidnight) {
-    if (value['quest_type'] === 0 || lastMidnight > Number(value['quest_timestamp']) || ((value['quest_pokemon_id'] > 0 && questsExcludedPokemon.indexOf(value['quest_pokemon_id']) > -1) || (value['quest_item_id'] > 0 && questsExcludedItem.indexOf(value['quest_item_id']) > -1) || ((value['quest_reward_type'] === 3 && (Number(value['quest_dust_amount']) < Number(Store.get('showDustAmount')))) || (value['quest_reward_type'] === 3 && Store.get('showDustAmount') === 0)))) {
+function pokestopMeetsQuestFilter(pokestop, lastMidnight) {
+    if (pokestop['quest_type'] === 0 || lastMidnight > Number(pokestop['quest_timestamp']) || ((pokestop['quest_pokemon_id'] > 0 && questsExcludedPokemon.indexOf(pokestop['quest_pokemon_id']) > -1) || (pokestop['quest_item_id'] > 0 && questsExcludedItem.indexOf(pokestop['quest_item_id']) > -1) || ((pokestop['quest_reward_type'] === 3 && (Number(pokestop['quest_dust_amount']) < Number(Store.get('showDustAmount')))) || (pokestop['quest_reward_type'] === 3 && Store.get('showDustAmount') === 0)))) {
         return false
     } else {
         return true


### PR DESCRIPTION
…ry refresh.

**ISSUE #1:**
With `Quests only` selected, PMSF added ALL the Pokéstops returned by raw_data regardless of the active Quests filter on EVERY refresh payload and then DELETED most of them milliseconds later. This is highly inefficient and caused issues for some (see issue #2). Other Pokéstop modes didn’t exhibit this behavior.

Example: For a large visible area (zoomed out) with `Quest only` selected to only display Silver Pinap, raw_data returned ~150 updated Pokéstops since last timestamp, those ~150 stops were added to `mapData` including the creation of their markers and then `updatePokestops` deleted those that didn’t meet the active quest filter a couple lines later (most of them in this case).

**FIX #1:**
- In `processPokestops`, we now check if `Quests only` is selected and simply skip processing the _new_ Pokéstops that do not meet the active Quest filter. Already existing (visible) Pokéstop are still processed normally since they could need updating for Invasion, Lure, etc.
- Instead of duplicating code already used elsewhere to check a Pokéstop against the active Quests filter, a function is created to keep things centralized for future changes.
- I choose to pass `lastMidnight` as a parameter so that it is constructed only once per refresh payload instead of many times per refresh payload (the number of Pokéstop received, ~150 times in my example above) to reduce the client load.

**ISSUE #2 (NOT FIXED):**
Although FIX#1 makes the client much more responsive and the sluggishness/unresponsiveness a non-issue, it does not address the core issue. If properly executed, the addition and removal of 150 Pokéstops every 2 seconds should not be causing a constant increase in both the processing time of the `processPokestops` function and memory usage to the point where the map becomes unresponsive. Since FIX#1 makes it a non-issue and that’s out of my wheelhouse, I am stopping here and leaving it to the more experienced coders to find the reason why if they so desire.

**BEFORE FIX (and what I mean in issue #2):**
```
11:50:43.840 map.js:5315 ProcessTime: 219ms ## BeforeProcess(4) AfterProcess(180) AfterUpdate(4)
11:55:01.713 map.js:5315 ProcessTime: 249ms ## BeforeProcess(4) AfterProcess(153) AfterUpdate(4)
11:59:58.004 map.js:5315 ProcessTime: 557ms ## BeforeProcess(4) AfterProcess(164) AfterUpdate(4)
12:04:52.040 map.js:5315 ProcessTime: 662ms ## BeforeProcess(4) AfterProcess(151) AfterUpdate(4)
12:09:28.183 map.js:5315 ProcessTime: 834ms ## BeforeProcess(4) AfterProcess(154) AfterUpdate(4)
12:14:38.344 map.js:5315 ProcessTime: 1024ms ## BeforeProcess(4) AfterProcess(158) AfterUpdate(4)
12:19:06.640 map.js:5315 ProcessTime: 1340ms ## BeforeProcess(4) AfterProcess(182) AfterUpdate(4)
12:24:38.995 map.js:5315 ProcessTime: 1744ms ## BeforeProcess(4) AfterProcess(205) AfterUpdate(4)
12:29:51.108 map.js:5315 ProcessTime: 1844ms ## BeforeProcess(4) AfterProcess(186) AfterUpdate(4)
```

**AFTER FIX (still with issue #2 unfixed but no more mass add/delete and much faster processing for the same refresh payload):**
```
09:00:30.488 map.js:5339 ProcessTime: 1ms ## BeforeProcess(6) AfterProcess(6) AfterUpdate(6)
09:05:48.578 map.js:5339 ProcessTime: 1ms ## BeforeProcess(6) AfterProcess(6) AfterUpdate(6)
09:11:08.600 map.js:5339 ProcessTime: 3ms ## BeforeProcess(6) AfterProcess(6) AfterUpdate(6)
09:16:28.589 map.js:5339 ProcessTime: 1ms ## BeforeProcess(6) AfterProcess(6) AfterUpdate(6)
09:21:50.946 map.js:5339 ProcessTime: 1ms ## BeforeProcess(6) AfterProcess(6) AfterUpdate(6)
09:27:10.848 map.js:5339 ProcessTime: 2ms ## BeforeProcess(6) AfterProcess(6) AfterUpdate(6)
09:32:30.838 map.js:5339 ProcessTime: 1ms ## BeforeProcess(6) AfterProcess(6) AfterUpdate(6)
09:33:08.475 map.js:5339 ProcessTime: 1ms ## BeforeProcess(6) AfterProcess(6) AfterUpdate(6)
```

**LEGEND:**
ProcessTime: Start/End timer around `$.each(result.pokestops, processPokestops)`
BeforeProcess: `Object.keys(mapData.pokestops).length` before `$.each(result.pokestops, processPokestops)`
AfterProcess: `Object.keys(mapData.pokestops).length` after `$.each(result.pokestops, processPokestops)`
AfterUpdate: `Object.keys(mapData.pokestops).length` after ` updatePokestops()`