### PR TITLE
Changing the nest table format

### DIFF
--- a/sql/manualdb/update13_manualdb.sql
+++ b/sql/manualdb/update13_manualdb.sql
@@ -5,6 +5,4 @@ ADD `pokemon_ratio` double DEFAULT 0,
 ADD `polygon_type` tinyint(1) DEFAULT 0,
 ADD `polygon_path` varchar(500) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
 
-ADD `unknown_name` tinyint(1) DEFAULT 0,
-
 DROP `nest_submitted_by`;

--- a/sql/manualdb/update13_manualdb.sql
+++ b/sql/manualdb/update13_manualdb.sql
@@ -1,0 +1,10 @@
+ALTER TABLE `nests`
+ADD `pokemon_form` smallint(6) DEFAULT NULL,
+ADD `pokemon_ratio` double DEFAULT 0,
+
+ADD `polygon_type` tinyint(1) DEFAULT 0,
+ADD `polygon_path` varchar(500) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+
+ADD `unknown_name` tinyint(1) DEFAULT 0,
+
+DROP `nest_submitted_by`;

--- a/sql/manualdb/update13_manualdb.sql
+++ b/sql/manualdb/update13_manualdb.sql
@@ -3,6 +3,4 @@ ADD `pokemon_form` smallint(6) DEFAULT NULL,
 ADD `pokemon_ratio` double DEFAULT 0,
 
 ADD `polygon_type` tinyint(1) DEFAULT 0,
-ADD `polygon_path` varchar(500) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-
-DROP `nest_submitted_by`;
+ADD `polygon_path` text COLLATE utf8mb4_unicode_ci DEFAULT NULL;


### PR DESCRIPTION
My nestscript fork will require a different table structure. this PR adds an update sql file.

It's only removing the `nest_submitted_by` columns which is neither being used by PMSF nor by madaos script. So it should be compatible