### PR TITLE
Don't skip encounter data on previously processed mons without encounter data

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -5167,7 +5167,23 @@ function processPokemons(i, item) {
     if (!Store.get('showPokemon')) {
         return false // in case the checkbox was unchecked in the meantime.
     }
-    if (!(item['encounter_id'] in mapData.pokemons) && item['disappear_time'] > Date.now() && ((encounterId && encounterId === item['encounter_id']) || (excludedPokemon.indexOf(item['pokemon_id']) < 0 && !isTemporaryHidden(item['pokemon_id'])))) {
+    if (item['disappear_time'] > Date.now() && ((encounterId && encounterId === item['encounter_id']) || (excludedPokemon.indexOf(item['pokemon_id']) < 0 && !isTemporaryHidden(item['pokemon_id'])))) {
+        if (item['encounter_id'] in mapData.pokemons) {
+            if ((mapData.pokemons[item['encounter_id']]['individual_attack'] != item['individual_attack']) || (mapData.pokemons[item['encounter_id']]['individual_defense'] != item['individual_defense']) || (mapData.pokemons[item['encounter_id']]['individual_stamina'] != item['individual_stamina'])) {
+                // updated information received. delete marker and item from dict
+                if (mapData.pokemons[item['encounter_id']].marker.rangeCircle) {
+                    markers.removeLayer(mapData.pokemons[item['encounter_id']].marker.rangeCircle)
+                    markersnotify.removeLayer(mapData.pokemons[item['encounter_id']].marker.rangeCircle)
+                    delete mapData.pokemons[item['encounter_id']].marker.rangeCircle
+                }
+                markers.removeLayer(mapData.pokemons[item['encounter_id']].marker)
+                markersnotify.removeLayer(mapData.pokemons[item['encounter_id']].marker)
+                delete mapData.pokemons[item['encounter_id']]
+            } else {
+                // in mapData and appears up to date, skip
+                return true
+            }
+        }
         // add marker to map and item to dict
         if (item.marker) {
             markers.removeLayer(item.marker)

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -5169,7 +5169,7 @@ function processPokemons(i, item) {
     }
     if (item['disappear_time'] > Date.now() && ((encounterId && encounterId === item['encounter_id']) || (excludedPokemon.indexOf(item['pokemon_id']) < 0 && !isTemporaryHidden(item['pokemon_id'])))) {
         if (item['encounter_id'] in mapData.pokemons) {
-            if ((mapData.pokemons[item['encounter_id']]['individual_attack'] != item['individual_attack']) || (mapData.pokemons[item['encounter_id']]['individual_defense'] != item['individual_defense']) || (mapData.pokemons[item['encounter_id']]['individual_stamina'] != item['individual_stamina'])) {
+            if ((mapData.pokemons[item['encounter_id']]['individual_attack'] !== item['individual_attack']) || (mapData.pokemons[item['encounter_id']]['individual_defense'] !== item['individual_defense']) || (mapData.pokemons[item['encounter_id']]['individual_stamina'] !== item['individual_stamina'])) {
                 // updated information received. delete marker and item from dict
                 if (mapData.pokemons[item['encounter_id']].marker.rangeCircle) {
                     markers.removeLayer(mapData.pokemons[item['encounter_id']].marker.rangeCircle)


### PR DESCRIPTION
**DEVS:**
I've been using this since late 2019 without issues. If you feel there is a better way to do it, feel free to do it!

**ISSUE:**
Stock pmsf will not update a mons marker after it has been processed once even if the 1st time was without encounter data and the 2nd time would have added the encounter data. The only way to display the encounter data in that case is to reload the entire map or disable/enable mons which is not practical. This also means a end-user won't know of a 100% if it was processed before without the encounter data.

**WHAT THIS DOES:**
This will compare the previously processed mons to the new received data and, if it would add the encounter information, it simply delete the previous information continues as if it was a new mons to ensure proper notifications and display.
