### PR TITLE
MAD: level key doesn't exist = undefined. Compute from cp_multiplier

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2131,8 +2131,9 @@ function getTimeUntil(time) {
 
 function getNotifyText(item) {
     var iv = getIv(item['individual_attack'], item['individual_defense'], item['individual_stamina'])
+    var level = (item['level'] != null) ? item['level'] : getPokemonLevel(item['cp_multiplier'])
     var find = ['<prc>', '<pkm>', '<lv>', '<atk>', '<def>', '<sta>']
-    var replace = [iv ? iv.toFixed(1) : '', item['pokemon_name'], item['level'], item['individual_attack'], item['individual_defense'], item['individual_stamina']]
+    var replace = [iv ? iv.toFixed(1) : '', item['pokemon_name'], level, item['individual_attack'], item['individual_defense'], item['individual_stamina']]
     var ntitle = repArray(iv ? notifyIvTitle : notifyNoIvTitle, find, replace)
     var dist = new Date(item['disappear_time']).toLocaleString([], {
         hour: '2-digit',


### PR DESCRIPTION
MAD doesn't have a `level` key and displays `undefined` for the level in the notification window.
Simply compute the level from the `cp_multiplier` like everywhere else to fix the issue