### PR TITLE
MAD Fix: `Notify of Level` could never trigger

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2213,8 +2213,8 @@ function customizePokemonMarker(marker, item, skipNotification) {
         }
     }
 
-    if (item['level'] != null) {
-        var level = item['level']
+    if (item['level'] != null || item['cp_multiplier'] != null) {
+        var level = (item['level'] != null) ? item['level'] : getPokemonLevel(item['cp_multiplier'])
         if (notifiedMinLevel > 0 && level >= notifiedMinLevel) {
             if (!skipNotification) {
                 checkAndCreateSound(item['pokemon_id'])


### PR DESCRIPTION
MAD doesn't have a `level` key so it could never trigger. This simply adds the MAD condition and proper level compute for both platforms.