### PR TITLE
WIP: Pokemon search

### DIFF
--- a/config/default.php
+++ b/config/default.php
@@ -486,6 +486,7 @@ $noSearchGyms = false;          //Wont work if noSearch = false
 $noSearchManualQuests = false;  //Wont work if noSearch = false
 $noSearchNests = true;
 $noSearchPortals = true;
+$noSearchPokemon = false;
 $defaultUnit = "km";                                            // mi/km
 $maxSearchResults = 10;
 $maxSearchNameLength = 0;	// 0 = Unlimited. Shorten pokestop names in reward search results if longer than this value to prevent UI layout issues

--- a/pre-index.php
+++ b/pre-index.php
@@ -2021,6 +2021,9 @@ if (!$noLoadingScreen) {
                         <?php if (! $noQuests && ! $noSearchManualQuests) { ?>
                             <li><a href="#tab-rewards"><img src="static/images/reward.png"/></a></li>
                         <?php }
+                        if (! $noSearchPokemon) { ?>
+                            <li><a href="#tab-pokemon"><img src="static/images/pokeball.png"/></a></li>
+                        <?php }
                         if (! $noSearchNests) { ?>
                             <li><a href="#tab-nests"><img src="static/images/nest.png"/></a></li>
                         <?php }
@@ -2040,6 +2043,14 @@ if (!$noLoadingScreen) {
                                    placeholder="<?php echo i8ln('Enter Reward Name'); ?>"
                                    data-type="reward" class="search-input"/>
                             <ul id="reward-search-results" class="search-results reward-results"></ul>
+                        </div>
+                    <?php } ?>
+                    <?php if (! $noSearchPokemon) { ?>
+                        <div id="tab-pokemon">
+                            <input type="search" id="pokemon-search" name="pokemon-search"
+                                   placeholder="<?php echo i8ln('Enter Pokémon or Type'); ?>"
+                                   data-type="pokemon" class="search-input"/>
+                            <ul id="pokemon-search-results" class="search-results pokemon-results"></ul>
                         </div>
                     <?php } ?>
                     <?php if (! $noSearchNests) { ?>

--- a/search.php
+++ b/search.php
@@ -55,6 +55,9 @@ if ($action === "portals") {
 if ($action === "pokestops") {
     $data["pokestops"] = $search->search($dbname, $lat, $lon, $term);
 }
+if ($action === "pokemon") {
+    $data["pokemon"] = $search->search_pokemon($lat, $lon, $term);
+}
 if ($action === "forts") {
     $data["forts"] = $search->search($dbname, $lat, $lon, $term);
 }

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -3638,6 +3638,25 @@ function searchForItem(lat, lon, term, type, field) {
                     '</li>'
                     sr.append(html)
                 })
+                $.each(data.pokemon, function (i, element) {
+                    var pokemonIdStr = ''
+                    if (element.pokemon_id <= 9) {
+                        pokemonIdStr = '00' + element.pokemon_id
+                    } else if (element.pokemon_id <= 99) {
+                        pokemonIdStr = '0' + element.pokemon_id
+                    } else {
+                        pokemonIdStr = element.pokemon_id
+                    }
+                    var html = '<li class="search-result ' + type + '" data-lat="' + element.lat + '" data-lon="' + element.lon + '"><div class="left-column" onClick="centerMapOnCoords(event);">'
+                    if (sr.hasClass('pokemon-results')) {
+                        html += '<span style="background:url(' + iconpath + 'pokemon_icon_' + pokemonIdStr + '_00.png) no-repeat;" class="i-icon" ></span>'
+                    }
+                    html += '<div class="cont">' +
+                    '<span class="name" style="font-weight:bold">' + element.name + '</span>' + '<span class="distance" style="font-weight:bold">&nbsp;-&#32;' + element.distance + defaultUnit + '</span>' +
+                    '</div></div>' +
+                    '</li>'
+                    sr.append(html)
+                })
             }
         })
     }
@@ -5137,7 +5156,7 @@ function openSearchModal(event) { // eslint-disable-line no-unused-vars
         width: width,
         buttons: {},
         open: function (event, ui) {
-            jQuery('input[name="gym-search"], input[name="pokestop-search"], input[name="reward-search"], input[name="nest-search"], input[name="portals-search"]').bind('input', function () {
+            jQuery('input[name="pokemon-search"], input[name="gym-search"], input[name="pokestop-search"], input[name="reward-search"], input[name="nest-search"], input[name="portals-search"]').bind('input', function () {
                 searchAjax($(this))
             })
             $('.search-widget-popup #search-tabs').tabs()


### PR DESCRIPTION
Being able to search pokemon by typing the name or type has a better user experience than using the pokemon filter to find rare pokemon, i.e. those in the category of "I might go out of my way to find one."

PR completion:
- [x] support for RDM backend
- [ ] support for rocketmap_mad
- [ ] support for monocle_pmsf

Note that searching pokemon might be an intensive operation if you have lots of scanning devices. I'm running 10-20k scans/hr and have no trouble searching with this PR on RDM with the mysql on docker. Probably the search input trigger should use [Lodash's debounce](https://lodash.com/docs/#debounce) or similar to reduce unnecessary queries, but that's out of the scope for this PR.

I don't run rocketmap_mad or monocle_pmsf so if someone running those could help continue this PR that would be great. 