### PR TITLE
Fix nestwatcher nests not showing

### DIFF
--- a/lib/Manual.php
+++ b/lib/Manual.php
@@ -73,7 +73,6 @@ class Manual
         pokemon_count,
         pokemon_form,
         type,
-        nest_submitted_by,
         polygon_path
         FROM nests
         WHERE :conditions";


### PR DESCRIPTION
Apparently PMSF tried to query a column that's missing in the nestwatcher database (pretty sure this wasn't always a thing?) anyway, it's working with this PR