### PR TITLE
Fixed map load race condition affecting Safari browsers.

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -651,7 +651,7 @@ function initMap() { // eslint-disable-line no-unused-vars
 
         $selectLocationIconMarker.val(Store.get('locationMarkerStyle')).trigger('change')
     })
-    
+
     _mapLoaded = true
 }
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -212,6 +212,8 @@ var searchProvider = new OpenStreetMapProvider()
 // Extras
 //
 
+var _mapLoaded = false
+
 L.Marker.addInitHook(function () {
     if (this.options.virtual) {
         this.on('add', function () {
@@ -649,6 +651,8 @@ function initMap() { // eslint-disable-line no-unused-vars
 
         $selectLocationIconMarker.val(Store.get('locationMarkerStyle')).trigger('change')
     })
+    
+    _mapLoaded = true
 }
 
 function toggleFullscreenMap() { // eslint-disable-line no-unused-vars
@@ -5721,122 +5725,124 @@ function updateSpawnPoints() {
 }
 
 function updateMap() {
-    var position = map.getCenter()
-    var lastMidnight = ''
-    var d = new Date()
-    if (mapFork === 'mad') {
-        lastMidnight = d.setHours(0, 0, 0, 0) / 1000
-    } else {
-        lastMidnight = 0
-    }
-    Store.set('startAtLastLocationPosition', {
-        lat: position.lat,
-        lng: position.lng
-    })
-    // lets try and get the s2 cell id in the middle
-    var s2CellCenter = S2.keyToId(S2.latLngToKey(position.lat, position.lng, 10))
-    if ((s2CellCenter) && (String(s2CellCenter) !== $('#currentWeather').data('current-cell')) && (map.getZoom() > 13)) {
-        loadWeatherCellData(s2CellCenter).done(function (cellWeather) {
-            var currentWeather = cellWeather.weather
-            var currentCell = $('#currentWeather').data('current-cell')
-            if ((currentWeather) && (currentCell !== currentWeather.s2_cell_id)) {
-                $('#currentWeather').data('current-cell', currentWeather.s2_cell_id)
-                $('#currentWeather').html('<img src="static/weather/' + currentWeather.condition + '.png" alt="" height="55px"">')
-            } else if (!currentWeather) {
-                $('#currentWeather').data('current-cell', '')
-                $('#currentWeather').html('')
+    if (_mapLoaded) {
+        var position = map.getCenter()
+        var lastMidnight = ''
+        var d = new Date()
+        if (mapFork === 'mad') {
+            lastMidnight = d.setHours(0, 0, 0, 0) / 1000
+        } else {
+            lastMidnight = 0
+        }
+        Store.set('startAtLastLocationPosition', {
+            lat: position.lat,
+            lng: position.lng
+        })
+        // lets try and get the s2 cell id in the middle
+        var s2CellCenter = S2.keyToId(S2.latLngToKey(position.lat, position.lng, 10))
+        if ((s2CellCenter) && (String(s2CellCenter) !== $('#currentWeather').data('current-cell')) && (map.getZoom() > 13)) {
+            loadWeatherCellData(s2CellCenter).done(function (cellWeather) {
+                var currentWeather = cellWeather.weather
+                var currentCell = $('#currentWeather').data('current-cell')
+                if ((currentWeather) && (currentCell !== currentWeather.s2_cell_id)) {
+                    $('#currentWeather').data('current-cell', currentWeather.s2_cell_id)
+                    $('#currentWeather').html('<img src="static/weather/' + currentWeather.condition + '.png" alt="" height="55px"">')
+                } else if (!currentWeather) {
+                    $('#currentWeather').data('current-cell', '')
+                    $('#currentWeather').html('')
+                }
+            })
+        }
+        loadRawData().done(function (result) {
+            $.each(result.pokemons, processPokemons)
+            $.each(result.pokestops, processPokestops, lastMidnight)
+            $.each(result.gyms, processGyms)
+            $.each(result.spawnpoints, processSpawnpoints)
+            $.each(result.scanlocations, processScanlocation)
+            $.each(result.nests, processNests)
+            $.each(result.communities, processCommunities)
+            $.each(result.portals, processPortals)
+            $.each(result.pois, processPois)
+            showInBoundsMarkers(mapData.pokemons, 'pokemon')
+            showInBoundsMarkers(mapData.gyms, 'gym')
+            showInBoundsMarkers(mapData.pokestops, 'pokestop')
+            showInBoundsMarkers(mapData.spawnpoints, 'inbound')
+
+            clearStaleMarkers()
+
+            updateSpawnPoints()
+            updatePokestops()
+            updatePortals()
+
+            if ($('#stats').hasClass('visible')) {
+                countMarkers(map)
             }
+
+            oSwLat = result.oSwLat
+            oSwLng = result.oSwLng
+            oNeLat = result.oNeLat
+            oNeLng = result.oNeLng
+
+            lastgyms = result.lastgyms
+            lastpokestops = result.lastpokestops
+            lastpokemon = result.lastpokemon
+            lastslocs = result.lastslocs
+            lastspawns = result.lastspawns
+            lastnests = result.lastnests
+            lastcommunities = result.lastcommunities
+            lastportals = result.lastportals
+            lastpois = result.lastpois
+
+            prevMinIV = result.preMinIV
+            prevMinLevel = result.preMinLevel
+            reids = result.reids
+            qpreids = result.qpreids
+            qireids = result.qireids
+            qereids = result.qereids
+            greids = result.greids
+            rbreids = result.rbreids
+            rereids = result.rereids
+            if (reids instanceof Array) {
+                reincludedPokemon = reids.filter(function (e) {
+                    return this.indexOf(e) < 0
+                }, reincludedPokemon)
+            }
+            if (qpreids instanceof Array) {
+                reincludedQuestsPokemon = qpreids.filter(function (e) {
+                    return this.indexOf(e) < 0
+                }, reincludedQuestsPokemon)
+            }
+            if (qereids instanceof Array) {
+                reincludedQuestsEnergy = qereids.filter(function (e) {
+                    return this.indexOf(e) < 0
+                }, reincludedQuestsEnergy)
+            }
+            if (qireids instanceof Array) {
+                reincludedQuestsItem = qireids.filter(function (e) {
+                    return this.indexOf(e) < 0
+                }, reincludedQuestsItem)
+            }
+            if (greids instanceof Array) {
+                reincludedGrunts = greids.filter(function (e) {
+                    return this.indexOf(e) < 0
+                }, reincludedGrunts)
+            }
+            if (rbreids instanceof Array) {
+                reincludedRaidboss = rbreids.filter(function (e) {
+                    return this.indexOf(e) < 0
+                }, reincludedRaidboss)
+            }
+            if (rereids instanceof Array) {
+                reincludedRaidegg = rereids.filter(function (e) {
+                    return this.indexOf(e) < 0
+                }, reincludedRaidegg)
+            }
+            reloaddustamount = false
+            timestamp = result.timestamp
+            lastUpdateTime = Date.now()
+            token = result.token
         })
     }
-    loadRawData().done(function (result) {
-        $.each(result.pokemons, processPokemons)
-        $.each(result.pokestops, processPokestops, lastMidnight)
-        $.each(result.gyms, processGyms)
-        $.each(result.spawnpoints, processSpawnpoints)
-        $.each(result.scanlocations, processScanlocation)
-        $.each(result.nests, processNests)
-        $.each(result.communities, processCommunities)
-        $.each(result.portals, processPortals)
-        $.each(result.pois, processPois)
-        showInBoundsMarkers(mapData.pokemons, 'pokemon')
-        showInBoundsMarkers(mapData.gyms, 'gym')
-        showInBoundsMarkers(mapData.pokestops, 'pokestop')
-        showInBoundsMarkers(mapData.spawnpoints, 'inbound')
-
-        clearStaleMarkers()
-
-        updateSpawnPoints()
-        updatePokestops()
-        updatePortals()
-
-        if ($('#stats').hasClass('visible')) {
-            countMarkers(map)
-        }
-
-        oSwLat = result.oSwLat
-        oSwLng = result.oSwLng
-        oNeLat = result.oNeLat
-        oNeLng = result.oNeLng
-
-        lastgyms = result.lastgyms
-        lastpokestops = result.lastpokestops
-        lastpokemon = result.lastpokemon
-        lastslocs = result.lastslocs
-        lastspawns = result.lastspawns
-        lastnests = result.lastnests
-        lastcommunities = result.lastcommunities
-        lastportals = result.lastportals
-        lastpois = result.lastpois
-
-        prevMinIV = result.preMinIV
-        prevMinLevel = result.preMinLevel
-        reids = result.reids
-        qpreids = result.qpreids
-        qireids = result.qireids
-        qereids = result.qereids
-        greids = result.greids
-        rbreids = result.rbreids
-        rereids = result.rereids
-        if (reids instanceof Array) {
-            reincludedPokemon = reids.filter(function (e) {
-                return this.indexOf(e) < 0
-            }, reincludedPokemon)
-        }
-        if (qpreids instanceof Array) {
-            reincludedQuestsPokemon = qpreids.filter(function (e) {
-                return this.indexOf(e) < 0
-            }, reincludedQuestsPokemon)
-        }
-        if (qereids instanceof Array) {
-            reincludedQuestsEnergy = qereids.filter(function (e) {
-                return this.indexOf(e) < 0
-            }, reincludedQuestsEnergy)
-        }
-        if (qireids instanceof Array) {
-            reincludedQuestsItem = qireids.filter(function (e) {
-                return this.indexOf(e) < 0
-            }, reincludedQuestsItem)
-        }
-        if (greids instanceof Array) {
-            reincludedGrunts = greids.filter(function (e) {
-                return this.indexOf(e) < 0
-            }, reincludedGrunts)
-        }
-        if (rbreids instanceof Array) {
-            reincludedRaidboss = rbreids.filter(function (e) {
-                return this.indexOf(e) < 0
-            }, reincludedRaidboss)
-        }
-        if (rereids instanceof Array) {
-            reincludedRaidegg = rereids.filter(function (e) {
-                return this.indexOf(e) < 0
-            }, reincludedRaidegg)
-        }
-        reloaddustamount = false
-        timestamp = result.timestamp
-        lastUpdateTime = Date.now()
-        token = result.token
-    })
 }
 
 function updateWeatherOverlay() {
@@ -6603,7 +6609,11 @@ $(function () {
         })
         $selectStyle.on('change', function (e) {
             selectedStyle = $selectStyle.val()
-            setTileLayer(selectedStyle)
+
+            if (_mapLoaded) {
+                setTileLayer(selectedStyle)
+            }
+
             Store.set('map_style', selectedStyle)
         })
 


### PR DESCRIPTION
For Safari users, there was a race condition preventing the map from fully loading, especially the sidebar. The results of this were the side menu tabs appearing as links instead of intended tabs. More importantly, settings were not being saved to the users' localStorage if a user were to attempt to change a setting when the race condition has hit the failed path.

Test:
Open the map using Safari, either on iOS or desktop. Keep notice of the side menu tabs. If they appear as links, you've hit the bug. If you keep refreshing, you'll see that it'll eventually render as tabs. 