### PR TITLE
Geo uri support

### DIFF
--- a/pre-index.php
+++ b/pre-index.php
@@ -1416,6 +1416,7 @@ if (!$noLoadingScreen) {
                     <option value="google_pin">' . i8ln('Google (Pin)') . '</option>
                     <option value="waze">' . i8ln('Waze') . '</option>
                     <option value="bing">' . i8ln('Bing') . '</option>
+                    <option value="geouri">' . i8ln('GeoUri') . '</option>
                 </select>
             </div>';
             }

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1224,6 +1224,9 @@ function openMapDirections(lat, lng) { // eslint-disable-line no-unused-vars
         case 'bing':
             url = 'https://www.bing.com/maps/?v=2&where1=' + lat + ',' + lng
             break
+        case 'geouri':
+            url = 'geo:' + lat + ',' + lng
+            break
     }
     window.open(url, '_blank')
 }


### PR DESCRIPTION
Adds a new direction provider: geo uri.

What is it? 
instead of linking to google maps direction it links to a `geo:lat,lon` link. This link will (on Android phones) allow the user to select their map app of choice at the time of clicking the link.

Example:
![image](https://user-images.githubusercontent.com/5710881/82366410-70284e80-9a12-11ea-93bb-7d11a27fa1fd.png)

![image](https://user-images.githubusercontent.com/5710881/82366289-4838eb00-9a12-11ea-891a-78ebcf2858b0.png)

Unfortunately this uri scheme does not seem to be supported on iOS at this time, but it's a cool feature in any case.