### PR TITLE
Hide Pokemon or ExcludeMinIV

### DIFF
--- a/pre-index.php
+++ b/pre-index.php
@@ -305,7 +305,7 @@ if (strtolower($map) === "rdm") {
                                                     <?php } ?>
                                                 </div>
                                             </div>
-                                            <?php if (! $noHidePokemon && ! $noExcludeMinIV) { ?>
+                                            <?php if (! $noHidePokemon || ! $noExcludeMinIV) { ?>
                                                 <ul class="nav nav-tabs nav-fill" id="pokemonHideMin" role="tablist">
                                                     <?php
                                                     $firstTab = 1;


### PR DESCRIPTION
A simple change in logic to allow maps without IVs to hide the ExcludeMinIV menu like before the rewrite.