### PR TITLE
Remove Duplicate access_level in FB Auth

### DIFF
--- a/login.php
+++ b/login.php
@@ -470,7 +470,6 @@ if (isset($_GET['callback'])) {
                     'user' => $user->name,
                     'access_level' => $groupmeAccessLevel,
                     'avatar' => $user->image_url,
-                    'access_level' => null,
                     'expire_timestamp' => time() + 86400,
                     'login_system' => 'groupme'
                 ]);

--- a/login.php
+++ b/login.php
@@ -424,7 +424,6 @@ if (isset($_GET['callback'])) {
                     'user' => $user['name'],
                     'access_level' => $facebookAccessLevel,
                     'avatar' => $user['picture']['url'],
-                    'access_level' => null,
                     'expire_timestamp' => time() + $sessionLifetime,
                     'login_system' => 'facebook',
                     'last_loggedin' => time()

--- a/static/data/pokemon.json
+++ b/static/data/pokemon.json
@@ -2,9 +2,6 @@
   "1": {
     "name": "Bulbasaur",
     "rarity": "Uncommon",
-    "baseAttack": 118,
-    "baseDefense": 111,
-    "baseStamina": 128,
     "types": [
       {
         "type": "Grass",
@@ -19,10 +16,6 @@
       {
         "nameform": "Normal",
         "protoform": "163",
-        "assetsform": "00",
-        "baseAttack": 118,
-        "baseDefense": 111,
-        "baseStamina": 128,
         "formtypes": [
           {
             "type": "Grass",
@@ -37,10 +30,6 @@
       {
         "nameform": "Shadow",
         "protoform": "164",
-        "assetsform": "00",
-        "baseAttack": 118,
-        "baseDefense": 111,
-        "baseStamina": 128,
         "formtypes": [
           {
             "type": "Grass",
@@ -55,10 +44,6 @@
       {
         "nameform": "Purified",
         "protoform": "165",
-        "assetsform": "00",
-        "baseAttack": 118,
-        "baseDefense": 111,
-        "baseStamina": 128,
         "formtypes": [
           {
             "type": "Grass",
@@ -73,10 +58,6 @@
       {
         "nameform": "No Evolve",
         "protoform": "604",
-        "assetsform": "00",
-        "baseAttack": 118,
-        "baseDefense": 111,
-        "baseStamina": 128,
         "formtypes": [
           {
             "type": "Grass",
@@ -91,10 +72,6 @@
       {
         "nameform": "Fall",
         "protoform": "897",
-        "assetsform": "00",
-        "baseAttack": 118,
-        "baseDefense": 111,
-        "baseStamina": 128,
         "formtypes": [
           {
             "type": "Grass",
@@ -111,9 +88,6 @@
   "2": {
     "name": "Ivysaur",
     "rarity": "Rare",
-    "baseAttack": 151,
-    "baseDefense": 143,
-    "baseStamina": 155,
     "types": [
       {
         "type": "Grass",
@@ -128,10 +102,6 @@
       {
         "nameform": "Normal",
         "protoform": "166",
-        "assetsform": "00",
-        "baseAttack": 151,
-        "baseDefense": 143,
-        "baseStamina": 155,
         "formtypes": [
           {
             "type": "Grass",
@@ -146,10 +116,6 @@
       {
         "nameform": "Shadow",
         "protoform": "167",
-        "assetsform": "00",
-        "baseAttack": 151,
-        "baseDefense": 143,
-        "baseStamina": 155,
         "formtypes": [
           {
             "type": "Grass",
@@ -164,10 +130,6 @@
       {
         "nameform": "Purified",
         "protoform": "168",
-        "assetsform": "00",
-        "baseAttack": 151,
-        "baseDefense": 143,
-        "baseStamina": 155,
         "formtypes": [
           {
             "type": "Grass",
@@ -184,9 +146,6 @@
   "3": {
     "name": "Venusaur",
     "rarity": "Very Rare",
-    "baseAttack": 198,
-    "baseDefense": 189,
-    "baseStamina": 190,
     "types": [
       {
         "type": "Grass",
@@ -201,10 +160,6 @@
       {
         "nameform": "Normal",
         "protoform": "169",
-        "assetsform": "00",
-        "baseAttack": 198,
-        "baseDefense": 189,
-        "baseStamina": 190,
         "formtypes": [
           {
             "type": "Grass",
@@ -219,10 +174,6 @@
       {
         "nameform": "Shadow",
         "protoform": "170",
-        "assetsform": "00",
-        "baseAttack": 198,
-        "baseDefense": 189,
-        "baseStamina": 190,
         "formtypes": [
           {
             "type": "Grass",
@@ -237,10 +188,6 @@
       {
         "nameform": "Purified",
         "protoform": "171",
-        "assetsform": "00",
-        "baseAttack": 198,
-        "baseDefense": 189,
-        "baseStamina": 190,
         "formtypes": [
           {
             "type": "Grass",
@@ -255,10 +202,6 @@
       {
         "nameform": "Clone",
         "protoform": "950",
-        "assetsform": "00",
-        "baseAttack": 198,
-        "baseDefense": 189,
-        "baseStamina": 190,
         "formtypes": [
           {
             "type": "Grass",
@@ -275,9 +218,6 @@
   "4": {
     "name": "Charmander",
     "rarity": "Rare",
-    "baseAttack": 116,
-    "baseDefense": 93,
-    "baseStamina": 118,
     "types": [
       {
         "type": "Fire",
@@ -288,10 +228,6 @@
       {
         "nameform": "Normal",
         "protoform": "172",
-        "assetsform": "00",
-        "baseAttack": 116,
-        "baseDefense": 93,
-        "baseStamina": 118,
         "formtypes": [
           {
             "type": "Fire",
@@ -302,10 +238,6 @@
       {
         "nameform": "Shadow",
         "protoform": "173",
-        "assetsform": "00",
-        "baseAttack": 116,
-        "baseDefense": 93,
-        "baseStamina": 118,
         "formtypes": [
           {
             "type": "Fire",
@@ -316,10 +248,6 @@
       {
         "nameform": "Purified",
         "protoform": "174",
-        "assetsform": "00",
-        "baseAttack": 116,
-        "baseDefense": 93,
-        "baseStamina": 118,
         "formtypes": [
           {
             "type": "Fire",
@@ -330,10 +258,6 @@
       {
         "nameform": "No Evolve",
         "protoform": "605",
-        "assetsform": "00",
-        "baseAttack": 116,
-        "baseDefense": 93,
-        "baseStamina": 118,
         "formtypes": [
           {
             "type": "Fire",
@@ -344,10 +268,6 @@
       {
         "nameform": "Fall",
         "protoform": "896",
-        "assetsform": "00",
-        "baseAttack": 116,
-        "baseDefense": 93,
-        "baseStamina": 118,
         "formtypes": [
           {
             "type": "Fire",
@@ -360,9 +280,6 @@
   "5": {
     "name": "Charmeleon",
     "rarity": "Very Rare",
-    "baseAttack": 158,
-    "baseDefense": 126,
-    "baseStamina": 151,
     "types": [
       {
         "type": "Fire",
@@ -373,10 +290,6 @@
       {
         "nameform": "Normal",
         "protoform": "175",
-        "assetsform": "00",
-        "baseAttack": 158,
-        "baseDefense": 126,
-        "baseStamina": 151,
         "formtypes": [
           {
             "type": "Fire",
@@ -387,10 +300,6 @@
       {
         "nameform": "Shadow",
         "protoform": "176",
-        "assetsform": "00",
-        "baseAttack": 158,
-        "baseDefense": 126,
-        "baseStamina": 151,
         "formtypes": [
           {
             "type": "Fire",
@@ -401,10 +310,6 @@
       {
         "nameform": "Purified",
         "protoform": "177",
-        "assetsform": "00",
-        "baseAttack": 158,
-        "baseDefense": 126,
-        "baseStamina": 151,
         "formtypes": [
           {
             "type": "Fire",
@@ -417,9 +322,6 @@
   "6": {
     "name": "Charizard",
     "rarity": "Very Rare",
-    "baseAttack": 223,
-    "baseDefense": 173,
-    "baseStamina": 186,
     "types": [
       {
         "type": "Fire",
@@ -434,10 +336,6 @@
       {
         "nameform": "Normal",
         "protoform": "178",
-        "assetsform": "00",
-        "baseAttack": 223,
-        "baseDefense": 173,
-        "baseStamina": 186,
         "formtypes": [
           {
             "type": "Fire",
@@ -452,10 +350,6 @@
       {
         "nameform": "Shadow",
         "protoform": "179",
-        "assetsform": "00",
-        "baseAttack": 223,
-        "baseDefense": 173,
-        "baseStamina": 186,
         "formtypes": [
           {
             "type": "Fire",
@@ -470,10 +364,6 @@
       {
         "nameform": "Purified",
         "protoform": "180",
-        "assetsform": "00",
-        "baseAttack": 223,
-        "baseDefense": 173,
-        "baseStamina": 186,
         "formtypes": [
           {
             "type": "Fire",
@@ -488,10 +378,6 @@
       {
         "nameform": "No Evolve",
         "protoform": "606",
-        "assetsform": "00",
-        "baseAttack": 223,
-        "baseDefense": 173,
-        "baseStamina": 186,
         "formtypes": [
           {
             "type": "Fire",
@@ -506,10 +392,6 @@
       {
         "nameform": "Clone",
         "protoform": "951",
-        "assetsform": "00",
-        "baseAttack": 223,
-        "baseDefense": 173,
-        "baseStamina": 186,
         "formtypes": [
           {
             "type": "Fire",
@@ -527,9 +409,6 @@
   "7": {
     "name": "Squirtle",
     "rarity": "Uncommon",
-    "baseAttack": 94,
-    "baseDefense": 121,
-    "baseStamina": 127,
     "types": [
       {
         "type": "Water",
@@ -540,10 +419,6 @@
       {
         "nameform": "Normal",
         "protoform": "181",
-        "assetsform": "00",
-        "baseAttack": 94,
-        "baseDefense": 121,
-        "baseStamina": 127,
         "formtypes": [
           {
             "type": "Water",
@@ -554,10 +429,6 @@
       {
         "nameform": "Shadow",
         "protoform": "182",
-        "assetsform": "00",
-        "baseAttack": 94,
-        "baseDefense": 121,
-        "baseStamina": 127,
         "formtypes": [
           {
             "type": "Water",
@@ -568,10 +439,6 @@
       {
         "nameform": "Purified",
         "protoform": "183",
-        "assetsform": "00",
-        "baseAttack": 94,
-        "baseDefense": 121,
-        "baseStamina": 127,
         "formtypes": [
           {
             "type": "Water",
@@ -582,10 +449,6 @@
       {
         "nameform": "No Evolve",
         "protoform": "607",
-        "assetsform": "00",
-        "baseAttack": 94,
-        "baseDefense": 121,
-        "baseStamina": 127,
         "formtypes": [
           {
             "type": "Water",
@@ -596,10 +459,6 @@
       {
         "nameform": "Fall",
         "protoform": "895",
-        "assetsform": "00",
-        "baseAttack": 94,
-        "baseDefense": 121,
-        "baseStamina": 127,
         "formtypes": [
           {
             "type": "Water",
@@ -612,9 +471,6 @@
   "8": {
     "name": "Wartortle",
     "rarity": "Rare",
-    "baseAttack": 126,
-    "baseDefense": 155,
-    "baseStamina": 153,
     "types": [
       {
         "type": "Water",
@@ -625,10 +481,6 @@
       {
         "nameform": "Normal",
         "protoform": "184",
-        "assetsform": "00",
-        "baseAttack": 126,
-        "baseDefense": 155,
-        "baseStamina": 153,
         "formtypes": [
           {
             "type": "Water",
@@ -639,10 +491,6 @@
       {
         "nameform": "Shadow",
         "protoform": "185",
-        "assetsform": "00",
-        "baseAttack": 126,
-        "baseDefense": 155,
-        "baseStamina": 153,
         "formtypes": [
           {
             "type": "Fire",
@@ -653,10 +501,6 @@
       {
         "nameform": "Purified",
         "protoform": "186",
-        "assetsform": "00",
-        "baseAttack": 126,
-        "baseDefense": 155,
-        "baseStamina": 153,
         "formtypes": [
           {
             "type": "Water",
@@ -669,9 +513,6 @@
   "9": {
     "name": "Blastoise",
     "rarity": "Very Rare",
-    "baseAttack": 171,
-    "baseDefense": 207,
-    "baseStamina": 188,
     "types": [
       {
         "type": "Water",
@@ -682,10 +523,6 @@
       {
         "nameform": "Normal",
         "protoform": "187",
-        "assetsform": "00",
-        "baseAttack": 171,
-        "baseDefense": 207,
-        "baseStamina": 188,
         "formtypes": [
           {
             "type": "Water",
@@ -696,10 +533,6 @@
       {
         "nameform": "Shadow",
         "protoform": "188",
-        "assetsform": "00",
-        "baseAttack": 171,
-        "baseDefense": 207,
-        "baseStamina": 188,
         "formtypes": [
           {
             "type": "Fire",
@@ -710,10 +543,6 @@
       {
         "nameform": "Purified",
         "protoform": "189",
-        "assetsform": "00",
-        "baseAttack": 171,
-        "baseDefense": 207,
-        "baseStamina": 188,
         "formtypes": [
           {
             "type": "Water",
@@ -724,10 +553,6 @@
       {
         "nameform": "No Evolve",
         "protoform": "607",
-        "assetsform": "00",
-        "baseAttack": 171,
-        "baseDefense": 207,
-        "baseStamina": 188,
         "formtypes": [
           {
             "type": "Water",
@@ -738,10 +563,6 @@
       {
         "nameform": "Clone",
         "protoform": "952",
-        "assetsform": "00",
-        "baseAttack": 171,
-        "baseDefense": 207,
-        "baseStamina": 188,
         "formtypes": [
           {
             "type": "Water",
@@ -754,9 +575,6 @@
   "10": {
     "name": "Caterpie",
     "rarity": "Uncommon",
-    "baseAttack": 55,
-    "baseDefense": 55,
-    "baseStamina": 128,
     "types": [
       {
         "type": "Bug",
@@ -767,7 +585,6 @@
       {
         "nameform": "Normal",
         "protoform": "953",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -778,7 +595,6 @@
       {
         "nameform": "Shadow",
         "protoform": "954",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -789,7 +605,6 @@
       {
         "nameform": "Purified",
         "protoform": "955",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -802,9 +617,6 @@
   "11": {
     "name": "Metapod",
     "rarity": "Rare",
-    "baseAttack": 45,
-    "baseDefense": 80,
-    "baseStamina": 137,
     "types": [
       {
         "type": "Bug",
@@ -815,7 +627,6 @@
       {
         "nameform": "Normal",
         "protoform": "956",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -826,7 +637,6 @@
       {
         "nameform": "Shadow",
         "protoform": "957",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -837,7 +647,6 @@
       {
         "nameform": "Purified",
         "protoform": "958",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -850,9 +659,6 @@
   "12": {
     "name": "Butterfree",
     "rarity": "Very Rare",
-    "baseStamina": 155,
-    "baseAttack": 167,
-    "baseDefense": 137,
     "types": [
       {
         "type": "Bug",
@@ -867,7 +673,6 @@
       {
         "nameform": "Normal",
         "protoform": "959",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -882,7 +687,6 @@
       {
         "nameform": "Shadow",
         "protoform": "960",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -897,7 +701,6 @@
       {
         "nameform": "Purified",
         "protoform": "961",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -914,9 +717,6 @@
   "13": {
     "name": "Weedle",
     "rarity": "Common",
-    "baseStamina": 120,
-    "baseAttack": 63,
-    "baseDefense": 50,
     "types": [
       {
         "type": "Bug",
@@ -931,10 +731,6 @@
       {
         "nameform": "Normal",
         "protoform": "616",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 63,
-        "baseDefense": 50,
         "formtypes": [
           {
             "type": "Bug",
@@ -949,10 +745,6 @@
       {
         "nameform": "Shadow",
         "protoform": "617",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 63,
-        "baseDefense": 50,
         "formtypes": [
           {
             "type": "Bug",
@@ -967,10 +759,6 @@
       {
         "nameform": "Purified",
         "protoform": "618",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 63,
-        "baseDefense": 50,
         "formtypes": [
           {
             "type": "Bug",
@@ -987,9 +775,6 @@
   "14": {
     "name": "Kakuna",
     "rarity": "Rare",
-    "baseStamina": 128,
-    "baseAttack": 46,
-    "baseDefense": 75,
     "types": [
       {
         "type": "Bug",
@@ -1004,10 +789,6 @@
       {
         "nameform": "Normal",
         "protoform": "619",
-        "assetsform": "00",
-        "baseStamina": 128,
-        "baseAttack": 46,
-        "baseDefense": 75,
         "formtypes": [
           {
             "type": "Bug",
@@ -1022,10 +803,6 @@
       {
         "nameform": "Shadow",
         "protoform": "620",
-        "assetsform": "00",
-        "baseStamina": 128,
-        "baseAttack": 46,
-        "baseDefense": 75,
         "formtypes": [
           {
             "type": "Bug",
@@ -1040,10 +817,6 @@
       {
         "nameform": "Purified",
         "protoform": "621",
-        "assetsform": "00",
-        "baseStamina": 128,
-        "baseAttack": 46,
-        "baseDefense": 75,
         "formtypes": [
           {
             "type": "Bug",
@@ -1060,9 +833,6 @@
   "15": {
     "name": "Beedrill",
     "rarity": "Rare",
-    "baseStamina": 163,
-    "baseAttack": 169,
-    "baseDefense": 130,
     "types": [
       {
         "type": "Bug",
@@ -1077,10 +847,6 @@
       {
         "nameform": "Normal",
         "protoform": "622",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 169,
-        "baseDefense": 130,
         "formtypes": [
           {
             "type": "Bug",
@@ -1095,10 +861,6 @@
       {
         "nameform": "Shadow",
         "protoform": "623",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 169,
-        "baseDefense": 130,
         "formtypes": [
           {
             "type": "Bug",
@@ -1113,10 +875,6 @@
       {
         "nameform": "Purified",
         "protoform": "624",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 169,
-        "baseDefense": 130,
         "formtypes": [
           {
             "type": "Bug",
@@ -1133,9 +891,6 @@
   "16": {
     "name": "Pidgey",
     "rarity": "Common",
-    "baseStamina": 120,
-    "baseAttack": 85,
-    "baseDefense": 73,
     "types": [
       {
         "type": "Normal",
@@ -1150,7 +905,6 @@
       {
         "nameform": "Normal",
         "protoform": "962",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -1165,7 +919,6 @@
       {
         "nameform": "Shadow",
         "protoform": "963",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -1180,7 +933,6 @@
       {
         "nameform": "Purified",
         "protoform": "964",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -1197,9 +949,6 @@
   "17": {
     "name": "Pidgeotto",
     "rarity": "Uncommon",
-    "baseStamina": 160,
-    "baseAttack": 117,
-    "baseDefense": 105,
     "types": [
       {
         "type": "Normal",
@@ -1214,7 +963,6 @@
       {
         "nameform": "Normal",
         "protoform": "965",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -1229,7 +977,6 @@
       {
         "nameform": "Shadow",
         "protoform": "966",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -1244,7 +991,6 @@
       {
         "nameform": "Purified",
         "protoform": "967",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -1261,9 +1007,6 @@
   "18": {
     "name": "Pidgeot",
     "rarity": "Rare",
-    "baseStamina": 195,
-    "baseAttack": 166,
-    "baseDefense": 154,
     "types": [
       {
         "type": "Normal",
@@ -1278,7 +1021,6 @@
       {
         "nameform": "Normal",
         "protoform": "968",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -1293,7 +1035,6 @@
       {
         "nameform": "Shadow",
         "protoform": "969",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -1308,7 +1049,6 @@
       {
         "nameform": "Purified",
         "protoform": "970",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -1325,9 +1065,6 @@
   "19": {
     "name": "Rattata",
     "rarity": "Common",
-    "baseStamina": 102,
-    "baseAttack": 103,
-    "baseDefense": 70,
     "types": [
       {
         "type": "Normal",
@@ -1338,10 +1075,6 @@
       {
         "nameform": "Normal",
         "protoform": "45",
-        "assetsform": "00",
-        "baseStamina": 102,
-        "baseAttack": 103,
-        "baseDefense": 70,
         "formtypes": [
           {
             "type": "Normal",
@@ -1352,10 +1085,6 @@
       {
         "nameform": "Alolan",
         "protoform": "46",
-        "assetsform": "61",
-        "baseStamina": 102,
-        "baseAttack": 103,
-        "baseDefense": 70,
         "formtypes": [
           {
             "type": "Dark",
@@ -1370,10 +1099,6 @@
       {
         "nameform": "Shadow",
         "protoform": "153",
-        "assetsform": "00",
-        "baseStamina": 102,
-        "baseAttack": 103,
-        "baseDefense": 70,
         "formtypes": [
           {
             "type": "Normal",
@@ -1384,10 +1109,6 @@
       {
         "nameform": "Purified",
         "protoform": "154",
-        "assetsform": "00",
-        "baseStamina": 102,
-        "baseAttack": 103,
-        "baseDefense": 70,
         "formtypes": [
           {
             "type": "Normal",
@@ -1400,9 +1121,6 @@
   "20": {
     "name": "Raticate",
     "rarity": "Rare",
-    "baseStamina": 146,
-    "baseAttack": 161,
-    "baseDefense": 139,
     "types": [
       {
         "type": "Normal",
@@ -1413,10 +1131,6 @@
       {
         "nameform": "Normal",
         "protoform": "47",
-        "assetsform": "00",
-        "baseStamina": 146,
-        "baseAttack": 161,
-        "baseDefense": 139,
         "formtypes": [
           {
             "type": "Normal",
@@ -1427,10 +1141,6 @@
       {
         "nameform": "Alolan",
         "protoform": "48",
-        "assetsform": "61",
-        "baseStamina": 181,
-        "baseAttack": 135,
-        "baseDefense": 154,
         "formtypes": [
           {
             "type": "Dark",
@@ -1445,10 +1155,6 @@
       {
         "nameform": "Shadow",
         "protoform": "155",
-        "assetsform": "00",
-        "baseStamina": 146,
-        "baseAttack": 161,
-        "baseDefense": 139,
         "formtypes": [
           {
             "type": "Normal",
@@ -1459,10 +1165,6 @@
       {
         "nameform": "Purified",
         "protoform": "156",
-        "assetsform": "00",
-        "baseStamina": 146,
-        "baseAttack": 161,
-        "baseDefense": 139,
         "formtypes": [
           {
             "type": "Normal",
@@ -1473,10 +1175,16 @@
       {
         "nameform": "No Evolve",
         "protoform": "609",
-        "assetsform": "00",
-        "baseStamina": 146,
-        "baseAttack": 161,
-        "baseDefense": 139,
+        "formtypes": [
+          {
+            "type": "Normal",
+            "color": "#8a8a59"
+          }
+        ]
+      },
+      {
+        "nameform": "Spring 2020",
+        "protoform": "2329",
         "formtypes": [
           {
             "type": "Normal",
@@ -1489,9 +1197,6 @@
   "21": {
     "name": "Spearow",
     "rarity": "Uncommon",
-    "baseStamina": 120,
-    "baseAttack": 112,
-    "baseDefense": 60,
     "types": [
       {
         "type": "Normal",
@@ -1506,7 +1211,6 @@
       {
         "nameform": "Normal",
         "protoform": "971",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -1521,7 +1225,6 @@
       {
         "nameform": "Shadow",
         "protoform": "972",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -1536,7 +1239,6 @@
       {
         "nameform": "Purified",
         "protoform": "973",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -1553,9 +1255,6 @@
   "22": {
     "name": "Fearow",
     "rarity": "Rare",
-    "baseStamina": 163,
-    "baseAttack": 182,
-    "baseDefense": 133,
     "types": [
       {
         "type": "Normal",
@@ -1570,7 +1269,6 @@
       {
         "nameform": "Normal",
         "protoform": "974",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -1585,7 +1283,6 @@
       {
         "nameform": "Shadow",
         "protoform": "975",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -1600,7 +1297,6 @@
       {
         "nameform": "Purified",
         "protoform": "976",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -1617,9 +1313,6 @@
   "23": {
     "name": "Ekans",
     "rarity": "Uncommon",
-    "baseStamina": 111,
-    "baseAttack": 110,
-    "baseDefense": 97,
     "types": [
       {
         "type": "Poison",
@@ -1630,10 +1323,6 @@
       {
         "nameform": "Normal",
         "protoform": "697",
-        "assetsform": "00",
-        "baseStamina": 111,
-        "baseAttack": 110,
-        "baseDefense": 97,
         "formtypes": [
           {
             "type": "Poison",
@@ -1644,10 +1333,6 @@
       {
         "nameform": "Shadow",
         "protoform": "698",
-        "assetsform": "00",
-        "baseStamina": 111,
-        "baseAttack": 110,
-        "baseDefense": 97,
         "formtypes": [
           {
             "type": "Poison",
@@ -1658,10 +1343,6 @@
       {
         "nameform": "Purified",
         "protoform": "699",
-        "assetsform": "00",
-        "baseStamina": 111,
-        "baseAttack": 110,
-        "baseDefense": 97,
         "formtypes": [
           {
             "type": "Poison",
@@ -1674,9 +1355,6 @@
   "24": {
     "name": "Arbok",
     "rarity": "Very Rare",
-    "baseStamina": 155,
-    "baseAttack": 167,
-    "baseDefense": 153,
     "types": [
       {
         "type": "Poison",
@@ -1687,10 +1365,6 @@
       {
         "nameform": "Normal",
         "protoform": "700",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 167,
-        "baseDefense": 153,
         "formtypes": [
           {
             "type": "Poison",
@@ -1701,10 +1375,6 @@
       {
         "nameform": "Shadow",
         "protoform": "701",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 167,
-        "baseDefense": 153,
         "formtypes": [
           {
             "type": "Poison",
@@ -1715,10 +1385,6 @@
       {
         "nameform": "Purified",
         "protoform": "702",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 167,
-        "baseDefense": 153,
         "formtypes": [
           {
             "type": "Poison",
@@ -1731,9 +1397,6 @@
   "25": {
     "name": "Pikachu",
     "rarity": "Uncommon",
-    "baseStamina": 111,
-    "baseAttack": 112,
-    "baseDefense": 96,
     "types": [
       {
         "type": "Electric",
@@ -1744,10 +1407,6 @@
       {
         "nameform": "Normal",
         "protoform": "598",
-        "assetsform": "00",
-        "baseStamina": 111,
-        "baseAttack": 112,
-        "baseDefense": 96,
         "formtypes": [
           {
             "type": "Electric",
@@ -1758,10 +1417,6 @@
       {
         "nameform": "No Evolve",
         "protoform": "599",
-        "assetsform": "00",
-        "baseStamina": 111,
-        "baseAttack": 112,
-        "baseDefense": 96,
         "formtypes": [
           {
             "type": "Electric",
@@ -1772,10 +1427,6 @@
       {
         "nameform": "Fall",
         "protoform": "894",
-        "assetsform": "00",
-        "baseStamina": 111,
-        "baseAttack": 112,
-        "baseDefense": 96,
         "formtypes": [
           {
             "type": "Electric",
@@ -1786,7 +1437,6 @@
       {
         "nameform": "VS 2019",
         "protoform": "901",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -1797,7 +1447,6 @@
       {
         "nameform": "Clone",
         "protoform": "949",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -1808,7 +1457,6 @@
       {
         "nameform": "Shadow",
         "protoform": "969",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -1819,7 +1467,6 @@
       {
         "nameform": "Purified",
         "protoform": "970",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -1830,7 +1477,6 @@
       {
         "nameform": "Costume 2020",
         "protoform": "2332",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -1841,7 +1487,6 @@
       {
         "nameform": "Adventure hat 2020",
         "protoform": "2669",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -1852,10 +1497,6 @@
       {
         "nameform": "Winter 2020",
         "protoform": "2670",
-        "assetsform": "00",
-        "baseStamina": 111,
-        "baseAttack": 112,
-        "baseDefense": 96,
         "formtypes": [
           {
             "type": "Electric",
@@ -1866,10 +1507,6 @@
       {
         "nameform": "Kariyushi",
         "protoform": "2675",
-        "assetsform": "00",
-        "baseStamina": 111,
-        "baseAttack": 112,
-        "baseDefense": 96,
         "formtypes": [
           {
             "type": "Electric",
@@ -1880,10 +1517,6 @@
       {
         "nameform": "Pop Star",
         "protoform": "2676",
-        "assetsform": "00",
-        "baseStamina": 111,
-        "baseAttack": 112,
-        "baseDefense": 96,
         "formtypes": [
           {
             "type": "Electric",
@@ -1894,10 +1527,6 @@
       {
         "nameform": "Rock Star",
         "protoform": "2677",
-        "assetsform": "00",
-        "baseStamina": 111,
-        "baseAttack": 112,
-        "baseDefense": 96,
         "formtypes": [
           {
             "type": "Electric",
@@ -1908,10 +1537,6 @@
       {
         "nameform": "5th Anniversary",
         "protoform": "2678",
-        "assetsform": "00",
-        "baseStamina": 111,
-        "baseAttack": 112,
-        "baseDefense": 96,
         "formtypes": [
           {
             "type": "Electric",
@@ -1924,9 +1549,6 @@
   "26": {
     "name": "Raichu",
     "rarity": "Ultra Rare",
-    "baseStamina": 155,
-    "baseAttack": 193,
-    "baseDefense": 151,
     "types": [
       {
         "type": "Electric",
@@ -1937,10 +1559,6 @@
       {
         "nameform": "Normal",
         "protoform": "49",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 193,
-        "baseDefense": 151,
         "formtypes": [
           {
             "type": "Electric",
@@ -1951,10 +1569,6 @@
       {
         "nameform": "Alolan",
         "protoform": "50",
-        "assetsform": "61",
-        "baseStamina": 155,
-        "baseAttack": 201,
-        "baseDefense": 154,
         "formtypes": [
           {
             "type": "Electric",
@@ -1969,7 +1583,6 @@
       {
         "nameform": "Shadow",
         "protoform": "969",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -1980,7 +1593,6 @@
       {
         "nameform": "Purified",
         "protoform": "970",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -1993,9 +1605,6 @@
   "27": {
     "name": "Sandshrew",
     "rarity": "Rare",
-    "baseStamina": 137,
-    "baseAttack": 126,
-    "baseDefense": 120,
     "types": [
       {
         "type": "Ground",
@@ -2006,10 +1615,6 @@
       {
         "nameform": "Normal",
         "protoform": "51",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 126,
-        "baseDefense": 120,
         "formtypes": [
           {
             "type": "Ground",
@@ -2020,10 +1625,6 @@
       {
         "nameform": "Alolan",
         "protoform": "52",
-        "assetsform": "61",
-        "baseStamina": 137,
-        "baseAttack": 125,
-        "baseDefense": 129,
         "formtypes": [
           {
             "type": "Ice",
@@ -2038,10 +1639,6 @@
       {
         "nameform": "Shadow",
         "protoform": "673",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 126,
-        "baseDefense": 120,
         "formtypes": [
           {
             "type": "Ground",
@@ -2052,10 +1649,6 @@
       {
         "nameform": "Purified",
         "protoform": "674",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 126,
-        "baseDefense": 120,
         "formtypes": [
           {
             "type": "Ground",
@@ -2068,9 +1661,6 @@
   "28": {
     "name": "Sandslash",
     "rarity": "Ultra Rare",
-    "baseStamina": 181,
-    "baseAttack": 182,
-    "baseDefense": 175,
     "types": [
       {
         "type": "Ground",
@@ -2081,10 +1671,6 @@
       {
         "nameform": "Normal",
         "protoform": "53",
-        "assetsform": "00",
-        "baseStamina": 181,
-        "baseAttack": 182,
-        "baseDefense": 175,
         "formtypes": [
           {
             "type": "Ground",
@@ -2095,10 +1681,6 @@
       {
         "nameform": "Alolan",
         "protoform": "54",
-        "assetsform": "61",
-        "baseStamina": 181,
-        "baseAttack": 177,
-        "baseDefense": 195,
         "formtypes": [
           {
             "type": "Ice",
@@ -2113,10 +1695,6 @@
       {
         "nameform": "Shadow",
         "protoform": "675",
-        "assetsform": "00",
-        "baseStamina": 181,
-        "baseAttack": 182,
-        "baseDefense": 175,
         "formtypes": [
           {
             "type": "Ground",
@@ -2127,10 +1705,6 @@
       {
         "nameform": "Purified",
         "protoform": "676",
-        "assetsform": "00",
-        "baseStamina": 181,
-        "baseAttack": 182,
-        "baseDefense": 175,
         "formtypes": [
           {
             "type": "Ground",
@@ -2143,9 +1717,6 @@
   "29": {
     "name": "Nidoran",
     "rarity": "Uncommon",
-    "baseStamina": 146,
-    "baseAttack": 86,
-    "baseDefense": 89,
     "types": [
       {
         "type": "Poison",
@@ -2156,10 +1727,6 @@
       {
         "nameform": "Normal",
         "protoform": "776",
-        "assetsform": "00",
-        "baseStamina": 146,
-        "baseAttack": 86,
-        "baseDefense": 89,
         "formtypes": [
           {
             "type": "Poison",
@@ -2170,10 +1737,6 @@
       {
         "nameform": "Shadow",
         "protoform": "777",
-        "assetsform": "00",
-        "baseStamina": 146,
-        "baseAttack": 86,
-        "baseDefense": 89,
         "formtypes": [
           {
             "type": "Poison",
@@ -2184,10 +1747,6 @@
       {
         "nameform": "Purified",
         "protoform": "778",
-        "assetsform": "00",
-        "baseStamina": 146,
-        "baseAttack": 86,
-        "baseDefense": 89,
         "formtypes": [
           {
             "type": "Poison",
@@ -2200,9 +1759,6 @@
   "30": {
     "name": "Nidorina",
     "rarity": "Very Rare",
-    "baseStamina": 172,
-    "baseAttack": 117,
-    "baseDefense": 120,
     "types": [
       {
         "type": "Poison",
@@ -2213,10 +1769,6 @@
       {
         "nameform": "Normal",
         "protoform": "779",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 117,
-        "baseDefense": 120,
         "formtypes": [
           {
             "type": "Poison",
@@ -2227,10 +1779,6 @@
       {
         "nameform": "Shadow",
         "protoform": "780",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 117,
-        "baseDefense": 120,
         "formtypes": [
           {
             "type": "Poison",
@@ -2241,10 +1789,6 @@
       {
         "nameform": "Purified",
         "protoform": "781",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 117,
-        "baseDefense": 120,
         "formtypes": [
           {
             "type": "Poison",
@@ -2257,9 +1801,6 @@
   "31": {
     "name": "Nidoqueen",
     "rarity": "Very Rare",
-    "baseStamina": 207,
-    "baseAttack": 180,
-    "baseDefense": 173,
     "types": [
       {
         "type": "Poison",
@@ -2274,10 +1815,6 @@
       {
         "nameform": "Normal",
         "protoform": "782",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 180,
-        "baseDefense": 173,
         "formtypes": [
           {
             "type": "Poison",
@@ -2288,10 +1825,6 @@
       {
         "nameform": "Shadow",
         "protoform": "783",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 180,
-        "baseDefense": 173,
         "formtypes": [
           {
             "type": "Poison",
@@ -2302,10 +1835,6 @@
       {
         "nameform": "Purified",
         "protoform": "784",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 180,
-        "baseDefense": 173,
         "formtypes": [
           {
             "type": "Poison",
@@ -2318,9 +1847,6 @@
   "32": {
     "name": "Nidoran",
     "rarity": "Uncommon",
-    "baseStamina": 130,
-    "baseAttack": 105,
-    "baseDefense": 76,
     "types": [
       {
         "type": "Poison",
@@ -2331,10 +1857,6 @@
       {
         "nameform": "Normal",
         "protoform": "776",
-        "assetsform": "00",
-        "baseStamina": 130,
-        "baseAttack": 105,
-        "baseDefense": 76,
         "formtypes": [
           {
             "type": "Poison",
@@ -2345,10 +1867,6 @@
       {
         "nameform": "Shadow",
         "protoform": "777",
-        "assetsform": "00",
-        "baseStamina": 130,
-        "baseAttack": 105,
-        "baseDefense": 76,
         "formtypes": [
           {
             "type": "Poison",
@@ -2359,10 +1877,6 @@
       {
         "nameform": "Purified",
         "protoform": "778",
-        "assetsform": "00",
-        "baseStamina": 130,
-        "baseAttack": 105,
-        "baseDefense": 76,
         "formtypes": [
           {
             "type": "Poison",
@@ -2375,9 +1889,6 @@
   "33": {
     "name": "Nidorino",
     "rarity": "Very Rare",
-    "baseStamina": 156,
-    "baseAttack": 137,
-    "baseDefense": 111,
     "types": [
       {
         "type": "Poison",
@@ -2388,10 +1899,6 @@
       {
         "nameform": "Normal",
         "protoform": "785",
-        "assetsform": "00",
-        "baseStamina": 156,
-        "baseAttack": 137,
-        "baseDefense": 111,
         "formtypes": [
           {
             "type": "Poison",
@@ -2402,10 +1909,6 @@
       {
         "nameform": "Shadow",
         "protoform": "786",
-        "assetsform": "00",
-        "baseStamina": 156,
-        "baseAttack": 137,
-        "baseDefense": 111,
         "formtypes": [
           {
             "type": "Poison",
@@ -2416,10 +1919,6 @@
       {
         "nameform": "Purified",
         "protoform": "787",
-        "assetsform": "00",
-        "baseStamina": 156,
-        "baseAttack": 137,
-        "baseDefense": 111,
         "formtypes": [
           {
             "type": "Poison",
@@ -2432,9 +1931,6 @@
   "34": {
     "name": "Nidoking",
     "rarity": "Very Rare",
-    "baseStamina": 191,
-    "baseAttack": 204,
-    "baseDefense": 156,
     "types": [
       {
         "type": "Poison",
@@ -2449,10 +1945,6 @@
       {
         "nameform": "Normal",
         "protoform": "788",
-        "assetsform": "00",
-        "baseStamina": 191,
-        "baseAttack": 204,
-        "baseDefense": 156,
         "formtypes": [
           {
             "type": "Poison",
@@ -2463,10 +1955,6 @@
       {
         "nameform": "Shadow",
         "protoform": "789",
-        "assetsform": "00",
-        "baseStamina": 191,
-        "baseAttack": 204,
-        "baseDefense": 156,
         "formtypes": [
           {
             "type": "Poison",
@@ -2477,10 +1965,6 @@
       {
         "nameform": "Purified",
         "protoform": "790",
-        "assetsform": "00",
-        "baseStamina": 191,
-        "baseAttack": 204,
-        "baseDefense": 156,
         "formtypes": [
           {
             "type": "Poison",
@@ -2493,9 +1977,6 @@
   "35": {
     "name": "Clefairy",
     "rarity": "Uncommon",
-    "baseStamina": 172,
-    "baseAttack": 107,
-    "baseDefense": 108,
     "types": [
       {
         "type": "Fairy",
@@ -2506,7 +1987,6 @@
       {
         "nameform": "Normal",
         "protoform": "981",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fairy",
@@ -2517,7 +1997,6 @@
       {
         "nameform": "Shadow",
         "protoform": "982",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fairy",
@@ -2528,7 +2007,6 @@
       {
         "nameform": "Purified",
         "protoform": "983",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fairy",
@@ -2541,9 +2019,6 @@
   "36": {
     "name": "Clefable",
     "rarity": "Very Rare",
-    "baseStamina": 216,
-    "baseAttack": 178,
-    "baseDefense": 162,
     "types": [
       {
         "type": "Fairy",
@@ -2554,7 +2029,6 @@
       {
         "nameform": "Normal",
         "protoform": "984",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fairy",
@@ -2565,7 +2039,6 @@
       {
         "nameform": "Shadow",
         "protoform": "985",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fairy",
@@ -2576,7 +2049,6 @@
       {
         "nameform": "Purified",
         "protoform": "986",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fairy",
@@ -2589,9 +2061,6 @@
   "37": {
     "name": "Vulpix",
     "rarity": "Rare",
-    "baseStamina": 116,
-    "baseAttack": 96,
-    "baseDefense": 109,
     "types": [
       {
         "type": "Fire",
@@ -2602,10 +2071,6 @@
       {
         "nameform": "Normal",
         "protoform": "55",
-        "assetsform": "00",
-        "baseStamina": 116,
-        "baseAttack": 96,
-        "baseDefense": 109,
         "formtypes": [
           {
             "type": "Fire",
@@ -2616,10 +2081,6 @@
       {
         "nameform": "Alolan",
         "protoform": "56",
-        "assetsform": "61",
-        "baseStamina": 116,
-        "baseAttack": 96,
-        "baseDefense": 109,
         "formtypes": [
           {
             "type": "Ice",
@@ -2630,10 +2091,6 @@
       {
         "nameform": "Shadow",
         "protoform": "725",
-        "assetsform": "00",
-        "baseStamina": 116,
-        "baseAttack": 96,
-        "baseDefense": 109,
         "formtypes": [
           {
             "type": "Fire",
@@ -2644,10 +2101,6 @@
       {
         "nameform": "Purified",
         "protoform": "726",
-        "assetsform": "00",
-        "baseStamina": 116,
-        "baseAttack": 96,
-        "baseDefense": 109,
         "formtypes": [
           {
             "type": "Fire",
@@ -2660,9 +2113,6 @@
   "38": {
     "name": "Ninetales",
     "rarity": "Ultra Rare",
-    "baseStamina": 177,
-    "baseAttack": 169,
-    "baseDefense": 190,
     "types": [
       {
         "type": "Fire",
@@ -2673,10 +2123,6 @@
       {
         "nameform": "Normal",
         "protoform": "57",
-        "assetsform": "00",
-        "baseStamina": 177,
-        "baseAttack": 169,
-        "baseDefense": 190,
         "formtypes": [
           {
             "type": "Fire",
@@ -2687,10 +2133,6 @@
       {
         "nameform": "Alolan",
         "protoform": "58",
-        "assetsform": "61",
-        "baseStamina": 177,
-        "baseAttack": 170,
-        "baseDefense": 193,
         "formtypes": [
           {
             "type": "Ice",
@@ -2705,10 +2147,6 @@
       {
         "nameform": "Shadow",
         "protoform": "727",
-        "assetsform": "00",
-        "baseStamina": 177,
-        "baseAttack": 169,
-        "baseDefense": 190,
         "formtypes": [
           {
             "type": "Fire",
@@ -2719,10 +2157,6 @@
       {
         "nameform": "Purified",
         "protoform": "728",
-        "assetsform": "00",
-        "baseStamina": 177,
-        "baseAttack": 169,
-        "baseDefense": 190,
         "formtypes": [
           {
             "type": "Fire",
@@ -2735,9 +2169,6 @@
   "39": {
     "name": "Jigglypuff",
     "rarity": "Rare",
-    "baseStamina": 251,
-    "baseAttack": 80,
-    "baseDefense": 41,
     "types": [
       {
         "type": "Normal",
@@ -2752,7 +2183,6 @@
       {
         "nameform": "Normal",
         "protoform": "987",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -2767,7 +2197,6 @@
       {
         "nameform": "Shadow",
         "protoform": "988",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -2782,7 +2211,6 @@
       {
         "nameform": "Purified",
         "protoform": "989",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fairy",
@@ -2799,9 +2227,6 @@
   "40": {
     "name": "Wigglytuff",
     "rarity": "Ultra Rare",
-    "baseStamina": 295,
-    "baseAttack": 156,
-    "baseDefense": 90,
     "types": [
       {
         "type": "Normal",
@@ -2816,7 +2241,6 @@
       {
         "nameform": "Normal",
         "protoform": "990",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -2831,7 +2255,6 @@
       {
         "nameform": "Shadow",
         "protoform": "991",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -2846,7 +2269,6 @@
       {
         "nameform": "Purified",
         "protoform": "992",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fairy",
@@ -2863,9 +2285,6 @@
   "41": {
     "name": "Zubat",
     "rarity": "Common",
-    "baseStamina": 120,
-    "baseAttack": 83,
-    "baseDefense": 73,
     "types": [
       {
         "type": "Poison",
@@ -2880,10 +2299,6 @@
       {
         "nameform": "Normal",
         "protoform": "157",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 83,
-        "baseDefense": 73,
         "formtypes": [
           {
             "type": "Poison",
@@ -2898,10 +2313,6 @@
       {
         "nameform": "Shadow",
         "protoform": "158",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 83,
-        "baseDefense": 73,
         "formtypes": [
           {
             "type": "Poison",
@@ -2916,10 +2327,6 @@
       {
         "nameform": "Purified",
         "protoform": "159",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 83,
-        "baseDefense": 73,
         "formtypes": [
           {
             "type": "Poison",
@@ -2936,9 +2343,6 @@
   "42": {
     "name": "Golbat",
     "rarity": "Rare",
-    "baseStamina": 181,
-    "baseAttack": 161,
-    "baseDefense": 150,
     "types": [
       {
         "type": "Poison",
@@ -2953,10 +2357,6 @@
       {
         "nameform": "Normal",
         "protoform": "160",
-        "assetsform": "00",
-        "baseStamina": 181,
-        "baseAttack": 161,
-        "baseDefense": 150,
         "formtypes": [
           {
             "type": "Poison",
@@ -2971,10 +2371,6 @@
       {
         "nameform": "Shadow",
         "protoform": "161",
-        "assetsform": "00",
-        "baseStamina": 181,
-        "baseAttack": 161,
-        "baseDefense": 150,
         "formtypes": [
           {
             "type": "Poison",
@@ -2989,10 +2385,6 @@
       {
         "nameform": "Purified",
         "protoform": "162",
-        "assetsform": "00",
-        "baseStamina": 181,
-        "baseAttack": 161,
-        "baseDefense": 150,
         "formtypes": [
           {
             "type": "Poison",
@@ -3009,9 +2401,6 @@
   "43": {
     "name": "Oddish",
     "rarity": "Uncommon",
-    "baseStamina": 128,
-    "baseAttack": 131,
-    "baseDefense": 112,
     "types": [
       {
         "type": "Grass",
@@ -3026,10 +2415,6 @@
       {
         "nameform": "Normal",
         "protoform": "265",
-        "assetsform": "00",
-        "baseStamina": 128,
-        "baseAttack": 131,
-        "baseDefense": 112,
         "formtypes": [
           {
             "type": "Grass",
@@ -3044,10 +2429,6 @@
       {
         "nameform": "Shadow",
         "protoform": "266",
-        "assetsform": "00",
-        "baseStamina": 128,
-        "baseAttack": 131,
-        "baseDefense": 112,
         "formtypes": [
           {
             "type": "Grass",
@@ -3062,10 +2443,6 @@
       {
         "nameform": "Purified",
         "protoform": "267",
-        "assetsform": "00",
-        "baseStamina": 128,
-        "baseAttack": 131,
-        "baseDefense": 112,
         "formtypes": [
           {
             "type": "Grass",
@@ -3082,9 +2459,6 @@
   "44": {
     "name": "Gloom",
     "rarity": "Very Rare",
-    "baseStamina": 155,
-    "baseAttack": 153,
-    "baseDefense": 136,
     "types": [
       {
         "type": "Grass",
@@ -3099,10 +2473,6 @@
       {
         "nameform": "Normal",
         "protoform": "268",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 153,
-        "baseDefense": 136,
         "formtypes": [
           {
             "type": "Grass",
@@ -3117,10 +2487,6 @@
       {
         "nameform": "Shadow",
         "protoform": "269",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 153,
-        "baseDefense": 136,
         "formtypes": [
           {
             "type": "Grass",
@@ -3135,10 +2501,6 @@
       {
         "nameform": "Purified",
         "protoform": "270",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 153,
-        "baseDefense": 136,
         "formtypes": [
           {
             "type": "Grass",
@@ -3155,9 +2517,6 @@
   "45": {
     "name": "Vileplume",
     "rarity": "Ultra Rare",
-    "baseStamina": 181,
-    "baseAttack": 202,
-    "baseDefense": 167,
     "types": [
       {
         "type": "Grass",
@@ -3172,10 +2531,6 @@
       {
         "nameform": "Normal",
         "protoform": "271",
-        "assetsform": "00",
-        "baseStamina": 181,
-        "baseAttack": 202,
-        "baseDefense": 167,
         "formtypes": [
           {
             "type": "Grass",
@@ -3190,10 +2545,6 @@
       {
         "nameform": "Shadow",
         "protoform": "272",
-        "assetsform": "00",
-        "baseStamina": 181,
-        "baseAttack": 202,
-        "baseDefense": 167,
         "formtypes": [
           {
             "type": "Grass",
@@ -3208,10 +2559,6 @@
       {
         "nameform": "Purified",
         "protoform": "273",
-        "assetsform": "00",
-        "baseStamina": 181,
-        "baseAttack": 202,
-        "baseDefense": 167,
         "formtypes": [
           {
             "type": "Grass",
@@ -3228,9 +2575,6 @@
   "46": {
     "name": "Paras",
     "rarity": "Uncommon",
-    "baseStamina": 111,
-    "baseAttack": 121,
-    "baseDefense": 99,
     "types": [
       {
         "type": "Bug",
@@ -3245,7 +2589,6 @@
       {
         "nameform": "Normal",
         "protoform": "993",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -3260,7 +2603,6 @@
       {
         "nameform": "Shadow",
         "protoform": "994",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -3275,7 +2617,6 @@
       {
         "nameform": "Purified",
         "protoform": "995",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -3292,9 +2633,6 @@
   "47": {
     "name": "Parasect",
     "rarity": "Rare",
-    "baseStamina": 155,
-    "baseAttack": 165,
-    "baseDefense": 146,
     "types": [
       {
         "type": "Bug",
@@ -3309,7 +2647,6 @@
       {
         "nameform": "Normal",
         "protoform": "996",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -3324,7 +2661,6 @@
       {
         "nameform": "Shadow",
         "protoform": "997",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -3339,7 +2675,6 @@
       {
         "nameform": "Purified",
         "protoform": "998",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -3356,9 +2691,6 @@
   "48": {
     "name": "Venonat",
     "rarity": "Uncommon",
-    "baseStamina": 155,
-    "baseAttack": 100,
-    "baseDefense": 100,
     "types": [
       {
         "type": "Bug",
@@ -3373,10 +2705,6 @@
       {
         "nameform": "Normal",
         "protoform": "259",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 100,
-        "baseDefense": 100,
         "formtypes": [
           {
             "type": "Bug",
@@ -3391,10 +2719,6 @@
       {
         "nameform": "Shadow",
         "protoform": "260",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 100,
-        "baseDefense": 100,
         "formtypes": [
           {
             "type": "Bug",
@@ -3409,10 +2733,6 @@
       {
         "nameform": "Purified",
         "protoform": "261",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 100,
-        "baseDefense": 100,
         "formtypes": [
           {
             "type": "Bug",
@@ -3429,9 +2749,6 @@
   "49": {
     "name": "Venomoth",
     "rarity": "Rare",
-    "baseStamina": 172,
-    "baseAttack": 179,
-    "baseDefense": 143,
     "types": [
       {
         "type": "Bug",
@@ -3446,10 +2763,6 @@
       {
         "nameform": "Normal",
         "protoform": "262",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 179,
-        "baseDefense": 143,
         "formtypes": [
           {
             "type": "Bug",
@@ -3464,10 +2777,6 @@
       {
         "nameform": "Shadow",
         "protoform": "263",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 179,
-        "baseDefense": 143,
         "formtypes": [
           {
             "type": "Bug",
@@ -3482,10 +2791,6 @@
       {
         "nameform": "Purified",
         "protoform": "264",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 179,
-        "baseDefense": 143,
         "formtypes": [
           {
             "type": "Bug",
@@ -3502,9 +2807,6 @@
   "50": {
     "name": "Diglett",
     "rarity": "Rare",
-    "baseStamina": 67,
-    "baseAttack": 109,
-    "baseDefense": 78,
     "types": [
       {
         "type": "Ground",
@@ -3515,10 +2817,6 @@
       {
         "nameform": "Normal",
         "protoform": "59",
-        "assetsform": "00",
-        "baseStamina": 67,
-        "baseAttack": 109,
-        "baseDefense": 78,
         "formtypes": [
           {
             "type": "Ground",
@@ -3529,10 +2827,6 @@
       {
         "nameform": "Alolan",
         "protoform": "60",
-        "assetsform": "61",
-        "baseStamina": 67,
-        "baseAttack": 108,
-        "baseDefense": 81,
         "formtypes": [
           {
             "type": "Ground",
@@ -3547,10 +2841,6 @@
       {
         "nameform": "Shadow",
         "protoform": "842",
-        "assetsform": "00",
-        "baseStamina": 67,
-        "baseAttack": 109,
-        "baseDefense": 78,
         "formtypes": [
           {
             "type": "Ground",
@@ -3561,10 +2851,6 @@
       {
         "nameform": "Purified",
         "protoform": "843",
-        "assetsform": "00",
-        "baseStamina": 67,
-        "baseAttack": 109,
-        "baseDefense": 78,
         "formtypes": [
           {
             "type": "Ground",
@@ -3577,9 +2863,6 @@
   "51": {
     "name": "Dugtrio",
     "rarity": "Ultra Rare",
-    "baseStamina": 111,
-    "baseAttack": 167,
-    "baseDefense": 136,
     "types": [
       {
         "type": "Ground",
@@ -3590,10 +2873,6 @@
       {
         "nameform": "Normal",
         "protoform": "61",
-        "assetsform": "00",
-        "baseStamina": 111,
-        "baseAttack": 167,
-        "baseDefense": 136,
         "formtypes": [
           {
             "type": "Ground",
@@ -3604,10 +2883,6 @@
       {
         "nameform": "Alolan",
         "protoform": "62",
-        "assetsform": "61",
-        "baseStamina": 111,
-        "baseAttack": 201,
-        "baseDefense": 142,
         "formtypes": [
           {
             "type": "Ground",
@@ -3622,10 +2897,6 @@
       {
         "nameform": "Shadow",
         "protoform": "844",
-        "assetsform": "00",
-        "baseStamina": 111,
-        "baseAttack": 167,
-        "baseDefense": 136,
         "formtypes": [
           {
             "type": "Ground",
@@ -3636,10 +2907,6 @@
       {
         "nameform": "Purified",
         "protoform": "845",
-        "assetsform": "00",
-        "baseStamina": 111,
-        "baseAttack": 167,
-        "baseDefense": 136,
         "formtypes": [
           {
             "type": "Ground",
@@ -3652,9 +2919,6 @@
   "52": {
     "name": "Meowth",
     "rarity": "Rare",
-    "baseStamina": 120,
-    "baseAttack": 92,
-    "baseDefense": 78,
     "types": [
       {
         "type": "Normal",
@@ -3665,10 +2929,6 @@
       {
         "nameform": "Normal",
         "protoform": "63",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 92,
-        "baseDefense": 78,
         "formtypes": [
           {
             "type": "Normal",
@@ -3679,10 +2939,6 @@
       {
         "nameform": "Alolan",
         "protoform": "64",
-        "assetsform": "61",
-        "baseStamina": 120,
-        "baseAttack": 99,
-        "baseDefense": 78,
         "formtypes": [
           {
             "type": "Dark",
@@ -3693,10 +2949,6 @@
       {
         "nameform": "Shadow",
         "protoform": "709",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 92,
-        "baseDefense": 78,
         "formtypes": [
           {
             "type": "Normal",
@@ -3707,10 +2959,6 @@
       {
         "nameform": "Purified",
         "protoform": "710",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 92,
-        "baseDefense": 78,
         "formtypes": [
           {
             "type": "Normal",
@@ -3721,10 +2969,6 @@
       {
         "nameform": "Galarian",
         "protoform": "2335",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 92,
-        "baseDefense": 78,
         "formtypes": [
           {
             "type": "Steel",
@@ -3737,9 +2981,6 @@
   "53": {
     "name": "Persian",
     "rarity": "Very Rare",
-    "baseStamina": 163,
-    "baseAttack": 150,
-    "baseDefense": 136,
     "types": [
       {
         "type": "Normal",
@@ -3750,10 +2991,6 @@
       {
         "nameform": "Normal",
         "protoform": "65",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 150,
-        "baseDefense": 136,
         "formtypes": [
           {
             "type": "Normal",
@@ -3764,10 +3001,6 @@
       {
         "nameform": "Alolan",
         "protoform": "66",
-        "assetsform": "61",
-        "baseStamina": 163,
-        "baseAttack": 158,
-        "baseDefense": 136,
         "formtypes": [
           {
             "type": "Dark",
@@ -3778,10 +3011,6 @@
       {
         "nameform": "Shadow",
         "protoform": "711",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 150,
-        "baseDefense": 136,
         "formtypes": [
           {
             "type": "Normal",
@@ -3792,10 +3021,6 @@
       {
         "nameform": "Purified",
         "protoform": "712",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 150,
-        "baseDefense": 136,
         "formtypes": [
           {
             "type": "Normal",
@@ -3808,9 +3033,6 @@
   "54": {
     "name": "Psyduck",
     "rarity": "Rare",
-    "baseStamina": 137,
-    "baseAttack": 122,
-    "baseDefense": 95,
     "types": [
       {
         "type": "Water",
@@ -3821,10 +3043,6 @@
       {
         "nameform": "Normal",
         "protoform": "286",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 122,
-        "baseDefense": 95,
         "formtypes": [
           {
             "type": "Water",
@@ -3835,10 +3053,6 @@
       {
         "nameform": "Shadow",
         "protoform": "287",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 122,
-        "baseDefense": 95,
         "formtypes": [
           {
             "type": "Water",
@@ -3849,10 +3063,6 @@
       {
         "nameform": "Purified",
         "protoform": "288",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 122,
-        "baseDefense": 95,
         "formtypes": [
           {
             "type": "Water",
@@ -3865,9 +3075,6 @@
   "55": {
     "name": "Golduck",
     "rarity": "Very Rare",
-    "baseStamina": 190,
-    "baseAttack": 191,
-    "baseDefense": 162,
     "types": [
       {
         "type": "Water",
@@ -3878,10 +3085,6 @@
       {
         "nameform": "Normal",
         "protoform": "289",
-        "assetsform": "00",
-        "baseStamina": 190,
-        "baseAttack": 191,
-        "baseDefense": 162,
         "formtypes": [
           {
             "type": "Water",
@@ -3892,10 +3095,6 @@
       {
         "nameform": "Shadow",
         "protoform": "290",
-        "assetsform": "00",
-        "baseStamina": 190,
-        "baseAttack": 191,
-        "baseDefense": 162,
         "formtypes": [
           {
             "type": "Water",
@@ -3906,10 +3105,6 @@
       {
         "nameform": "Purified",
         "protoform": "291",
-        "assetsform": "00",
-        "baseStamina": 190,
-        "baseAttack": 191,
-        "baseDefense": 162,
         "formtypes": [
           {
             "type": "Water",
@@ -3922,9 +3117,6 @@
   "56": {
     "name": "Mankey",
     "rarity": "Rare",
-    "baseStamina": 120,
-    "baseAttack": 148,
-    "baseDefense": 82,
     "types": [
       {
         "type": "Fighting",
@@ -3935,7 +3127,6 @@
       {
         "nameform": "Normal",
         "protoform": "999",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -3946,7 +3137,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1000",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -3957,7 +3147,6 @@
       {
         "nameform": "Purified",
         "protoform": "1001",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -3970,9 +3159,6 @@
   "57": {
     "name": "Primeape",
     "rarity": "Very Rare",
-    "baseStamina": 163,
-    "baseAttack": 207,
-    "baseDefense": 138,
     "types": [
       {
         "type": "Fighting",
@@ -3983,7 +3169,6 @@
       {
         "nameform": "Normal",
         "protoform": "1002",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -3994,7 +3179,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1003",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -4005,7 +3189,6 @@
       {
         "nameform": "Purified",
         "protoform": "1004",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -4018,9 +3201,6 @@
   "58": {
     "name": "Growlithe",
     "rarity": "Uncommon",
-    "baseStamina": 146,
-    "baseAttack": 136,
-    "baseDefense": 93,
     "types": [
       {
         "type": "Fire",
@@ -4031,10 +3211,6 @@
       {
         "nameform": "Normal",
         "protoform": "280",
-        "assetsform": "00",
-        "baseStamina": 146,
-        "baseAttack": 136,
-        "baseDefense": 93,
         "formtypes": [
           {
             "type": "Fire",
@@ -4045,10 +3221,6 @@
       {
         "nameform": "Shadow",
         "protoform": "281",
-        "assetsform": "00",
-        "baseStamina": 146,
-        "baseAttack": 136,
-        "baseDefense": 93,
         "formtypes": [
           {
             "type": "Fire",
@@ -4059,10 +3231,6 @@
       {
         "nameform": "Purified",
         "protoform": "282",
-        "assetsform": "00",
-        "baseStamina": 146,
-        "baseAttack": 136,
-        "baseDefense": 93,
         "formtypes": [
           {
             "type": "Fire",
@@ -4075,9 +3243,6 @@
   "59": {
     "name": "Arcanine",
     "rarity": "Very Rare",
-    "baseStamina": 207,
-    "baseAttack": 227,
-    "baseDefense": 166,
     "types": [
       {
         "type": "Fire",
@@ -4088,10 +3253,6 @@
       {
         "nameform": "Normal",
         "protoform": "283",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 227,
-        "baseDefense": 166,
         "formtypes": [
           {
             "type": "Fire",
@@ -4102,10 +3263,6 @@
       {
         "nameform": "Shadow",
         "protoform": "284",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 227,
-        "baseDefense": 166,
         "formtypes": [
           {
             "type": "Fire",
@@ -4116,10 +3273,6 @@
       {
         "nameform": "Purified",
         "protoform": "285",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 227,
-        "baseDefense": 166,
         "formtypes": [
           {
             "type": "Fire",
@@ -4132,9 +3285,6 @@
   "60": {
     "name": "Poliwag",
     "rarity": "Uncommon",
-    "baseStamina": 120,
-    "baseAttack": 101,
-    "baseDefense": 82,
     "types": [
       {
         "type": "Water",
@@ -4145,10 +3295,6 @@
       {
         "nameform": "Normal",
         "protoform": "235",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 101,
-        "baseDefense": 82,
         "formtypes": [
           {
             "type": "Water",
@@ -4159,10 +3305,6 @@
       {
         "nameform": "Shadow",
         "protoform": "236",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 101,
-        "baseDefense": 82,
         "formtypes": [
           {
             "type": "Water",
@@ -4173,10 +3315,6 @@
       {
         "nameform": "Purified",
         "protoform": "237",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 101,
-        "baseDefense": 82,
         "formtypes": [
           {
             "type": "Water",
@@ -4189,9 +3327,6 @@
   "61": {
     "name": "Poliwhirl",
     "rarity": "Rare",
-    "baseStamina": 163,
-    "baseAttack": 130,
-    "baseDefense": 123,
     "types": [
       {
         "type": "Water",
@@ -4202,10 +3337,6 @@
       {
         "nameform": "Normal",
         "protoform": "238",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 130,
-        "baseDefense": 123,
         "formtypes": [
           {
             "type": "Water",
@@ -4216,10 +3347,6 @@
       {
         "nameform": "Shadow",
         "protoform": "239",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 130,
-        "baseDefense": 123,
         "formtypes": [
           {
             "type": "Water",
@@ -4230,10 +3357,6 @@
       {
         "nameform": "Purified",
         "protoform": "240",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 130,
-        "baseDefense": 123,
         "formtypes": [
           {
             "type": "Water",
@@ -4246,9 +3369,6 @@
   "62": {
     "name": "Poliwrath",
     "rarity": "Ultra Rare",
-    "baseStamina": 207,
-    "baseAttack": 182,
-    "baseDefense": 184,
     "types": [
       {
         "type": "Water",
@@ -4263,10 +3383,6 @@
       {
         "nameform": "Normal",
         "protoform": "241",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 182,
-        "baseDefense": 184,
         "formtypes": [
           {
             "type": "Water",
@@ -4281,10 +3397,6 @@
       {
         "nameform": "Shadow",
         "protoform": "242",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 182,
-        "baseDefense": 184,
         "formtypes": [
           {
             "type": "Water",
@@ -4299,10 +3411,6 @@
       {
         "nameform": "Purified",
         "protoform": "243",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 182,
-        "baseDefense": 184,
         "formtypes": [
           {
             "type": "Water",
@@ -4319,9 +3427,6 @@
   "63": {
     "name": "Abra",
     "rarity": "Rare",
-    "baseStamina": 93,
-    "baseAttack": 195,
-    "baseDefense": 82,
     "types": [
       {
         "type": "Psychic",
@@ -4332,10 +3437,6 @@
       {
         "nameform": "Normal",
         "protoform": "304",
-        "assetsform": "00",
-        "baseStamina": 93,
-        "baseAttack": 195,
-        "baseDefense": 82,
         "formtypes": [
           {
             "type": "Psychic",
@@ -4346,10 +3447,6 @@
       {
         "nameform": "Shadow",
         "protoform": "305",
-        "assetsform": "00",
-        "baseStamina": 93,
-        "baseAttack": 195,
-        "baseDefense": 82,
         "formtypes": [
           {
             "type": "Psychic",
@@ -4360,10 +3457,6 @@
       {
         "nameform": "Purified",
         "protoform": "306",
-        "assetsform": "00",
-        "baseStamina": 93,
-        "baseAttack": 195,
-        "baseDefense": 82,
         "formtypes": [
           {
             "type": "Psychic",
@@ -4376,9 +3469,6 @@
   "64": {
     "name": "Kadabra",
     "rarity": "Very Rare",
-    "baseStamina": 120,
-    "baseAttack": 232,
-    "baseDefense": 117,
     "types": [
       {
         "type": "Psychic",
@@ -4389,10 +3479,6 @@
       {
         "nameform": "Normal",
         "protoform": "307",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 232,
-        "baseDefense": 117,
         "formtypes": [
           {
             "type": "Psychic",
@@ -4403,10 +3489,6 @@
       {
         "nameform": "Shadow",
         "protoform": "308",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 232,
-        "baseDefense": 117,
         "formtypes": [
           {
             "type": "Psychic",
@@ -4417,10 +3499,6 @@
       {
         "nameform": "Purified",
         "protoform": "309",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 232,
-        "baseDefense": 117,
         "formtypes": [
           {
             "type": "Psychic",
@@ -4433,9 +3511,6 @@
   "65": {
     "name": "Alakazam",
     "rarity": "Ultra Rare",
-    "baseStamina": 146,
-    "baseAttack": 271,
-    "baseDefense": 167,
     "types": [
       {
         "type": "Psychic",
@@ -4446,10 +3521,6 @@
       {
         "nameform": "Normal",
         "protoform": "310",
-        "assetsform": "00",
-        "baseStamina": 146,
-        "baseAttack": 271,
-        "baseDefense": 167,
         "formtypes": [
           {
             "type": "Psychic",
@@ -4460,10 +3531,6 @@
       {
         "nameform": "Shadow",
         "protoform": "311",
-        "assetsform": "00",
-        "baseStamina": 146,
-        "baseAttack": 271,
-        "baseDefense": 167,
         "formtypes": [
           {
             "type": "Psychic",
@@ -4474,10 +3541,6 @@
       {
         "nameform": "Purified",
         "protoform": "312",
-        "assetsform": "00",
-        "baseStamina": 146,
-        "baseAttack": 271,
-        "baseDefense": 167,
         "formtypes": [
           {
             "type": "Psychic",
@@ -4490,9 +3553,6 @@
   "66": {
     "name": "Machop",
     "rarity": "Rare",
-    "baseStamina": 172,
-    "baseAttack": 137,
-    "baseDefense": 82,
     "types": [
       {
         "type": "Fighting",
@@ -4503,10 +3563,6 @@
       {
         "nameform": "Normal",
         "protoform": "809",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 137,
-        "baseDefense": 82,
         "formtypes": [
           {
             "type": "Fighting",
@@ -4517,10 +3573,6 @@
       {
         "nameform": "Shadow",
         "protoform": "810",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 137,
-        "baseDefense": 82,
         "formtypes": [
           {
             "type": "Fighting",
@@ -4531,10 +3583,6 @@
       {
         "nameform": "Purified",
         "protoform": "811",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 137,
-        "baseDefense": 82,
         "formtypes": [
           {
             "type": "Fighting",
@@ -4547,9 +3595,6 @@
   "67": {
     "name": "Machoke",
     "rarity": "Very Rare",
-    "baseStamina": 190,
-    "baseAttack": 177,
-    "baseDefense": 125,
     "types": [
       {
         "type": "Fighting",
@@ -4560,10 +3605,6 @@
       {
         "nameform": "Normal",
         "protoform": "812",
-        "assetsform": "00",
-        "baseStamina": 190,
-        "baseAttack": 177,
-        "baseDefense": 125,
         "formtypes": [
           {
             "type": "Fighting",
@@ -4574,10 +3615,6 @@
       {
         "nameform": "Shadow",
         "protoform": "813",
-        "assetsform": "00",
-        "baseStamina": 190,
-        "baseAttack": 177,
-        "baseDefense": 125,
         "formtypes": [
           {
             "type": "Fighting",
@@ -4588,10 +3625,6 @@
       {
         "nameform": "Purified",
         "protoform": "814",
-        "assetsform": "00",
-        "baseStamina": 190,
-        "baseAttack": 177,
-        "baseDefense": 125,
         "formtypes": [
           {
             "type": "Fighting",
@@ -4604,9 +3637,6 @@
   "68": {
     "name": "Machamp",
     "rarity": "Ultra Rare",
-    "baseStamina": 207,
-    "baseAttack": 234,
-    "baseDefense": 159,
     "types": [
       {
         "type": "Fighting",
@@ -4617,10 +3647,6 @@
       {
         "nameform": "Normal",
         "protoform": "815",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 234,
-        "baseDefense": 159,
         "formtypes": [
           {
             "type": "Fighting",
@@ -4631,10 +3657,6 @@
       {
         "nameform": "Shadow",
         "protoform": "816",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 234,
-        "baseDefense": 159,
         "formtypes": [
           {
             "type": "Fighting",
@@ -4645,10 +3667,6 @@
       {
         "nameform": "Purified",
         "protoform": "817",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 234,
-        "baseDefense": 159,
         "formtypes": [
           {
             "type": "Fighting",
@@ -4661,9 +3679,6 @@
   "69": {
     "name": "Bellsprout",
     "rarity": "Uncommon",
-    "baseStamina": 137,
-    "baseAttack": 139,
-    "baseDefense": 61,
     "types": [
       {
         "type": "Grass",
@@ -4678,10 +3693,6 @@
       {
         "nameform": "Normal",
         "protoform": "664",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 139,
-        "baseDefense": 61,
         "formtypes": [
           {
             "type": "Grass",
@@ -4696,10 +3707,6 @@
       {
         "nameform": "Shadow",
         "protoform": "665",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 139,
-        "baseDefense": 61,
         "formtypes": [
           {
             "type": "Grass",
@@ -4714,10 +3721,6 @@
       {
         "nameform": "Purified",
         "protoform": "666",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 139,
-        "baseDefense": 61,
         "formtypes": [
           {
             "type": "Grass",
@@ -4734,9 +3737,6 @@
   "70": {
     "name": "Weepinbell",
     "rarity": "Rare",
-    "baseStamina": 163,
-    "baseAttack": 172,
-    "baseDefense": 92,
     "types": [
       {
         "type": "Grass",
@@ -4751,10 +3751,6 @@
       {
         "nameform": "Normal",
         "protoform": "667",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 172,
-        "baseDefense": 92,
         "formtypes": [
           {
             "type": "Grass",
@@ -4769,10 +3765,6 @@
       {
         "nameform": "Shadow",
         "protoform": "668",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 172,
-        "baseDefense": 92,
         "formtypes": [
           {
             "type": "Grass",
@@ -4787,10 +3779,6 @@
       {
         "nameform": "Purified",
         "protoform": "669",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 172,
-        "baseDefense": 92,
         "formtypes": [
           {
             "type": "Grass",
@@ -4807,9 +3795,6 @@
   "71": {
     "name": "Victreebel",
     "rarity": "Ultra Rare",
-    "baseStamina": 190,
-    "baseAttack": 207,
-    "baseDefense": 135,
     "types": [
       {
         "type": "Grass",
@@ -4824,10 +3809,6 @@
       {
         "nameform": "Normal",
         "protoform": "670",
-        "assetsform": "00",
-        "baseStamina": 190,
-        "baseAttack": 207,
-        "baseDefense": 135,
         "formtypes": [
           {
             "type": "Grass",
@@ -4842,10 +3823,6 @@
       {
         "nameform": "Shadow",
         "protoform": "671",
-        "assetsform": "00",
-        "baseStamina": 190,
-        "baseAttack": 207,
-        "baseDefense": 135,
         "formtypes": [
           {
             "type": "Grass",
@@ -4860,10 +3837,6 @@
       {
         "nameform": "Purified",
         "protoform": "672",
-        "assetsform": "00",
-        "baseStamina": 190,
-        "baseAttack": 207,
-        "baseDefense": 135,
         "formtypes": [
           {
             "type": "Grass",
@@ -4880,9 +3853,6 @@
   "72": {
     "name": "Tentacool",
     "rarity": "Rare",
-    "baseStamina": 120,
-    "baseAttack": 97,
-    "baseDefense": 149,
     "types": [
       {
         "type": "Water",
@@ -4897,7 +3867,6 @@
       {
         "nameform": "Normal",
         "protoform": "1005",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -4912,7 +3881,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1006",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -4927,7 +3895,6 @@
       {
         "nameform": "Purified",
         "protoform": "1007",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -4944,9 +3911,6 @@
   "73": {
     "name": "Tentacruel",
     "rarity": "Very Rare",
-    "baseStamina": 190,
-    "baseAttack": 166,
-    "baseDefense": 209,
     "types": [
       {
         "type": "Water",
@@ -4961,7 +3925,6 @@
       {
         "nameform": "Normal",
         "protoform": "1007",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -4976,7 +3939,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1008",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -4991,7 +3953,6 @@
       {
         "nameform": "Purified",
         "protoform": "1009",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -5008,9 +3969,6 @@
   "74": {
     "name": "Geodude",
     "rarity": "Rare",
-    "baseStamina": 120,
-    "baseAttack": 132,
-    "baseDefense": 132,
     "types": [
       {
         "type": "Rock",
@@ -5025,10 +3983,6 @@
       {
         "nameform": "Normal",
         "protoform": "67",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 132,
-        "baseDefense": 132,
         "formtypes": [
           {
             "type": "Rock",
@@ -5043,10 +3997,6 @@
       {
         "nameform": "Alolan",
         "protoform": "68",
-        "assetsform": "61",
-        "baseStamina": 120,
-        "baseAttack": 132,
-        "baseDefense": 132,
         "formtypes": [
           {
             "type": "Rock",
@@ -5061,10 +4011,6 @@
       {
         "nameform": "Shadow",
         "protoform": "882",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 132,
-        "baseDefense": 132,
         "formtypes": [
           {
             "type": "Rock",
@@ -5079,10 +4025,6 @@
       {
         "nameform": "Purified",
         "protoform": "883",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 132,
-        "baseDefense": 132,
         "formtypes": [
           {
             "type": "Rock",
@@ -5099,9 +4041,6 @@
   "75": {
     "name": "Graveler",
     "rarity": "Very Rare",
-    "baseStamina": 146,
-    "baseAttack": 164,
-    "baseDefense": 164,
     "types": [
       {
         "type": "Rock",
@@ -5116,10 +4055,6 @@
       {
         "nameform": "Normal",
         "protoform": "69",
-        "assetsform": "00",
-        "baseStamina": 146,
-        "baseAttack": 164,
-        "baseDefense": 164,
         "formtypes": [
           {
             "type": "Rock",
@@ -5134,10 +4069,6 @@
       {
         "nameform": "Alolan",
         "protoform": "70",
-        "assetsform": "61",
-        "baseStamina": 146,
-        "baseAttack": 164,
-        "baseDefense": 164,
         "formtypes": [
           {
             "type": "Rock",
@@ -5152,10 +4083,6 @@
       {
         "nameform": "Shadow",
         "protoform": "884",
-        "assetsform": "00",
-        "baseStamina": 146,
-        "baseAttack": 164,
-        "baseDefense": 164,
         "formtypes": [
           {
             "type": "Rock",
@@ -5170,10 +4097,6 @@
       {
         "nameform": "Purified",
         "protoform": "885",
-        "assetsform": "00",
-        "baseStamina": 146,
-        "baseAttack": 164,
-        "baseDefense": 164,
         "formtypes": [
           {
             "type": "Rock",
@@ -5190,9 +4113,6 @@
   "76": {
     "name": "Golem",
     "rarity": "Ultra Rare",
-    "baseStamina": 190,
-    "baseAttack": 211,
-    "baseDefense": 198,
     "types": [
       {
         "type": "Rock",
@@ -5207,10 +4127,6 @@
       {
         "nameform": "Normal",
         "protoform": "71",
-        "assetsform": "00",
-        "baseStamina": 190,
-        "baseAttack": 211,
-        "baseDefense": 198,
         "formtypes": [
           {
             "type": "Rock",
@@ -5225,10 +4141,6 @@
       {
         "nameform": "Alolan",
         "protoform": "72",
-        "assetsform": "61",
-        "baseStamina": 190,
-        "baseAttack": 211,
-        "baseDefense": 198,
         "formtypes": [
           {
             "type": "Rock",
@@ -5243,10 +4155,6 @@
       {
         "nameform": "Shadow",
         "protoform": "886",
-        "assetsform": "00",
-        "baseStamina": 190,
-        "baseAttack": 211,
-        "baseDefense": 198,
         "formtypes": [
           {
             "type": "Rock",
@@ -5261,10 +4169,6 @@
       {
         "nameform": "Purified",
         "protoform": "887",
-        "assetsform": "00",
-        "baseStamina": 190,
-        "baseAttack": 211,
-        "baseDefense": 198,
         "formtypes": [
           {
             "type": "Rock",
@@ -5281,9 +4185,6 @@
   "77": {
     "name": "Ponyta",
     "rarity": "Rare",
-    "baseStamina": 137,
-    "baseAttack": 170,
-    "baseDefense": 127,
     "types": [
       {
         "type": "Fire",
@@ -5294,7 +4195,6 @@
       {
         "nameform": "Normal",
         "protoform": "1011",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -5305,7 +4205,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1012",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -5316,7 +4215,6 @@
       {
         "nameform": "Purified",
         "protoform": "1013",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -5327,7 +4225,6 @@
       {
         "nameform": "Galarian",
         "protoform": "2336",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -5340,9 +4237,6 @@
   "78": {
     "name": "Rapidash",
     "rarity": "Very Rare",
-    "baseStamina": 163,
-    "baseAttack": 207,
-    "baseDefense": 162,
     "types": [
       {
         "type": "Fire",
@@ -5353,7 +4247,6 @@
       {
         "nameform": "Normal",
         "protoform": "1014",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -5364,7 +4257,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1015",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -5375,7 +4267,6 @@
       {
         "nameform": "Purified",
         "protoform": "1016",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -5386,7 +4277,6 @@
       {
         "nameform": "Galarian",
         "protoform": "2337",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -5403,9 +4293,6 @@
   "79": {
     "name": "Slowpoke",
     "rarity": "Rare",
-    "baseStamina": 207,
-    "baseAttack": 109,
-    "baseDefense": 98,
     "types": [
       {
         "type": "Water",
@@ -5420,7 +4307,6 @@
       {
         "nameform": "Normal",
         "protoform": "1017",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -5435,7 +4321,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1018",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -5450,7 +4335,6 @@
       {
         "nameform": "Purified",
         "protoform": "1019",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -5465,7 +4349,6 @@
       {
         "nameform": "Galarian",
         "protoform": "2582",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -5476,10 +4359,6 @@
       {
         "nameform": "2020",
         "protoform": "2673",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 109,
-        "baseDefense": 98,
         "formtypes": [
           {
             "type": "Water",
@@ -5496,9 +4375,6 @@
   "80": {
     "name": "Slowbro",
     "rarity": "Very Rare",
-    "baseStamina": 216,
-    "baseAttack": 177,
-    "baseDefense": 180,
     "types": [
       {
         "type": "Water",
@@ -5513,7 +4389,6 @@
       {
         "nameform": "Normal",
         "protoform": "1020",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -5528,7 +4403,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1021",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -5543,7 +4417,6 @@
       {
         "nameform": "Purified",
         "protoform": "1022",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -5558,7 +4431,6 @@
       {
         "nameform": "Galarian",
         "protoform": "2583",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -5569,10 +4441,6 @@
       {
         "nameform": "2021",
         "protoform": "2674",
-        "assetsform": "00",
-        "baseStamina": 216,
-        "baseAttack": 177,
-        "baseDefense": 180,
         "formtypes": [
           {
             "type": "Water",
@@ -5589,9 +4457,6 @@
   "81": {
     "name": "Magnemite",
     "rarity": "Rare",
-    "baseStamina": 93,
-    "baseAttack": 165,
-    "baseDefense": 121,
     "types": [
       {
         "type": "Electric",
@@ -5606,10 +4471,6 @@
       {
         "nameform": "Normal",
         "protoform": "655",
-        "assetsform": "00",
-        "baseStamina": 93,
-        "baseAttack": 165,
-        "baseDefense": 121,
         "formtypes": [
           {
             "type": "Electric",
@@ -5624,10 +4485,6 @@
       {
         "nameform": "Shadow",
         "protoform": "656",
-        "assetsform": "00",
-        "baseStamina": 93,
-        "baseAttack": 165,
-        "baseDefense": 121,
         "formtypes": [
           {
             "type": "Electric",
@@ -5642,10 +4499,6 @@
       {
         "nameform": "Purified",
         "protoform": "657",
-        "assetsform": "00",
-        "baseStamina": 93,
-        "baseAttack": 165,
-        "baseDefense": 121,
         "formtypes": [
           {
             "type": "Electric",
@@ -5662,9 +4515,6 @@
   "82": {
     "name": "Magneton",
     "rarity": "Ultra Rare",
-    "baseStamina": 137,
-    "baseAttack": 223,
-    "baseDefense": 169,
     "types": [
       {
         "type": "Electric",
@@ -5679,10 +4529,6 @@
       {
         "nameform": "Normal",
         "protoform": "658",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 223,
-        "baseDefense": 169,
         "formtypes": [
           {
             "type": "Electric",
@@ -5697,10 +4543,6 @@
       {
         "nameform": "Shadow",
         "protoform": "659",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 223,
-        "baseDefense": 169,
         "formtypes": [
           {
             "type": "Electric",
@@ -5715,10 +4557,6 @@
       {
         "nameform": "Purified",
         "protoform": "660",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 223,
-        "baseDefense": 169,
         "formtypes": [
           {
             "type": "Electric",
@@ -5735,9 +4573,6 @@
   "83": {
     "name": "Farfetch'd",
     "rarity": "Ultra Rare",
-    "baseStamina": 141,
-    "baseAttack": 124,
-    "baseDefense": 115,
     "types": [
       {
         "type": "Normal",
@@ -5752,7 +4587,6 @@
       {
         "nameform": "Normal",
         "protoform": "1023",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -5767,7 +4601,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1024",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -5782,7 +4615,6 @@
       {
         "nameform": "Purified",
         "protoform": "1025",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -5797,7 +4629,6 @@
       {
         "nameform": "Galarian",
         "protoform": "2338",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -5814,9 +4645,6 @@
   "84": {
     "name": "Doduo",
     "rarity": "Uncommon",
-    "baseStamina": 111,
-    "baseAttack": 158,
-    "baseDefense": 83,
     "types": [
       {
         "type": "Normal",
@@ -5831,7 +4659,6 @@
       {
         "nameform": "Normal",
         "protoform": "1026",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -5846,7 +4673,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1027",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -5861,7 +4687,6 @@
       {
         "nameform": "Purified",
         "protoform": "1028",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -5878,9 +4703,6 @@
   "85": {
     "name": "Dodrio",
     "rarity": "Very Rare",
-    "baseStamina": 155,
-    "baseAttack": 218,
-    "baseDefense": 140,
     "types": [
       {
         "type": "Normal",
@@ -5895,7 +4717,6 @@
       {
         "nameform": "Normal",
         "protoform": "1029",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -5910,7 +4731,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1030",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -5925,7 +4745,6 @@
       {
         "nameform": "Purified",
         "protoform": "1031",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -5942,9 +4761,6 @@
   "86": {
     "name": "Seel",
     "rarity": "Rare",
-    "baseStamina": 163,
-    "baseAttack": 85,
-    "baseDefense": 121,
     "types": [
       {
         "type": "Water",
@@ -5955,7 +4771,6 @@
       {
         "nameform": "Normal",
         "protoform": "1032",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -5966,7 +4781,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1033",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -5977,7 +4791,6 @@
       {
         "nameform": "Purified",
         "protoform": "1034",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -5990,9 +4803,6 @@
   "87": {
     "name": "Dewgong",
     "rarity": "Ultra Rare",
-    "baseStamina": 207,
-    "baseAttack": 139,
-    "baseDefense": 177,
     "types": [
       {
         "type": "Water",
@@ -6007,7 +4817,6 @@
       {
         "nameform": "Normal",
         "protoform": "1035",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -6022,7 +4831,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1036",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -6037,7 +4845,6 @@
       {
         "nameform": "Purified",
         "protoform": "1037",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -6054,9 +4861,6 @@
   "88": {
     "name": "Grimer",
     "rarity": "Very Rare",
-    "baseStamina": 190,
-    "baseAttack": 135,
-    "baseDefense": 90,
     "types": [
       {
         "type": "Poison",
@@ -6067,10 +4871,6 @@
       {
         "nameform": "Normal",
         "protoform": "73",
-        "assetsform": "00",
-        "baseStamina": 190,
-        "baseAttack": 135,
-        "baseDefense": 90,
         "formtypes": [
           {
             "type": "Poison",
@@ -6081,10 +4881,6 @@
       {
         "nameform": "Alolan",
         "protoform": "74",
-        "assetsform": "61",
-        "baseStamina": 190,
-        "baseAttack": 135,
-        "baseDefense": 90,
         "formtypes": [
           {
             "type": "Poison",
@@ -6099,10 +4895,6 @@
       {
         "nameform": "Shadow",
         "protoform": "220",
-        "assetsform": "00",
-        "baseStamina": 190,
-        "baseAttack": 135,
-        "baseDefense": 90,
         "formtypes": [
           {
             "type": "Poison",
@@ -6113,10 +4905,6 @@
       {
         "nameform": "Purified",
         "protoform": "221",
-        "assetsform": "00",
-        "baseStamina": 190,
-        "baseAttack": 135,
-        "baseDefense": 90,
         "formtypes": [
           {
             "type": "Poison",
@@ -6129,9 +4917,6 @@
   "89": {
     "name": "Muk",
     "rarity": "Ultra Rare",
-    "baseStamina": 233,
-    "baseAttack": 190,
-    "baseDefense": 172,
     "types": [
       {
         "type": "Poison",
@@ -6142,10 +4927,6 @@
       {
         "nameform": "Normal",
         "protoform": "75",
-        "assetsform": "00",
-        "baseStamina": 233,
-        "baseAttack": 190,
-        "baseDefense": 172,
         "formtypes": [
           {
             "type": "Poison",
@@ -6156,10 +4937,6 @@
       {
         "nameform": "Alolan",
         "protoform": "76",
-        "assetsform": "61",
-        "baseStamina": 233,
-        "baseAttack": 190,
-        "baseDefense": 172,
         "formtypes": [
           {
             "type": "Poison",
@@ -6174,10 +4951,6 @@
       {
         "nameform": "Shadow",
         "protoform": "222",
-        "assetsform": "00",
-        "baseStamina": 233,
-        "baseAttack": 190,
-        "baseDefense": 172,
         "formtypes": [
           {
             "type": "Poison",
@@ -6188,10 +4961,6 @@
       {
         "nameform": "Purified",
         "protoform": "223",
-        "assetsform": "00",
-        "baseStamina": 233,
-        "baseAttack": 190,
-        "baseDefense": 172,
         "formtypes": [
           {
             "type": "Poison",
@@ -6204,9 +4973,6 @@
   "90": {
     "name": "Shellder",
     "rarity": "Rare",
-    "baseStamina": 102,
-    "baseAttack": 116,
-    "baseDefense": 134,
     "types": [
       {
         "type": "Water",
@@ -6217,10 +4983,6 @@
       {
         "nameform": "Normal",
         "protoform": "876",
-        "assetsform": "00",
-        "baseStamina": 102,
-        "baseAttack": 116,
-        "baseDefense": 134,
         "formtypes": [
           {
             "type": "Water",
@@ -6231,10 +4993,6 @@
       {
         "nameform": "Shadow",
         "protoform": "877",
-        "assetsform": "00",
-        "baseStamina": 102,
-        "baseAttack": 116,
-        "baseDefense": 134,
         "formtypes": [
           {
             "type": "Water",
@@ -6245,10 +5003,6 @@
       {
         "nameform": "Purified",
         "protoform": "878",
-        "assetsform": "00",
-        "baseStamina": 102,
-        "baseAttack": 116,
-        "baseDefense": 134,
         "formtypes": [
           {
             "type": "Water",
@@ -6261,9 +5015,6 @@
   "91": {
     "name": "Cloyster",
     "rarity": "Ultra Rare",
-    "baseStamina": 137,
-    "baseAttack": 186,
-    "baseDefense": 256,
     "types": [
       {
         "type": "Water",
@@ -6278,10 +5029,6 @@
       {
         "nameform": "Normal",
         "protoform": "879",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 186,
-        "baseDefense": 256,
         "formtypes": [
           {
             "type": "Water",
@@ -6296,10 +5043,6 @@
       {
         "nameform": "Shadow",
         "protoform": "880",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 186,
-        "baseDefense": 256,
         "formtypes": [
           {
             "type": "Water",
@@ -6314,10 +5057,6 @@
       {
         "nameform": "Purified",
         "protoform": "881",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 186,
-        "baseDefense": 256,
         "formtypes": [
           {
             "type": "Water",
@@ -6334,9 +5073,6 @@
   "92": {
     "name": "Gastly",
     "rarity": "Uncommon",
-    "baseStamina": 102,
-    "baseAttack": 186,
-    "baseDefense": 67,
     "types": [
       {
         "type": "Ghost",
@@ -6351,7 +5087,6 @@
       {
         "nameform": "Normal",
         "protoform": "1038",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -6366,7 +5101,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1039",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -6381,7 +5115,6 @@
       {
         "nameform": "Purified",
         "protoform": "1040",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -6398,9 +5131,6 @@
   "93": {
     "name": "Haunter",
     "rarity": "Rare",
-    "baseStamina": 128,
-    "baseAttack": 223,
-    "baseDefense": 107,
     "types": [
       {
         "type": "Ghost",
@@ -6415,7 +5145,6 @@
       {
         "nameform": "Normal",
         "protoform": "1041",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -6430,7 +5159,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1042",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -6445,7 +5173,6 @@
       {
         "nameform": "Purified",
         "protoform": "1043",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -6462,9 +5189,6 @@
   "94": {
     "name": "Gengar",
     "rarity": "Ultra Rare",
-    "baseStamina": 155,
-    "baseAttack": 261,
-    "baseDefense": 149,
     "types": [
       {
         "type": "Ghost",
@@ -6479,7 +5203,6 @@
       {
         "nameform": "Normal",
         "protoform": "1044",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -6494,7 +5217,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1045",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -6509,7 +5231,6 @@
       {
         "nameform": "Purified",
         "protoform": "1046",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -6524,7 +5245,6 @@
       {
         "nameform": "Costume 2020",
         "protoform": "2586",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -6541,9 +5261,6 @@
   "95": {
     "name": "Onix",
     "rarity": "Rare",
-    "baseStamina": 111,
-    "baseAttack": 85,
-    "baseDefense": 232,
     "types": [
       {
         "type": "Rock",
@@ -6558,10 +5275,6 @@
       {
         "nameform": "Normal",
         "protoform": "902",
-        "assetsform": "00",
-        "baseStamina": 111,
-        "baseAttack": 85,
-        "baseDefense": 232,
         "formtypes": [
           {
             "type": "Rock",
@@ -6576,10 +5289,6 @@
       {
         "nameform": "Shadow",
         "protoform": "903",
-        "assetsform": "00",
-        "baseStamina": 111,
-        "baseAttack": 85,
-        "baseDefense": 232,
         "formtypes": [
           {
             "type": "Rock",
@@ -6594,10 +5303,6 @@
       {
         "nameform": "Purified",
         "protoform": "904",
-        "assetsform": "00",
-        "baseStamina": 111,
-        "baseAttack": 85,
-        "baseDefense": 232,
         "formtypes": [
           {
             "type": "Rock",
@@ -6612,10 +5317,6 @@
       {
         "nameform": "Costume 2020",
         "protoform": "2334",
-        "assetsform": "00",
-        "baseStamina": 111,
-        "baseAttack": 85,
-        "baseDefense": 232,
         "formtypes": [
           {
             "type": "Rock",
@@ -6632,9 +5333,6 @@
   "96": {
     "name": "Drowzee",
     "rarity": "Uncommon",
-    "baseStamina": 155,
-    "baseAttack": 89,
-    "baseDefense": 136,
     "types": [
       {
         "type": "Psychic",
@@ -6645,10 +5343,6 @@
       {
         "nameform": "Normal",
         "protoform": "214",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 89,
-        "baseDefense": 136,
         "formtypes": [
           {
             "type": "Psychic",
@@ -6659,10 +5353,6 @@
       {
         "nameform": "Shadow",
         "protoform": "215",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 89,
-        "baseDefense": 136,
         "formtypes": [
           {
             "type": "Psychic",
@@ -6673,10 +5363,6 @@
       {
         "nameform": "Purified",
         "protoform": "216",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 89,
-        "baseDefense": 136,
         "formtypes": [
           {
             "type": "Psychic",
@@ -6689,9 +5375,6 @@
   "97": {
     "name": "Hypno",
     "rarity": "Rare",
-    "baseStamina": 198,
-    "baseAttack": 144,
-    "baseDefense": 193,
     "types": [
       {
         "type": "Psychic",
@@ -6702,10 +5385,6 @@
       {
         "nameform": "Normal",
         "protoform": "217",
-        "assetsform": "00",
-        "baseStamina": 198,
-        "baseAttack": 144,
-        "baseDefense": 193,
         "formtypes": [
           {
             "type": "Psychic",
@@ -6716,10 +5395,6 @@
       {
         "nameform": "Shadow",
         "protoform": "218",
-        "assetsform": "00",
-        "baseStamina": 198,
-        "baseAttack": 144,
-        "baseDefense": 193,
         "formtypes": [
           {
             "type": "Psychic",
@@ -6730,10 +5405,6 @@
       {
         "nameform": "Purified",
         "protoform": "219",
-        "assetsform": "00",
-        "baseStamina": 198,
-        "baseAttack": 144,
-        "baseDefense": 193,
         "formtypes": [
           {
             "type": "Psychic",
@@ -6746,9 +5417,6 @@
   "98": {
     "name": "Krabby",
     "rarity": "Uncommon",
-    "baseStamina": 102,
-    "baseAttack": 181,
-    "baseDefense": 124,
     "types": [
       {
         "type": "Water",
@@ -6759,10 +5427,6 @@
       {
         "nameform": "Normal",
         "protoform": "870",
-        "assetsform": "00",
-        "baseStamina": 102,
-        "baseAttack": 181,
-        "baseDefense": 124,
         "formtypes": [
           {
             "type": "Water",
@@ -6773,10 +5437,6 @@
       {
         "nameform": "Shadow",
         "protoform": "871",
-        "assetsform": "00",
-        "baseStamina": 102,
-        "baseAttack": 181,
-        "baseDefense": 124,
         "formtypes": [
           {
             "type": "Water",
@@ -6787,10 +5447,6 @@
       {
         "nameform": "Purified",
         "protoform": "872",
-        "assetsform": "00",
-        "baseStamina": 102,
-        "baseAttack": 181,
-        "baseDefense": 124,
         "formtypes": [
           {
             "type": "Water",
@@ -6803,9 +5459,6 @@
   "99": {
     "name": "Kingler",
     "rarity": "Very Rare",
-    "baseStamina": 146,
-    "baseAttack": 240,
-    "baseDefense": 181,
     "types": [
       {
         "type": "Water",
@@ -6816,10 +5469,6 @@
       {
         "nameform": "Normal",
         "protoform": "873",
-        "assetsform": "00",
-        "baseStamina": 146,
-        "baseAttack": 240,
-        "baseDefense": 181,
         "formtypes": [
           {
             "type": "Water",
@@ -6830,10 +5479,6 @@
       {
         "nameform": "Shadow",
         "protoform": "874",
-        "assetsform": "00",
-        "baseStamina": 146,
-        "baseAttack": 240,
-        "baseDefense": 181,
         "formtypes": [
           {
             "type": "Water",
@@ -6844,10 +5489,6 @@
       {
         "nameform": "Purified",
         "protoform": "875",
-        "assetsform": "00",
-        "baseStamina": 146,
-        "baseAttack": 240,
-        "baseDefense": 181,
         "formtypes": [
           {
             "type": "Water",
@@ -6860,9 +5501,6 @@
   "100": {
     "name": "Voltorb",
     "rarity": "Rare",
-    "baseStamina": 120,
-    "baseAttack": 109,
-    "baseDefense": 111,
     "types": [
       {
         "type": "Electric",
@@ -6873,7 +5511,6 @@
       {
         "nameform": "Normal",
         "protoform": "1047",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -6884,7 +5521,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1048",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -6895,7 +5531,6 @@
       {
         "nameform": "Purified",
         "protoform": "1049",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -6908,9 +5543,6 @@
   "101": {
     "name": "Electrode",
     "rarity": "Ultra Rare",
-    "baseStamina": 155,
-    "baseAttack": 173,
-    "baseDefense": 173,
     "types": [
       {
         "type": "Electric",
@@ -6921,7 +5553,6 @@
       {
         "nameform": "Normal",
         "protoform": "1050",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -6932,7 +5563,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1051",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -6943,7 +5573,6 @@
       {
         "nameform": "Purified",
         "protoform": "1052",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -6956,9 +5585,6 @@
   "102": {
     "name": "Exeggcute",
     "rarity": "Rare",
-    "baseStamina": 155,
-    "baseAttack": 107,
-    "baseDefense": 125,
     "types": [
       {
         "type": "Grass",
@@ -6973,10 +5599,6 @@
       {
         "nameform": "Normal",
         "protoform": "729",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 107,
-        "baseDefense": 125,
         "formtypes": [
           {
             "type": "Grass",
@@ -6991,10 +5613,6 @@
       {
         "nameform": "Shadow",
         "protoform": "730",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 107,
-        "baseDefense": 125,
         "formtypes": [
           {
             "type": "Grass",
@@ -7009,10 +5627,6 @@
       {
         "nameform": "Purified",
         "protoform": "731",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 107,
-        "baseDefense": 125,
         "formtypes": [
           {
             "type": "Grass",
@@ -7029,9 +5643,6 @@
   "103": {
     "name": "Exeggutor",
     "rarity": "Very Rare",
-    "baseStamina": 216,
-    "baseAttack": 233,
-    "baseDefense": 149,
     "types": [
       {
         "type": "Grass",
@@ -7046,10 +5657,6 @@
       {
         "nameform": "Normal",
         "protoform": "77",
-        "assetsform": "00",
-        "baseStamina": 216,
-        "baseAttack": 233,
-        "baseDefense": 149,
         "formtypes": [
           {
             "type": "Grass",
@@ -7064,10 +5671,6 @@
       {
         "nameform": "Alolan",
         "protoform": "78",
-        "assetsform": "61",
-        "baseStamina": 216,
-        "baseAttack": 230,
-        "baseDefense": 153,
         "formtypes": [
           {
             "type": "Grass",
@@ -7082,10 +5685,6 @@
       {
         "nameform": "Shadow",
         "protoform": "732",
-        "assetsform": "00",
-        "baseStamina": 216,
-        "baseAttack": 233,
-        "baseDefense": 149,
         "formtypes": [
           {
             "type": "Grass",
@@ -7100,10 +5699,6 @@
       {
         "nameform": "Purified",
         "protoform": "733",
-        "assetsform": "00",
-        "baseStamina": 216,
-        "baseAttack": 233,
-        "baseDefense": 149,
         "formtypes": [
           {
             "type": "Grass",
@@ -7120,9 +5715,6 @@
   "104": {
     "name": "Cubone",
     "rarity": "Rare",
-    "baseStamina": 137,
-    "baseAttack": 90,
-    "baseDefense": 144,
     "types": [
       {
         "type": "Ground",
@@ -7133,10 +5725,6 @@
       {
         "nameform": "Normal",
         "protoform": "224",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 90,
-        "baseDefense": 144,
         "formtypes": [
           {
             "type": "Ground",
@@ -7147,10 +5735,6 @@
       {
         "nameform": "Shadow",
         "protoform": "225",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 90,
-        "baseDefense": 144,
         "formtypes": [
           {
             "type": "Ground",
@@ -7161,10 +5745,6 @@
       {
         "nameform": "Purified",
         "protoform": "226",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 90,
-        "baseDefense": 144,
         "formtypes": [
           {
             "type": "Ground",
@@ -7177,9 +5757,6 @@
   "105": {
     "name": "Marowak",
     "rarity": "Very Rare",
-    "baseStamina": 155,
-    "baseAttack": 144,
-    "baseDefense": 186,
     "types": [
       {
         "type": "Ground",
@@ -7190,10 +5767,6 @@
       {
         "nameform": "Normal",
         "protoform": "79",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 144,
-        "baseDefense": 186,
         "formtypes": [
           {
             "type": "Ground",
@@ -7205,10 +5778,6 @@
       {
         "nameform": "Alolan",
         "protoform": "80",
-        "assetsform": "61",
-        "baseStamina": 155,
-        "baseAttack": 144,
-        "baseDefense": 186,
         "formtypes": [
           {
             "type": "Fire",
@@ -7223,10 +5792,6 @@
       {
         "nameform": "Shadow",
         "protoform": "227",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 144,
-        "baseDefense": 186,
         "formtypes": [
           {
             "type": "Ground",
@@ -7237,10 +5802,6 @@
       {
         "nameform": "Purified",
         "protoform": "228",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 144,
-        "baseDefense": 186,
         "formtypes": [
           {
             "type": "Ground",
@@ -7254,9 +5815,6 @@
   "106": {
     "name": "Hitmonlee",
     "rarity": "Very Rare",
-    "baseStamina": 137,
-    "baseAttack": 224,
-    "baseDefense": 181,
     "types": [
       {
         "type": "Fighting",
@@ -7267,10 +5825,6 @@
       {
         "nameform": "Normal",
         "protoform": "713",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 224,
-        "baseDefense": 181,
         "formtypes": [
           {
             "type": "Fighting",
@@ -7281,10 +5835,6 @@
       {
         "nameform": "Shadow",
         "protoform": "714",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 224,
-        "baseDefense": 181,
         "formtypes": [
           {
             "type": "Fighting",
@@ -7295,10 +5845,6 @@
       {
         "nameform": "Purified",
         "protoform": "715",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 224,
-        "baseDefense": 181,
         "formtypes": [
           {
             "type": "Fighting",
@@ -7311,9 +5857,6 @@
   "107": {
     "name": "Hitmonchan",
     "rarity": "Rare",
-    "baseStamina": 137,
-    "baseAttack": 193,
-    "baseDefense": 197,
     "types": [
       {
         "type": "Fighting",
@@ -7324,10 +5867,6 @@
       {
         "nameform": "Normal",
         "protoform": "277",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 193,
-        "baseDefense": 197,
         "formtypes": [
           {
             "type": "Fighting",
@@ -7338,10 +5877,6 @@
       {
         "nameform": "Shadow",
         "protoform": "278",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 193,
-        "baseDefense": 197,
         "formtypes": [
           {
             "type": "Fighting",
@@ -7352,10 +5887,6 @@
       {
         "nameform": "Purified",
         "protoform": "279",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 193,
-        "baseDefense": 197,
         "formtypes": [
           {
             "type": "Fighting",
@@ -7368,9 +5899,6 @@
   "108": {
     "name": "Lickitung",
     "rarity": "Rare",
-    "baseStamina": 207,
-    "baseAttack": 108,
-    "baseDefense": 137,
     "types": [
       {
         "type": "Normal",
@@ -7381,7 +5909,6 @@
       {
         "nameform": "Normal",
         "protoform": "1053",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -7392,7 +5919,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1054",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -7403,7 +5929,6 @@
       {
         "nameform": "Purified",
         "protoform": "1055",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -7416,9 +5941,6 @@
   "109": {
     "name": "Koffing",
     "rarity": "Rare",
-    "baseStamina": 120,
-    "baseAttack": 119,
-    "baseDefense": 141,
     "types": [
       {
         "type": "Poison",
@@ -7429,10 +5951,6 @@
       {
         "nameform": "Normal",
         "protoform": "703",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 119,
-        "baseDefense": 141,
         "formtypes": [
           {
             "type": "Poison",
@@ -7443,10 +5961,6 @@
       {
         "nameform": "Shadow",
         "protoform": "704",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 119,
-        "baseDefense": 141,
         "formtypes": [
           {
             "type": "Poison",
@@ -7457,10 +5971,6 @@
       {
         "nameform": "Purified",
         "protoform": "705",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 119,
-        "baseDefense": 141,
         "formtypes": [
           {
             "type": "Poison",
@@ -7473,9 +5983,6 @@
   "110": {
     "name": "Weezing",
     "rarity": "Very Rare",
-    "baseStamina": 163,
-    "baseAttack": 174,
-    "baseDefense": 197,
     "types": [
       {
         "type": "Poison",
@@ -7486,10 +5993,6 @@
       {
         "nameform": "Normal",
         "protoform": "706",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 174,
-        "baseDefense": 197,
         "formtypes": [
           {
             "type": "Poison",
@@ -7500,10 +6003,6 @@
       {
         "nameform": "Shadow",
         "protoform": "707",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 174,
-        "baseDefense": 197,
         "formtypes": [
           {
             "type": "Poison",
@@ -7514,10 +6013,6 @@
       {
         "nameform": "Purified",
         "protoform": "708",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 174,
-        "baseDefense": 197,
         "formtypes": [
           {
             "type": "Poison",
@@ -7528,10 +6023,6 @@
       {
         "nameform": "Galarian",
         "protoform": "944",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 174,
-        "baseDefense": 197,
         "formtypes": [
           {
             "type": "Poison",
@@ -7548,9 +6039,6 @@
   "111": {
     "name": "Rhyhorn",
     "rarity": "Rare",
-    "baseStamina": 190,
-    "baseAttack": 140,
-    "baseDefense": 127,
     "types": [
       {
         "type": "Ground",
@@ -7565,10 +6053,6 @@
       {
         "nameform": "Normal",
         "protoform": "846",
-        "assetsform": "00",
-        "baseStamina": 190,
-        "baseAttack": 140,
-        "baseDefense": 127,
         "formtypes": [
           {
             "type": "Ground",
@@ -7583,10 +6067,6 @@
       {
         "nameform": "Shadow",
         "protoform": "847",
-        "assetsform": "00",
-        "baseStamina": 190,
-        "baseAttack": 140,
-        "baseDefense": 127,
         "formtypes": [
           {
             "type": "Ground",
@@ -7601,10 +6081,6 @@
       {
         "nameform": "Purified",
         "protoform": "848",
-        "assetsform": "00",
-        "baseStamina": 190,
-        "baseAttack": 140,
-        "baseDefense": 127,
         "formtypes": [
           {
             "type": "Ground",
@@ -7621,9 +6097,6 @@
   "112": {
     "name": "Rhydon",
     "rarity": "Very Rare",
-    "baseStamina": 233,
-    "baseAttack": 222,
-    "baseDefense": 171,
     "types": [
       {
         "type": "Ground",
@@ -7638,10 +6111,6 @@
       {
         "nameform": "Normal",
         "protoform": "849",
-        "assetsform": "00",
-        "baseStamina": 233,
-        "baseAttack": 222,
-        "baseDefense": 171,
         "formtypes": [
           {
             "type": "Ground",
@@ -7656,10 +6125,6 @@
       {
         "nameform": "Shadow",
         "protoform": "850",
-        "assetsform": "00",
-        "baseStamina": 233,
-        "baseAttack": 222,
-        "baseDefense": 171,
         "formtypes": [
           {
             "type": "Ground",
@@ -7674,10 +6139,6 @@
       {
         "nameform": "Purified",
         "protoform": "851",
-        "assetsform": "00",
-        "baseStamina": 233,
-        "baseAttack": 222,
-        "baseDefense": 171,
         "formtypes": [
           {
             "type": "Ground",
@@ -7694,9 +6155,6 @@
   "113": {
     "name": "Chansey",
     "rarity": "Very Rare",
-    "baseStamina": 487,
-    "baseAttack": 60,
-    "baseDefense": 128,
     "types": [
       {
         "type": "Normal",
@@ -7707,7 +6165,6 @@
       {
         "nameform": "Normal",
         "protoform": "1056",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -7718,7 +6175,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1057",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -7729,7 +6185,6 @@
       {
         "nameform": "Purified",
         "protoform": "1058",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -7742,9 +6197,6 @@
   "114": {
     "name": "Tangela",
     "rarity": "Rare",
-    "baseStamina": 163,
-    "baseAttack": 183,
-    "baseDefense": 169,
     "types": [
       {
         "type": "Grass",
@@ -7755,7 +6207,6 @@
       {
         "nameform": "Normal",
         "protoform": "1059",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -7766,7 +6217,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1060",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -7777,7 +6227,6 @@
       {
         "nameform": "Purified",
         "protoform": "1061",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -7790,9 +6239,6 @@
   "115": {
     "name": "Kangaskhan",
     "rarity": "Ultra Rare",
-    "baseStamina": 233,
-    "baseAttack": 181,
-    "baseDefense": 165,
     "types": [
       {
         "type": "Normal",
@@ -7803,10 +6249,6 @@
       {
         "nameform": "Normal",
         "protoform": "839",
-        "assetsform": "00",
-        "baseStamina": 233,
-        "baseAttack": 181,
-        "baseDefense": 165,
         "formtypes": [
           {
             "type": "Normal",
@@ -7817,10 +6259,6 @@
       {
         "nameform": "Shadow",
         "protoform": "840",
-        "assetsform": "00",
-        "baseStamina": 233,
-        "baseAttack": 181,
-        "baseDefense": 165,
         "formtypes": [
           {
             "type": "Normal",
@@ -7831,10 +6269,6 @@
       {
         "nameform": "Purified",
         "protoform": "841",
-        "assetsform": "00",
-        "baseStamina": 233,
-        "baseAttack": 181,
-        "baseDefense": 165,
         "formtypes": [
           {
             "type": "Normal",
@@ -7847,9 +6281,6 @@
   "116": {
     "name": "Horsea",
     "rarity": "Rare",
-    "baseStamina": 102,
-    "baseAttack": 129,
-    "baseDefense": 103,
     "types": [
       {
         "type": "Water",
@@ -7860,7 +6291,6 @@
       {
         "nameform": "Normal",
         "protoform": "1062",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -7871,7 +6301,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1063",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -7882,7 +6311,6 @@
       {
         "nameform": "Purified",
         "protoform": "1064",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -7895,9 +6323,6 @@
   "117": {
     "name": "Seadra",
     "rarity": "Very Rare",
-    "baseStamina": 146,
-    "baseAttack": 187,
-    "baseDefense": 156,
     "types": [
       {
         "type": "Water",
@@ -7908,7 +6333,6 @@
       {
         "nameform": "Normal",
         "protoform": "1065",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -7919,7 +6343,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1066",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -7930,7 +6353,6 @@
       {
         "nameform": "Purified",
         "protoform": "1067",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -7943,9 +6365,6 @@
   "118": {
     "name": "Goldeen",
     "rarity": "Rare",
-    "baseStamina": 128,
-    "baseAttack": 123,
-    "baseDefense": 110,
     "types": [
       {
         "type": "Water",
@@ -7956,7 +6375,6 @@
       {
         "nameform": "Normal",
         "protoform": "1068",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -7967,7 +6385,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1069",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -7978,7 +6395,6 @@
       {
         "nameform": "Purified",
         "protoform": "1070",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -7991,9 +6407,6 @@
   "119": {
     "name": "Seaking",
     "rarity": "Very Rare",
-    "baseStamina": 190,
-    "baseAttack": 175,
-    "baseDefense": 147,
     "types": [
       {
         "type": "Water",
@@ -8004,7 +6417,6 @@
       {
         "nameform": "Normal",
         "protoform": "1071",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -8015,7 +6427,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1072",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -8026,7 +6437,6 @@
       {
         "nameform": "Purified",
         "protoform": "1073",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -8039,9 +6449,6 @@
   "120": {
     "name": "Staryu",
     "rarity": "Uncommon",
-    "baseStamina": 102,
-    "baseAttack": 137,
-    "baseDefense": 112,
     "types": [
       {
         "type": "Water",
@@ -8052,7 +6459,6 @@
       {
         "nameform": "Normal",
         "protoform": "1074",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -8063,7 +6469,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1075",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -8074,7 +6479,6 @@
       {
         "nameform": "Purified",
         "protoform": "1076",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -8087,9 +6491,6 @@
   "121": {
     "name": "Starmie",
     "rarity": "Very Rare",
-    "baseStamina": 155,
-    "baseAttack": 210,
-    "baseDefense": 184,
     "types": [
       {
         "type": "Water",
@@ -8104,7 +6505,6 @@
       {
         "nameform": "Normal",
         "protoform": "1077",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -8119,7 +6519,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1078",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -8134,7 +6533,6 @@
       {
         "nameform": "Purified",
         "protoform": "1079",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -8151,9 +6549,6 @@
   "122": {
     "name": "Mr. Mime",
     "rarity": "Very Rare",
-    "baseStamina": 120,
-    "baseAttack": 192,
-    "baseDefense": 205,
     "types": [
       {
         "type": "Psychic",
@@ -8168,7 +6563,6 @@
       {
         "nameform": "Normal",
         "protoform": "1080",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -8183,7 +6577,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1081",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -8198,7 +6591,6 @@
       {
         "nameform": "Purified",
         "protoform": "1082",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -8213,7 +6605,6 @@
       {
         "nameform": "Galarian",
         "protoform": "2339",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -8230,9 +6621,6 @@
   "123": {
     "name": "Scyther",
     "rarity": "Rare",
-    "baseStamina": 172,
-    "baseAttack": 218,
-    "baseDefense": 170,
     "types": [
       {
         "type": "Bug",
@@ -8247,10 +6635,6 @@
       {
         "nameform": "Normal",
         "protoform": "247",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 218,
-        "baseDefense": 170,
         "formtypes": [
           {
             "type": "Bug",
@@ -8265,10 +6649,6 @@
       {
         "nameform": "Shadow",
         "protoform": "248",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 218,
-        "baseDefense": 170,
         "formtypes": [
           {
             "type": "Bug",
@@ -8283,10 +6663,6 @@
       {
         "nameform": "Purified",
         "protoform": "249",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 218,
-        "baseDefense": 170,
         "formtypes": [
           {
             "type": "Bug",
@@ -8303,9 +6679,6 @@
   "124": {
     "name": "Jynx",
     "rarity": "Rare",
-    "baseStamina": 163,
-    "baseAttack": 223,
-    "baseDefense": 151,
     "types": [
       {
         "type": "Ice",
@@ -8320,7 +6693,6 @@
       {
         "nameform": "Normal",
         "protoform": "1083",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -8335,7 +6707,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1084",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -8350,7 +6721,6 @@
       {
         "nameform": "Purified",
         "protoform": "1085",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -8367,9 +6737,6 @@
   "125": {
     "name": "Electabuzz",
     "rarity": "Rare",
-    "baseStamina": 163,
-    "baseAttack": 198,
-    "baseDefense": 158,
     "types": [
       {
         "type": "Electric",
@@ -8380,10 +6747,6 @@
       {
         "nameform": "Normal",
         "protoform": "640",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 198,
-        "baseDefense": 158,
         "formtypes": [
           {
             "type": "Electric",
@@ -8394,10 +6757,6 @@
       {
         "nameform": "Shadow",
         "protoform": "641",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 198,
-        "baseDefense": 158,
         "formtypes": [
           {
             "type": "Electric",
@@ -8408,10 +6767,6 @@
       {
         "nameform": "Purified",
         "protoform": "642",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 198,
-        "baseDefense": 158,
         "formtypes": [
           {
             "type": "Electric",
@@ -8424,9 +6779,6 @@
   "126": {
     "name": "Magmar",
     "rarity": "Rare",
-    "baseStamina": 163,
-    "baseAttack": 206,
-    "baseDefense": 154,
     "types": [
       {
         "type": "Fire",
@@ -8437,10 +6789,6 @@
       {
         "nameform": "Normal",
         "protoform": "634",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 206,
-        "baseDefense": 154,
         "formtypes": [
           {
             "type": "Fire",
@@ -8451,10 +6799,6 @@
       {
         "nameform": "Shadow",
         "protoform": "635",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 206,
-        "baseDefense": 154,
         "formtypes": [
           {
             "type": "Fire",
@@ -8465,10 +6809,6 @@
       {
         "nameform": "Purified",
         "protoform": "636",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 206,
-        "baseDefense": 154,
         "formtypes": [
           {
             "type": "Fire",
@@ -8481,9 +6821,6 @@
   "127": {
     "name": "Pinsir",
     "rarity": "Uncommon",
-    "baseStamina": 163,
-    "baseAttack": 238,
-    "baseDefense": 182,
     "types": [
       {
         "type": "Bug",
@@ -8494,10 +6831,6 @@
       {
         "nameform": "Normal",
         "protoform": "898",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 238,
-        "baseDefense": 182,
         "formtypes": [
           {
             "type": "Bug",
@@ -8508,10 +6841,6 @@
       {
         "nameform": "Shadow",
         "protoform": "899",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 238,
-        "baseDefense": 182,
         "formtypes": [
           {
             "type": "Bug",
@@ -8522,10 +6851,6 @@
       {
         "nameform": "Purified",
         "protoform": "900",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 238,
-        "baseDefense": 182,
         "formtypes": [
           {
             "type": "Bug",
@@ -8538,9 +6863,6 @@
   "128": {
     "name": "Tauros",
     "rarity": "Rare",
-    "baseStamina": 181,
-    "baseAttack": 198,
-    "baseDefense": 183,
     "types": [
       {
         "type": "Normal",
@@ -8551,7 +6873,6 @@
       {
         "nameform": "Normal",
         "protoform": "1086",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -8562,7 +6883,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1087",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -8573,7 +6893,6 @@
       {
         "nameform": "Purified",
         "protoform": "1088",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -8586,9 +6905,6 @@
   "129": {
     "name": "Magikarp",
     "rarity": "Uncommon",
-    "baseStamina": 85,
-    "baseAttack": 29,
-    "baseDefense": 85,
     "types": [
       {
         "type": "Water",
@@ -8599,10 +6915,6 @@
       {
         "nameform": "Normal",
         "protoform": "253",
-        "assetsform": "00",
-        "baseStamina": 85,
-        "baseAttack": 29,
-        "baseDefense": 85,
         "formtypes": [
           {
             "type": "Water",
@@ -8613,10 +6925,6 @@
       {
         "nameform": "Shadow",
         "protoform": "254",
-        "assetsform": "00",
-        "baseStamina": 85,
-        "baseAttack": 29,
-        "baseDefense": 85,
         "formtypes": [
           {
             "type": "Water",
@@ -8627,10 +6935,6 @@
       {
         "nameform": "Purified",
         "protoform": "255",
-        "assetsform": "00",
-        "baseStamina": 85,
-        "baseAttack": 29,
-        "baseDefense": 85,
         "formtypes": [
           {
             "type": "Water",
@@ -8643,9 +6947,6 @@
   "130": {
     "name": "Gyarados",
     "rarity": "Ultra Rare",
-    "baseStamina": 216,
-    "baseAttack": 237,
-    "baseDefense": 186,
     "types": [
       {
         "type": "Water",
@@ -8660,10 +6961,6 @@
       {
         "nameform": "Normal",
         "protoform": "256",
-        "assetsform": "00",
-        "baseStamina": 216,
-        "baseAttack": 237,
-        "baseDefense": 186,
         "formtypes": [
           {
             "type": "Water",
@@ -8678,10 +6975,6 @@
       {
         "nameform": "Shadow",
         "protoform": "257",
-        "assetsform": "00",
-        "baseStamina": 216,
-        "baseAttack": 237,
-        "baseDefense": 186,
         "formtypes": [
           {
             "type": "Water",
@@ -8696,10 +6989,6 @@
       {
         "nameform": "Purified",
         "protoform": "258",
-        "assetsform": "00",
-        "baseStamina": 216,
-        "baseAttack": 237,
-        "baseDefense": 186,
         "formtypes": [
           {
             "type": "Water",
@@ -8716,9 +7005,6 @@
   "131": {
     "name": "Lapras",
     "rarity": "Very Rare",
-    "baseStamina": 277,
-    "baseAttack": 165,
-    "baseDefense": 174,
     "types": [
       {
         "type": "Water",
@@ -8733,10 +7019,6 @@
       {
         "nameform": "Normal",
         "protoform": "322",
-        "assetsform": "00",
-        "baseStamina": 277,
-        "baseAttack": 165,
-        "baseDefense": 174,
         "formtypes": [
           {
             "type": "Water",
@@ -8751,10 +7033,6 @@
       {
         "nameform": "Shadow",
         "protoform": "323",
-        "assetsform": "00",
-        "baseStamina": 277,
-        "baseAttack": 165,
-        "baseDefense": 174,
         "formtypes": [
           {
             "type": "Water",
@@ -8769,10 +7047,6 @@
       {
         "nameform": "Purified",
         "protoform": "324",
-        "assetsform": "00",
-        "baseStamina": 277,
-        "baseAttack": 165,
-        "baseDefense": 174,
         "formtypes": [
           {
             "type": "Water",
@@ -8787,10 +7061,6 @@
       {
         "nameform": "Costume 2020",
         "protoform": "2585",
-        "assetsform": "00",
-        "baseStamina": 277,
-        "baseAttack": 165,
-        "baseDefense": 174,
         "formtypes": [
           {
             "type": "Water",
@@ -8807,9 +7077,6 @@
   "132": {
     "name": "Ditto",
     "rarity": "Ultra Rare",
-    "baseStamina": 134,
-    "baseAttack": 91,
-    "baseDefense": 91,
     "types": [
       {
         "type": "Normal",
@@ -8820,7 +7087,6 @@
       {
         "nameform": "Normal",
         "protoform": "1089",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -8831,7 +7097,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1090",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -8842,7 +7107,6 @@
       {
         "nameform": "Purified",
         "protoform": "1091",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -8855,9 +7119,6 @@
   "133": {
     "name": "Eevee",
     "rarity": "Common",
-    "baseStamina": 146,
-    "baseAttack": 104,
-    "baseDefense": 114,
     "types": [
       {
         "type": "Normal",
@@ -8868,7 +7129,6 @@
       {
         "nameform": "Normal",
         "protoform": "1092",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -8879,7 +7139,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1093",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -8890,7 +7149,6 @@
       {
         "nameform": "Purified",
         "protoform": "1094",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -8903,9 +7161,6 @@
   "134": {
     "name": "Vaporeon",
     "rarity": "Very Rare",
-    "baseStamina": 277,
-    "baseAttack": 205,
-    "baseDefense": 161,
     "types": [
       {
         "type": "Water",
@@ -8916,7 +7171,6 @@
       {
         "nameform": "Normal",
         "protoform": "1095",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -8927,7 +7181,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1096",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -8938,7 +7191,6 @@
       {
         "nameform": "Purified",
         "protoform": "1097",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -8951,9 +7203,6 @@
   "135": {
     "name": "Jolteon",
     "rarity": "Very Rare",
-    "baseStamina": 163,
-    "baseAttack": 232,
-    "baseDefense": 182,
     "types": [
       {
         "type": "Electric",
@@ -8964,7 +7213,6 @@
       {
         "nameform": "Normal",
         "protoform": "1098",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -8975,7 +7223,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1099",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -8986,7 +7233,6 @@
       {
         "nameform": "Purified",
         "protoform": "1100",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -8999,9 +7245,6 @@
   "136": {
     "name": "Flareon",
     "rarity": "Ultra Rare",
-    "baseStamina": 163,
-    "baseAttack": 246,
-    "baseDefense": 179,
     "types": [
       {
         "type": "Fire",
@@ -9012,7 +7255,6 @@
       {
         "nameform": "Normal",
         "protoform": "1101",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -9023,7 +7265,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1102",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -9034,7 +7275,6 @@
       {
         "nameform": "Purified",
         "protoform": "1103",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -9047,9 +7287,6 @@
   "137": {
     "name": "Porygon",
     "rarity": "Very Rare",
-    "baseStamina": 163,
-    "baseAttack": 153,
-    "baseDefense": 136,
     "types": [
       {
         "type": "Normal",
@@ -9060,10 +7297,6 @@
       {
         "nameform": "Normal",
         "protoform": "677",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 153,
-        "baseDefense": 136,
         "formtypes": [
           {
             "type": "Normal",
@@ -9074,10 +7307,6 @@
       {
         "nameform": "Shadow",
         "protoform": "678",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 153,
-        "baseDefense": 136,
         "formtypes": [
           {
             "type": "Normal",
@@ -9088,10 +7317,6 @@
       {
         "nameform": "Purified",
         "protoform": "679",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 153,
-        "baseDefense": 136,
         "formtypes": [
           {
             "type": "Normal",
@@ -9104,9 +7329,6 @@
   "138": {
     "name": "Omanyte",
     "rarity": "Rare",
-    "baseStamina": 111,
-    "baseAttack": 155,
-    "baseDefense": 153,
     "types": [
       {
         "type": "Rock",
@@ -9121,10 +7343,6 @@
       {
         "nameform": "Normal",
         "protoform": "740",
-        "assetsform": "00",
-        "baseStamina": 111,
-        "baseAttack": 155,
-        "baseDefense": 153,
         "formtypes": [
           {
             "type": "Rock",
@@ -9139,10 +7357,6 @@
       {
         "nameform": "Shadow",
         "protoform": "741",
-        "assetsform": "00",
-        "baseStamina": 111,
-        "baseAttack": 155,
-        "baseDefense": 153,
         "formtypes": [
           {
             "type": "Rock",
@@ -9157,10 +7371,6 @@
       {
         "nameform": "Purified",
         "protoform": "742",
-        "assetsform": "00",
-        "baseStamina": 111,
-        "baseAttack": 155,
-        "baseDefense": 153,
         "formtypes": [
           {
             "type": "Rock",
@@ -9177,9 +7387,6 @@
   "139": {
     "name": "Omastar",
     "rarity": "Ultra Rare",
-    "baseStamina": 172,
-    "baseAttack": 207,
-    "baseDefense": 201,
     "types": [
       {
         "type": "Rock",
@@ -9194,10 +7401,6 @@
       {
         "nameform": "Normal",
         "protoform": "743",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 207,
-        "baseDefense": 201,
         "formtypes": [
           {
             "type": "Rock",
@@ -9212,10 +7415,6 @@
       {
         "nameform": "Shadow",
         "protoform": "744",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 207,
-        "baseDefense": 201,
         "formtypes": [
           {
             "type": "Rock",
@@ -9230,10 +7429,6 @@
       {
         "nameform": "Purified",
         "protoform": "745",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 207,
-        "baseDefense": 201,
         "formtypes": [
           {
             "type": "Rock",
@@ -9250,9 +7445,6 @@
   "140": {
     "name": "Kabuto",
     "rarity": "Rare",
-    "baseStamina": 102,
-    "baseAttack": 148,
-    "baseDefense": 140,
     "types": [
       {
         "type": "Rock",
@@ -9267,7 +7459,6 @@
       {
         "nameform": "Normal",
         "protoform": "1104",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -9282,7 +7473,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1105",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -9297,7 +7487,6 @@
       {
         "nameform": "Purified",
         "protoform": "1106",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -9314,9 +7503,6 @@
   "141": {
     "name": "Kabutops",
     "rarity": "Ultra Rare",
-    "baseStamina": 155,
-    "baseAttack": 220,
-    "baseDefense": 186,
     "types": [
       {
         "type": "Rock",
@@ -9331,7 +7517,6 @@
       {
         "nameform": "Normal",
         "protoform": "1107",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -9346,7 +7531,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1108",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -9361,7 +7545,6 @@
       {
         "nameform": "Purified",
         "protoform": "1109",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -9378,9 +7561,6 @@
   "142": {
     "name": "Aerodactyl",
     "rarity": "Very Rare",
-    "baseStamina": 190,
-    "baseAttack": 221,
-    "baseDefense": 159,
     "types": [
       {
         "type": "Rock",
@@ -9395,7 +7575,6 @@
       {
         "nameform": "Normal",
         "protoform": "1110",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -9410,7 +7589,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1111",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -9425,7 +7603,6 @@
       {
         "nameform": "Purified",
         "protoform": "1112",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -9442,9 +7619,6 @@
   "143": {
     "name": "Snorlax",
     "rarity": "Very Rare",
-    "baseStamina": 330,
-    "baseAttack": 190,
-    "baseDefense": 169,
     "types": [
       {
         "type": "Normal",
@@ -9455,10 +7629,6 @@
       {
         "nameform": "Normal",
         "protoform": "199",
-        "assetsform": "00",
-        "baseStamina": 330,
-        "baseAttack": 190,
-        "baseDefense": 169,
         "formtypes": [
           {
             "type": "Normal",
@@ -9469,10 +7639,6 @@
       {
         "nameform": "Shadow",
         "protoform": "200",
-        "assetsform": "00",
-        "baseStamina": 330,
-        "baseAttack": 190,
-        "baseDefense": 169,
         "formtypes": [
           {
             "type": "Normal",
@@ -9483,10 +7649,6 @@
       {
         "nameform": "Purified",
         "protoform": "201",
-        "assetsform": "00",
-        "baseStamina": 330,
-        "baseAttack": 190,
-        "baseDefense": 169,
         "formtypes": [
           {
             "type": "Normal",
@@ -9499,9 +7661,6 @@
   "144": {
     "name": "Articuno",
     "rarity": "Ultra Rare",
-    "baseStamina": 207,
-    "baseAttack": 192,
-    "baseDefense": 236,
     "types": [
       {
         "type": "Ice",
@@ -9516,10 +7675,6 @@
       {
         "nameform": "Normal",
         "protoform": "716",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 192,
-        "baseDefense": 236,
         "formtypes": [
           {
             "type": "Ice",
@@ -9534,10 +7689,6 @@
       {
         "nameform": "Shadow",
         "protoform": "717",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 192,
-        "baseDefense": 236,
         "formtypes": [
           {
             "type": "Ice",
@@ -9552,10 +7703,6 @@
       {
         "nameform": "Purified",
         "protoform": "718",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 192,
-        "baseDefense": 236,
         "formtypes": [
           {
             "type": "Ice",
@@ -9572,9 +7719,6 @@
   "145": {
     "name": "Zapdos",
     "rarity": "Ultra Rare",
-    "baseStamina": 207,
-    "baseAttack": 253,
-    "baseDefense": 185,
     "types": [
       {
         "type": "Electric",
@@ -9589,10 +7733,6 @@
       {
         "nameform": "Normal",
         "protoform": "773",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 253,
-        "baseDefense": 185,
         "formtypes": [
           {
             "type": "Electric",
@@ -9607,10 +7747,6 @@
       {
         "nameform": "Shadow",
         "protoform": "774",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 253,
-        "baseDefense": 185,
         "formtypes": [
           {
             "type": "Electric",
@@ -9625,10 +7761,6 @@
       {
         "nameform": "Purified",
         "protoform": "775",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 253,
-        "baseDefense": 185,
         "formtypes": [
           {
             "type": "Electric",
@@ -9645,9 +7777,6 @@
   "146": {
     "name": "Moltres",
     "rarity": "Ultra Rare",
-    "baseStamina": 207,
-    "baseAttack": 251,
-    "baseDefense": 181,
     "types": [
       {
         "type": "Fire",
@@ -9662,10 +7791,6 @@
       {
         "nameform": "Normal",
         "protoform": "836",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 251,
-        "baseDefense": 181,
         "formtypes": [
           {
             "type": "Fire",
@@ -9680,10 +7805,6 @@
       {
         "nameform": "Shadow",
         "protoform": "837",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 251,
-        "baseDefense": 181,
         "formtypes": [
           {
             "type": "Fire",
@@ -9698,10 +7819,6 @@
       {
         "nameform": "Purified",
         "protoform": "838",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 251,
-        "baseDefense": 181,
         "formtypes": [
           {
             "type": "Fire",
@@ -9718,9 +7835,6 @@
   "147": {
     "name": "Dratini",
     "rarity": "Uncommon",
-    "baseStamina": 121,
-    "baseAttack": 119,
-    "baseDefense": 91,
     "types": [
       {
         "type": "Dragon",
@@ -9731,10 +7845,6 @@
       {
         "nameform": "Normal",
         "protoform": "190",
-        "assetsform": "00",
-        "baseStamina": 121,
-        "baseAttack": 119,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Dragon",
@@ -9745,10 +7855,6 @@
       {
         "nameform": "Shadow",
         "protoform": "191",
-        "assetsform": "00",
-        "baseStamina": 121,
-        "baseAttack": 119,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Dragon",
@@ -9759,10 +7865,6 @@
       {
         "nameform": "Purified",
         "protoform": "192",
-        "assetsform": "00",
-        "baseStamina": 121,
-        "baseAttack": 119,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Dragon",
@@ -9775,9 +7877,6 @@
   "148": {
     "name": "Dragonair",
     "rarity": "Very Rare",
-    "baseStamina": 156,
-    "baseAttack": 163,
-    "baseDefense": 135,
     "types": [
       {
         "type": "Dragon",
@@ -9788,10 +7887,6 @@
       {
         "nameform": "Normal",
         "protoform": "193",
-        "assetsform": "00",
-        "baseStamina": 156,
-        "baseAttack": 163,
-        "baseDefense": 135,
         "formtypes": [
           {
             "type": "Dragon",
@@ -9802,10 +7897,6 @@
       {
         "nameform": "Shadow",
         "protoform": "194",
-        "assetsform": "00",
-        "baseStamina": 156,
-        "baseAttack": 163,
-        "baseDefense": 135,
         "formtypes": [
           {
             "type": "Dragon",
@@ -9816,10 +7907,6 @@
       {
         "nameform": "Purified",
         "protoform": "195",
-        "assetsform": "00",
-        "baseStamina": 156,
-        "baseAttack": 163,
-        "baseDefense": 135,
         "formtypes": [
           {
             "type": "Dragon",
@@ -9832,9 +7919,6 @@
   "149": {
     "name": "Dragonite",
     "rarity": "Very Rare",
-    "baseStamina": 209,
-    "baseAttack": 263,
-    "baseDefense": 198,
     "types": [
       {
         "type": "Dragon",
@@ -9849,10 +7933,6 @@
       {
         "nameform": "Normal",
         "protoform": "196",
-        "assetsform": "00",
-        "baseStamina": 209,
-        "baseAttack": 263,
-        "baseDefense": 198,
         "formtypes": [
           {
             "type": "Dragon",
@@ -9867,10 +7947,6 @@
       {
         "nameform": "Shadow",
         "protoform": "197",
-        "assetsform": "00",
-        "baseStamina": 209,
-        "baseAttack": 263,
-        "baseDefense": 198,
         "formtypes": [
           {
             "type": "Dragon",
@@ -9885,10 +7961,6 @@
       {
         "nameform": "Purified",
         "protoform": "198",
-        "assetsform": "00",
-        "baseStamina": 209,
-        "baseAttack": 263,
-        "baseDefense": 198,
         "formtypes": [
           {
             "type": "Dragon",
@@ -9903,10 +7975,6 @@
       {
         "nameform": "Costume 2020",
         "protoform": "2333",
-        "assetsform": "00",
-        "baseStamina": 209,
-        "baseAttack": 263,
-        "baseDefense": 198,
         "formtypes": [
           {
             "type": "Dragon",
@@ -9923,9 +7991,6 @@
   "150": {
     "name": "Mewtwo",
     "rarity": "Ultra Rare",
-    "baseStamina": 214,
-    "baseAttack": 300,
-    "baseDefense": 182,
     "types": [
       {
         "type": "Psychic",
@@ -9936,10 +8001,6 @@
       {
         "nameform": "Normal",
         "protoform": "135",
-        "assetsform": "00",
-        "baseStamina": 214,
-        "baseAttack": 300,
-        "baseDefense": 182,
         "formtypes": [
           {
             "type": "Psychic",
@@ -9950,10 +8011,6 @@
       {
         "nameform": "Armored",
         "protoform": "133",
-        "assetsform": "00",
-        "baseStamina": 214,
-        "baseAttack": 182,
-        "baseDefense": 278,
         "formtypes": [
           {
             "type": "Psychic",
@@ -9964,7 +8021,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1113",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -9975,7 +8031,6 @@
       {
         "nameform": "Purified",
         "protoform": "1114",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -9988,9 +8043,6 @@
   "151": {
     "name": "Mew",
     "rarity": "Ultra Rare",
-    "baseStamina": 225,
-    "baseAttack": 210,
-    "baseDefense": 210,
     "types": [
       {
         "type": "Psychic",
@@ -10001,7 +8053,6 @@
       {
         "nameform": "Normal",
         "protoform": "1115",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -10012,7 +8063,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1116",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -10023,7 +8073,6 @@
       {
         "nameform": "Purified",
         "protoform": "1117",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -10036,9 +8085,6 @@
   "152": {
     "name": "Chikorita",
     "rarity": "Uncommon",
-    "baseStamina": 128,
-    "baseAttack": 92,
-    "baseDefense": 122,
     "types": [
       {
         "type": "Grass",
@@ -10049,7 +8095,6 @@
       {
         "nameform": "Normal",
         "protoform": "1118",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -10060,7 +8105,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1119",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -10071,7 +8115,6 @@
       {
         "nameform": "Purified",
         "protoform": "1120",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -10084,9 +8127,6 @@
   "153": {
     "name": "Bayleef",
     "rarity": "Rare",
-    "baseStamina": 155,
-    "baseAttack": 122,
-    "baseDefense": 155,
     "types": [
       {
         "type": "Grass",
@@ -10097,7 +8137,6 @@
       {
         "nameform": "Normal",
         "protoform": "1121",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -10108,7 +8147,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1122",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -10119,7 +8157,6 @@
       {
         "nameform": "Purified",
         "protoform": "1123",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -10132,9 +8169,6 @@
   "154": {
     "name": "Meganium",
     "rarity": "Very Rare",
-    "baseStamina": 190,
-    "baseAttack": 168,
-    "baseDefense": 202,
     "types": [
       {
         "type": "Grass",
@@ -10145,7 +8179,6 @@
       {
         "nameform": "Normal",
         "protoform": "1124",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -10156,7 +8189,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1125",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -10167,7 +8199,6 @@
       {
         "nameform": "Purified",
         "protoform": "1126",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -10180,9 +8211,6 @@
   "155": {
     "name": "Cyndaquil",
     "rarity": "Uncommon",
-    "baseStamina": 118,
-    "baseAttack": 116,
-    "baseDefense": 93,
     "types": [
       {
         "type": "Fire",
@@ -10193,7 +8221,6 @@
       {
         "nameform": "Normal",
         "protoform": "1127",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -10204,7 +8231,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1128",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -10215,7 +8241,6 @@
       {
         "nameform": "Purified",
         "protoform": "1129",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -10228,9 +8253,6 @@
   "156": {
     "name": "Quilava",
     "rarity": "Very Rare",
-    "baseStamina": 151,
-    "baseAttack": 158,
-    "baseDefense": 126,
     "types": [
       {
         "type": "Fire",
@@ -10241,7 +8263,6 @@
       {
         "nameform": "Normal",
         "protoform": "1130",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -10252,7 +8273,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1131",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -10263,7 +8283,6 @@
       {
         "nameform": "Purified",
         "protoform": "1132",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -10276,9 +8295,6 @@
   "157": {
     "name": "Typhlosion",
     "rarity": "Ultra Rare",
-    "baseStamina": 186,
-    "baseAttack": 223,
-    "baseDefense": 173,
     "types": [
       {
         "type": "Fire",
@@ -10289,7 +8305,6 @@
       {
         "nameform": "Normal",
         "protoform": "1133",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -10300,7 +8315,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1134",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -10311,7 +8325,6 @@
       {
         "nameform": "Purified",
         "protoform": "1135",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -10324,9 +8337,6 @@
   "158": {
     "name": "Totodile",
     "rarity": "Uncommon",
-    "baseStamina": 137,
-    "baseAttack": 117,
-    "baseDefense": 109,
     "types": [
       {
         "type": "Water",
@@ -10337,7 +8347,6 @@
       {
         "nameform": "Normal",
         "protoform": "1136",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -10348,7 +8357,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1137",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -10359,7 +8367,6 @@
       {
         "nameform": "Purified",
         "protoform": "1138",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -10372,9 +8379,6 @@
   "159": {
     "name": "Croconaw",
     "rarity": "Rare",
-    "baseStamina": 163,
-    "baseAttack": 150,
-    "baseDefense": 142,
     "types": [
       {
         "type": "Water",
@@ -10385,7 +8389,6 @@
       {
         "nameform": "Normal",
         "protoform": "1139",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -10396,7 +8399,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1140",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -10407,7 +8409,6 @@
       {
         "nameform": "Purified",
         "protoform": "1141",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -10420,9 +8421,6 @@
   "160": {
     "name": "Feraligatr",
     "rarity": "Very Rare",
-    "baseStamina": 198,
-    "baseAttack": 205,
-    "baseDefense": 188,
     "types": [
       {
         "type": "Water",
@@ -10433,7 +8431,6 @@
       {
         "nameform": "Normal",
         "protoform": "1142",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -10444,7 +8441,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1143",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -10455,7 +8451,6 @@
       {
         "nameform": "Purified",
         "protoform": "1144",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -10468,9 +8463,6 @@
   "161": {
     "name": "Sentret",
     "rarity": "Common",
-    "baseStamina": 111,
-    "baseAttack": 79,
-    "baseDefense": 73,
     "types": [
       {
         "type": "Normal",
@@ -10481,7 +8473,6 @@
       {
         "nameform": "Normal",
         "protoform": "1145",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -10492,7 +8483,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1146",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -10503,7 +8493,6 @@
       {
         "nameform": "Purified",
         "protoform": "1147",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -10516,9 +8505,6 @@
   "162": {
     "name": "Furret",
     "rarity": "Uncommon",
-    "baseStamina": 198,
-    "baseAttack": 148,
-    "baseDefense": 125,
     "types": [
       {
         "type": "Normal",
@@ -10529,7 +8515,6 @@
       {
         "nameform": "Normal",
         "protoform": "1148",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -10540,7 +8525,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1149",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -10551,7 +8535,6 @@
       {
         "nameform": "Purified",
         "protoform": "1150",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -10564,9 +8547,6 @@
   "163": {
     "name": "Hoothoot",
     "rarity": "Common",
-    "baseStamina": 155,
-    "baseAttack": 67,
-    "baseDefense": 88,
     "types": [
       {
         "type": "Normal",
@@ -10581,7 +8561,6 @@
       {
         "nameform": "Normal",
         "protoform": "1151",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -10596,7 +8575,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1152",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -10611,7 +8589,6 @@
       {
         "nameform": "Purified",
         "protoform": "1153",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -10628,9 +8605,6 @@
   "164": {
     "name": "Noctowl",
     "rarity": "Rare",
-    "baseStamina": 225,
-    "baseAttack": 145,
-    "baseDefense": 156,
     "types": [
       {
         "type": "Normal",
@@ -10645,7 +8619,6 @@
       {
         "nameform": "Normal",
         "protoform": "1154",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -10660,7 +8633,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1155",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -10675,7 +8647,6 @@
       {
         "nameform": "Purified",
         "protoform": "1156",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -10692,9 +8663,6 @@
   "165": {
     "name": "Ledyba",
     "rarity": "Common",
-    "baseStamina": 120,
-    "baseAttack": 72,
-    "baseDefense": 118,
     "types": [
       {
         "type": "Bug",
@@ -10709,7 +8677,6 @@
       {
         "nameform": "Normal",
         "protoform": "1157",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -10724,7 +8691,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1158",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -10739,7 +8705,6 @@
       {
         "nameform": "Purified",
         "protoform": "1159",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -10756,9 +8721,6 @@
   "166": {
     "name": "Ledian",
     "rarity": "Uncommon",
-    "baseStamina": 146,
-    "baseAttack": 107,
-    "baseDefense": 179,
     "types": [
       {
         "type": "Bug",
@@ -10773,7 +8735,6 @@
       {
         "nameform": "Normal",
         "protoform": "1160",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -10788,7 +8749,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1161",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -10803,7 +8763,6 @@
       {
         "nameform": "Purified",
         "protoform": "1162",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -10820,9 +8779,6 @@
   "167": {
     "name": "Spinarak",
     "rarity": "Common",
-    "baseStamina": 120,
-    "baseAttack": 105,
-    "baseDefense": 73,
     "types": [
       {
         "type": "Bug",
@@ -10837,7 +8793,6 @@
       {
         "nameform": "Normal",
         "protoform": "1163",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -10852,7 +8807,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1164",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -10867,7 +8821,6 @@
       {
         "nameform": "Purified",
         "protoform": "1165",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -10884,9 +8837,6 @@
   "168": {
     "name": "Ariados",
     "rarity": "Uncommon",
-    "baseStamina": 172,
-    "baseAttack": 161,
-    "baseDefense": 124,
     "types": [
       {
         "type": "Bug",
@@ -10901,7 +8851,6 @@
       {
         "nameform": "Normal",
         "protoform": "1166",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -10916,7 +8865,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1167",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -10931,7 +8879,6 @@
       {
         "nameform": "Purified",
         "protoform": "1168",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -10948,9 +8895,6 @@
   "169": {
     "name": "Crobat",
     "rarity": "Rare",
-    "baseStamina": 198,
-    "baseAttack": 194,
-    "baseDefense": 178,
     "types": [
       {
         "type": "Poison",
@@ -10965,10 +8909,6 @@
       {
         "nameform": "Normal",
         "protoform": "202",
-        "assetsform": "00",
-        "baseStamina": 198,
-        "baseAttack": 194,
-        "baseDefense": 178,
         "formtypes": [
           {
             "type": "Poison",
@@ -10983,10 +8923,6 @@
       {
         "nameform": "Shadow",
         "protoform": "203",
-        "assetsform": "00",
-        "baseStamina": 198,
-        "baseAttack": 194,
-        "baseDefense": 178,
         "formtypes": [
           {
             "type": "Poison",
@@ -11001,10 +8937,6 @@
       {
         "nameform": "Purified",
         "protoform": "204",
-        "assetsform": "00",
-        "baseStamina": 198,
-        "baseAttack": 194,
-        "baseDefense": 178,
         "formtypes": [
           {
             "type": "Poison",
@@ -11021,9 +8953,6 @@
   "170": {
     "name": "Chinchou",
     "rarity": "Uncommon",
-    "baseStamina": 181,
-    "baseAttack": 106,
-    "baseDefense": 97,
     "types": [
       {
         "type": "Water",
@@ -11038,7 +8967,6 @@
       {
         "nameform": "Normal",
         "protoform": "1169",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -11053,7 +8981,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1170",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -11068,7 +8995,6 @@
       {
         "nameform": "Purified",
         "protoform": "1171",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -11085,9 +9011,6 @@
   "171": {
     "name": "Lanturn",
     "rarity": "Rare",
-    "baseStamina": 268,
-    "baseAttack": 146,
-    "baseDefense": 137,
     "types": [
       {
         "type": "Water",
@@ -11102,7 +9025,6 @@
       {
         "nameform": "Normal",
         "protoform": "1172",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -11117,7 +9039,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1173",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -11132,7 +9053,6 @@
       {
         "nameform": "Purified",
         "protoform": "1174",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -11149,9 +9069,6 @@
   "172": {
     "name": "Pichu",
     "rarity": "Very Rare",
-    "baseStamina": 85,
-    "baseAttack": 77,
-    "baseDefense": 53,
     "types": [
       {
         "type": "Electric",
@@ -11162,7 +9079,6 @@
       {
         "nameform": "Normal",
         "protoform": "1175",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -11173,7 +9089,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1176",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -11184,7 +9099,6 @@
       {
         "nameform": "Purified",
         "protoform": "1177",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -11197,9 +9111,6 @@
   "173": {
     "name": "Cleffa",
     "rarity": "Very Rare",
-    "baseStamina": 137,
-    "baseAttack": 75,
-    "baseDefense": 79,
     "types": [
       {
         "type": "Fairy",
@@ -11210,7 +9121,6 @@
       {
         "nameform": "Normal",
         "protoform": "1178",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fairy",
@@ -11221,7 +9131,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1179",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fairy",
@@ -11232,7 +9141,6 @@
       {
         "nameform": "Purified",
         "protoform": "1180",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fairy",
@@ -11245,9 +9153,6 @@
   "174": {
     "name": "Igglybuff",
     "rarity": "Very Rare",
-    "baseStamina": 207,
-    "baseAttack": 69,
-    "baseDefense": 32,
     "types": [
       {
         "type": "Normal",
@@ -11262,7 +9167,6 @@
       {
         "nameform": "Normal",
         "protoform": "1181",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -11277,7 +9181,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1182",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -11292,7 +9195,6 @@
       {
         "nameform": "Purified",
         "protoform": "1183",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -11309,9 +9211,6 @@
   "175": {
     "name": "Togepi",
     "rarity": "Very Rare",
-    "baseStamina": 111,
-    "baseAttack": 67,
-    "baseDefense": 116,
     "types": [
       {
         "type": "Fairy",
@@ -11322,7 +9221,6 @@
       {
         "nameform": "Normal",
         "protoform": "1184",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fairy",
@@ -11333,7 +9231,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1185",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fairy",
@@ -11344,7 +9241,6 @@
       {
         "nameform": "Purified",
         "protoform": "1186",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fairy",
@@ -11357,9 +9253,6 @@
   "176": {
     "name": "Togetic",
     "rarity": "Ultra Rare",
-    "baseStamina": 146,
-    "baseAttack": 139,
-    "baseDefense": 181,
     "types": [
       {
         "type": "Fairy",
@@ -11374,7 +9267,6 @@
       {
         "nameform": "Normal",
         "protoform": "1187",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fairy",
@@ -11389,7 +9281,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1188",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fairy",
@@ -11404,7 +9295,6 @@
       {
         "nameform": "Purified",
         "protoform": "1189",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fairy",
@@ -11421,9 +9311,6 @@
   "177": {
     "name": "Natu",
     "rarity": "Common",
-    "baseStamina": 120,
-    "baseAttack": 134,
-    "baseDefense": 89,
     "types": [
       {
         "type": "Psychic",
@@ -11438,7 +9325,6 @@
       {
         "nameform": "Normal",
         "protoform": "1190",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -11453,7 +9339,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1191",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -11468,7 +9353,6 @@
       {
         "nameform": "Purified",
         "protoform": "1192",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -11485,9 +9369,6 @@
   "178": {
     "name": "Xatu",
     "rarity": "Uncommon",
-    "baseStamina": 163,
-    "baseAttack": 192,
-    "baseDefense": 146,
     "types": [
       {
         "type": "Psychic",
@@ -11502,7 +9383,6 @@
       {
         "nameform": "Normal",
         "protoform": "1193",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -11517,7 +9397,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1194",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -11532,7 +9411,6 @@
       {
         "nameform": "Purified",
         "protoform": "1195",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -11549,9 +9427,6 @@
   "179": {
     "name": "Mareep",
     "rarity": "Very Rare",
-    "baseStamina": 146,
-    "baseAttack": 114,
-    "baseDefense": 79,
     "types": [
       {
         "type": "Electric",
@@ -11562,10 +9437,6 @@
       {
         "nameform": "Normal",
         "protoform": "646",
-        "assetsform": "00",
-        "baseStamina": 146,
-        "baseAttack": 114,
-        "baseDefense": 79,
         "formtypes": [
           {
             "type": "Electric",
@@ -11576,10 +9447,6 @@
       {
         "nameform": "Shadow",
         "protoform": "647",
-        "assetsform": "00",
-        "baseStamina": 146,
-        "baseAttack": 114,
-        "baseDefense": 79,
         "formtypes": [
           {
             "type": "Electric",
@@ -11590,10 +9457,6 @@
       {
         "nameform": "Purified",
         "protoform": "648",
-        "assetsform": "00",
-        "baseStamina": 146,
-        "baseAttack": 114,
-        "baseDefense": 79,
         "formtypes": [
           {
             "type": "Electric",
@@ -11606,9 +9469,6 @@
   "180": {
     "name": "Flaaffy",
     "rarity": "Ultra Rare",
-    "baseStamina": 172,
-    "baseAttack": 145,
-    "baseDefense": 109,
     "types": [
       {
         "type": "Electric",
@@ -11619,10 +9479,6 @@
       {
         "nameform": "Normal",
         "protoform": "649",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 145,
-        "baseDefense": 109,
         "formtypes": [
           {
             "type": "Electric",
@@ -11633,10 +9489,6 @@
       {
         "nameform": "Shadow",
         "protoform": "650",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 145,
-        "baseDefense": 109,
         "formtypes": [
           {
             "type": "Electric",
@@ -11647,10 +9499,6 @@
       {
         "nameform": "Purified",
         "protoform": "651",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 145,
-        "baseDefense": 109,
         "formtypes": [
           {
             "type": "Electric",
@@ -11663,9 +9511,6 @@
   "181": {
     "name": "Ampharos",
     "rarity": "Ultra Rare",
-    "baseStamina": 207,
-    "baseAttack": 211,
-    "baseDefense": 169,
     "types": [
       {
         "type": "Electric",
@@ -11676,10 +9521,6 @@
       {
         "nameform": "Normal",
         "protoform": "652",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 211,
-        "baseDefense": 169,
         "formtypes": [
           {
             "type": "Electric",
@@ -11690,10 +9531,6 @@
       {
         "nameform": "Shadow",
         "protoform": "653",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 211,
-        "baseDefense": 169,
         "formtypes": [
           {
             "type": "Electric",
@@ -11704,10 +9541,6 @@
       {
         "nameform": "Purified",
         "protoform": "654",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 211,
-        "baseDefense": 169,
         "formtypes": [
           {
             "type": "Electric",
@@ -11720,9 +9553,6 @@
   "182": {
     "name": "Bellossom",
     "rarity": "Ultra Rare",
-    "baseStamina": 181,
-    "baseAttack": 169,
-    "baseDefense": 186,
     "types": [
       {
         "type": "Grass",
@@ -11733,10 +9563,6 @@
       {
         "nameform": "Normal",
         "protoform": "274",
-        "assetsform": "00",
-        "baseStamina": 181,
-        "baseAttack": 169,
-        "baseDefense": 186,
         "formtypes": [
           {
             "type": "Grass",
@@ -11747,10 +9573,6 @@
       {
         "nameform": "Shadow",
         "protoform": "275",
-        "assetsform": "00",
-        "baseStamina": 181,
-        "baseAttack": 169,
-        "baseDefense": 186,
         "formtypes": [
           {
             "type": "Grass",
@@ -11761,10 +9583,6 @@
       {
         "nameform": "Purified",
         "protoform": "276",
-        "assetsform": "00",
-        "baseStamina": 181,
-        "baseAttack": 169,
-        "baseDefense": 186,
         "formtypes": [
           {
             "type": "Grass",
@@ -11777,9 +9595,6 @@
   "183": {
     "name": "Marill",
     "rarity": "Common",
-    "baseStamina": 172,
-    "baseAttack": 37,
-    "baseDefense": 93,
     "types": [
       {
         "type": "Water",
@@ -11794,7 +9609,6 @@
       {
         "nameform": "Normal",
         "protoform": "1196",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -11809,7 +9623,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1197",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -11824,7 +9637,6 @@
       {
         "nameform": "Purified",
         "protoform": "1198",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -11841,9 +9653,6 @@
   "184": {
     "name": "Azumarill",
     "rarity": "Rare",
-    "baseStamina": 225,
-    "baseAttack": 112,
-    "baseDefense": 152,
     "types": [
       {
         "type": "Water",
@@ -11858,7 +9667,6 @@
       {
         "nameform": "Normal",
         "protoform": "1199",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -11873,7 +9681,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1200",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -11888,7 +9695,6 @@
       {
         "nameform": "Purified",
         "protoform": "1201",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -11905,9 +9711,6 @@
   "185": {
     "name": "Sudowoodo",
     "rarity": "Uncommon",
-    "baseStamina": 172,
-    "baseAttack": 167,
-    "baseDefense": 176,
     "types": [
       {
         "type": "Rock",
@@ -11918,7 +9721,6 @@
       {
         "nameform": "Normal",
         "protoform": "1202",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -11929,7 +9731,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1203",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -11940,7 +9741,6 @@
       {
         "nameform": "Purified",
         "protoform": "1204",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -11953,9 +9753,6 @@
   "186": {
     "name": "Politoed",
     "rarity": "Ultra Rare",
-    "baseStamina": 207,
-    "baseAttack": 174,
-    "baseDefense": 179,
     "types": [
       {
         "type": "Water",
@@ -11966,10 +9763,6 @@
       {
         "nameform": "Normal",
         "protoform": "244",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 174,
-        "baseDefense": 179,
         "formtypes": [
           {
             "type": "Water",
@@ -11980,10 +9773,6 @@
       {
         "nameform": "Shadow",
         "protoform": "245",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 174,
-        "baseDefense": 179,
         "formtypes": [
           {
             "type": "Water",
@@ -11994,10 +9783,6 @@
       {
         "nameform": "Purified",
         "protoform": "246",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 174,
-        "baseDefense": 179,
         "formtypes": [
           {
             "type": "Water",
@@ -12010,9 +9795,6 @@
   "187": {
     "name": "Hoppip",
     "rarity": "Common",
-    "baseStamina": 111,
-    "baseAttack": 67,
-    "baseDefense": 94,
     "types": [
       {
         "type": "Grass",
@@ -12027,7 +9809,6 @@
       {
         "nameform": "Normal",
         "protoform": "1205",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -12042,7 +9823,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1206",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -12057,7 +9837,6 @@
       {
         "nameform": "Purified",
         "protoform": "1207",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -12074,9 +9853,6 @@
   "188": {
     "name": "Skiploom",
     "rarity": "Uncommon",
-    "baseStamina": 146,
-    "baseAttack": 91,
-    "baseDefense": 120,
     "types": [
       {
         "type": "Grass",
@@ -12091,7 +9867,6 @@
       {
         "nameform": "Normal",
         "protoform": "1208",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -12106,7 +9881,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1209",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -12121,7 +9895,6 @@
       {
         "nameform": "Purified",
         "protoform": "1210",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -12138,9 +9911,6 @@
   "189": {
     "name": "Jumpluff",
     "rarity": "Very Rare",
-    "baseStamina": 181,
-    "baseAttack": 118,
-    "baseDefense": 183,
     "types": [
       {
         "type": "Grass",
@@ -12155,7 +9925,6 @@
       {
         "nameform": "Normal",
         "protoform": "1211",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -12170,7 +9939,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1212",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -12185,7 +9953,6 @@
       {
         "nameform": "Purified",
         "protoform": "1213",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -12202,9 +9969,6 @@
   "190": {
     "name": "Aipom",
     "rarity": "Uncommon",
-    "baseStamina": 146,
-    "baseAttack": 136,
-    "baseDefense": 112,
     "types": [
       {
         "type": "Normal",
@@ -12215,7 +9979,6 @@
       {
         "nameform": "Normal",
         "protoform": "1214",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -12226,7 +9989,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1215",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -12237,7 +9999,6 @@
       {
         "nameform": "Purified",
         "protoform": "1216",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -12250,9 +10011,6 @@
   "191": {
     "name": "Sunkern",
     "rarity": "Common",
-    "baseStamina": 102,
-    "baseAttack": 55,
-    "baseDefense": 55,
     "types": [
       {
         "type": "Grass",
@@ -12263,7 +10021,6 @@
       {
         "nameform": "Normal",
         "protoform": "1217",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -12274,7 +10031,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1218",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -12285,7 +10041,6 @@
       {
         "nameform": "Purified",
         "protoform": "1219",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -12298,9 +10053,6 @@
   "192": {
     "name": "Sunflora",
     "rarity": "Ultra Rare",
-    "baseStamina": 181,
-    "baseAttack": 185,
-    "baseDefense": 135,
     "types": [
       {
         "type": "Grass",
@@ -12311,7 +10063,6 @@
       {
         "nameform": "Normal",
         "protoform": "1220",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -12322,7 +10073,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1221",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -12333,7 +10083,6 @@
       {
         "nameform": "Purified",
         "protoform": "1222",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -12346,9 +10095,6 @@
   "193": {
     "name": "Yanma",
     "rarity": "Uncommon",
-    "baseStamina": 163,
-    "baseAttack": 154,
-    "baseDefense": 94,
     "types": [
       {
         "type": "Bug",
@@ -12363,7 +10109,6 @@
       {
         "nameform": "Normal",
         "protoform": "1223",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -12378,7 +10123,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1224",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -12393,7 +10137,6 @@
       {
         "nameform": "Purified",
         "protoform": "1225",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -12410,9 +10153,6 @@
   "194": {
     "name": "Wooper",
     "rarity": "Common",
-    "baseStamina": 146,
-    "baseAttack": 75,
-    "baseDefense": 66,
     "types": [
       {
         "type": "Water",
@@ -12427,7 +10167,6 @@
       {
         "nameform": "Normal",
         "protoform": "1226",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -12442,7 +10181,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1227",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -12457,7 +10195,6 @@
       {
         "nameform": "Purified",
         "protoform": "1228",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -12474,9 +10211,6 @@
   "195": {
     "name": "Quagsire",
     "rarity": "Rare",
-    "baseStamina": 216,
-    "baseAttack": 152,
-    "baseDefense": 143,
     "types": [
       {
         "type": "Water",
@@ -12491,7 +10225,6 @@
       {
         "nameform": "Normal",
         "protoform": "1229",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -12506,7 +10239,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1230",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -12521,7 +10253,6 @@
       {
         "nameform": "Purified",
         "protoform": "1231",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -12538,9 +10269,6 @@
   "196": {
     "name": "Espeon",
     "rarity": "Ultra Rare",
-    "baseStamina": 163,
-    "baseAttack": 261,
-    "baseDefense": 175,
     "types": [
       {
         "type": "Psychic",
@@ -12551,7 +10279,6 @@
       {
         "nameform": "Normal",
         "protoform": "1232",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -12562,7 +10289,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1233",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -12573,7 +10299,6 @@
       {
         "nameform": "Purified",
         "protoform": "1234",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -12586,9 +10311,6 @@
   "197": {
     "name": "Umbreon",
     "rarity": "Ultra Rare",
-    "baseStamina": 216,
-    "baseAttack": 126,
-    "baseDefense": 240,
     "types": [
       {
         "type": "Dark",
@@ -12599,7 +10321,6 @@
       {
         "nameform": "Normal",
         "protoform": "1235",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -12610,7 +10331,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1236",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -12621,7 +10341,6 @@
       {
         "nameform": "Purified",
         "protoform": "1237",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -12634,9 +10353,6 @@
   "198": {
     "name": "Murkrow",
     "rarity": "Uncommon",
-    "baseStamina": 155,
-    "baseAttack": 175,
-    "baseDefense": 87,
     "types": [
       {
         "type": "Dark",
@@ -12651,10 +10367,6 @@
       {
         "nameform": "Normal",
         "protoform": "855",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 175,
-        "baseDefense": 87,
         "formtypes": [
           {
             "type": "Dark",
@@ -12669,10 +10381,6 @@
       {
         "nameform": "Shadow",
         "protoform": "856",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 175,
-        "baseDefense": 87,
         "formtypes": [
           {
             "type": "Dark",
@@ -12687,10 +10395,6 @@
       {
         "nameform": "Purified",
         "protoform": "857",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 175,
-        "baseDefense": 87,
         "formtypes": [
           {
             "type": "Dark",
@@ -12707,9 +10411,6 @@
   "199": {
     "name": "Slowking",
     "rarity": "Ultra Rare",
-    "baseStamina": 216,
-    "baseAttack": 177,
-    "baseDefense": 180,
     "types": [
       {
         "type": "Water",
@@ -12724,7 +10425,6 @@
       {
         "nameform": "Normal",
         "protoform": "1238",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -12739,7 +10439,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1239",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -12754,7 +10453,6 @@
       {
         "nameform": "Purified",
         "protoform": "1240",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -12771,9 +10469,6 @@
   "200": {
     "name": "Misdreavus",
     "rarity": "Rare",
-    "baseStamina": 155,
-    "baseAttack": 167,
-    "baseDefense": 154,
     "types": [
       {
         "type": "Ghost",
@@ -12784,10 +10479,6 @@
       {
         "nameform": "Normal",
         "protoform": "719",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 167,
-        "baseDefense": 154,
         "formtypes": [
           {
             "type": "Ghost",
@@ -12798,10 +10489,6 @@
       {
         "nameform": "Shadow",
         "protoform": "720",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 167,
-        "baseDefense": 154,
         "formtypes": [
           {
             "type": "Ghost",
@@ -12812,10 +10499,6 @@
       {
         "nameform": "Purified",
         "protoform": "721",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 167,
-        "baseDefense": 154,
         "formtypes": [
           {
             "type": "Ghost",
@@ -12828,9 +10511,6 @@
   "201": {
     "name": "Unown",
     "rarity": "Ultra Rare",
-    "baseStamina": 134,
-    "baseAttack": 136,
-    "baseDefense": 91,
     "types": [
       {
         "type": "Psychic",
@@ -12841,10 +10521,6 @@
       {
         "nameform": "a",
         "protoform": "1",
-        "assetsform": "11",
-        "baseStamina": 134,
-        "baseAttack": 136,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Psychic",
@@ -12855,10 +10531,6 @@
       {
         "nameform": "b",
         "protoform": "2",
-        "assetsform": "12",
-        "baseStamina": 134,
-        "baseAttack": 136,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Psychic",
@@ -12869,10 +10541,6 @@
       {
         "nameform": "c",
         "protoform": "3",
-        "assetsform": "13",
-        "baseStamina": 134,
-        "baseAttack": 136,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Psychic",
@@ -12883,10 +10551,6 @@
       {
         "nameform": "d",
         "protoform": "4",
-        "assetsform": "14",
-        "baseStamina": 134,
-        "baseAttack": 136,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Psychic",
@@ -12897,10 +10561,6 @@
       {
         "nameform": "e",
         "protoform": "5",
-        "assetsform": "15",
-        "baseStamina": 134,
-        "baseAttack": 136,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Psychic",
@@ -12911,10 +10571,6 @@
       {
         "nameform": "f",
         "protoform": "6",
-        "assetsform": "16",
-        "baseStamina": 134,
-        "baseAttack": 136,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Psychic",
@@ -12925,10 +10581,6 @@
       {
         "nameform": "g",
         "protoform": "7",
-        "assetsform": "17",
-        "baseStamina": 134,
-        "baseAttack": 136,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Psychic",
@@ -12939,10 +10591,6 @@
       {
         "nameform": "h",
         "protoform": "8",
-        "assetsform": "18",
-        "baseStamina": 134,
-        "baseAttack": 136,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Psychic",
@@ -12953,10 +10601,6 @@
       {
         "nameform": "i",
         "protoform": "9",
-        "assetsform": "19",
-        "baseStamina": 134,
-        "baseAttack": 136,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Psychic",
@@ -12967,10 +10611,6 @@
       {
         "nameform": "j",
         "protoform": "10",
-        "assetsform": "20",
-        "baseStamina": 134,
-        "baseAttack": 136,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Psychic",
@@ -12981,10 +10621,6 @@
       {
         "nameform": "k",
         "protoform": "11",
-        "assetsform": "21",
-        "baseStamina": 134,
-        "baseAttack": 136,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Psychic",
@@ -12995,10 +10631,6 @@
       {
         "nameform": "l",
         "protoform": "12",
-        "assetsform": "22",
-        "baseStamina": 134,
-        "baseAttack": 136,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Psychic",
@@ -13009,10 +10641,6 @@
       {
         "nameform": "m",
         "protoform": "13",
-        "assetsform": "23",
-        "baseStamina": 134,
-        "baseAttack": 136,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Psychic",
@@ -13023,10 +10651,6 @@
       {
         "nameform": "n",
         "protoform": "14",
-        "assetsform": "24",
-        "baseStamina": 134,
-        "baseAttack": 136,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Psychic",
@@ -13037,10 +10661,6 @@
       {
         "nameform": "o",
         "protoform": "15",
-        "assetsform": "25",
-        "baseStamina": 134,
-        "baseAttack": 136,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Psychic",
@@ -13051,10 +10671,6 @@
       {
         "nameform": "p",
         "protoform": "16",
-        "assetsform": "26",
-        "baseStamina": 134,
-        "baseAttack": 136,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Psychic",
@@ -13065,10 +10681,6 @@
       {
         "nameform": "q",
         "protoform": "17",
-        "assetsform": "27",
-        "baseStamina": 134,
-        "baseAttack": 136,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Psychic",
@@ -13079,10 +10691,6 @@
       {
         "nameform": "r",
         "protoform": "18",
-        "assetsform": "28",
-        "baseStamina": 134,
-        "baseAttack": 136,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Psychic",
@@ -13093,10 +10701,6 @@
       {
         "nameform": "s",
         "protoform": "19",
-        "assetsform": "29",
-        "baseStamina": 134,
-        "baseAttack": 136,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Psychic",
@@ -13107,10 +10711,6 @@
       {
         "nameform": "t",
         "protoform": "20",
-        "assetsform": "30",
-        "baseStamina": 134,
-        "baseAttack": 136,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Psychic",
@@ -13121,10 +10721,6 @@
       {
         "nameform": "u",
         "protoform": "21",
-        "assetsform": "31",
-        "baseStamina": 134,
-        "baseAttack": 136,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Psychic",
@@ -13135,10 +10731,6 @@
       {
         "nameform": "v",
         "protoform": "22",
-        "assetsform": "32",
-        "baseStamina": 134,
-        "baseAttack": 136,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Psychic",
@@ -13149,10 +10741,6 @@
       {
         "nameform": "w",
         "protoform": "23",
-        "assetsform": "33",
-        "baseStamina": 134,
-        "baseAttack": 136,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Psychic",
@@ -13163,10 +10751,6 @@
       {
         "nameform": "x",
         "protoform": "24",
-        "assetsform": "34",
-        "baseStamina": 134,
-        "baseAttack": 136,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Psychic",
@@ -13177,10 +10761,6 @@
       {
         "nameform": "y",
         "protoform": "25",
-        "assetsform": "35",
-        "baseStamina": 134,
-        "baseAttack": 136,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Psychic",
@@ -13191,10 +10771,6 @@
       {
         "nameform": "z",
         "protoform": "26",
-        "assetsform": "36",
-        "baseStamina": 134,
-        "baseAttack": 136,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Psychic",
@@ -13205,10 +10781,6 @@
       {
         "nameform": "!",
         "protoform": "27",
-        "assetsform": "37",
-        "baseStamina": 134,
-        "baseAttack": 136,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Psychic",
@@ -13219,10 +10791,6 @@
       {
         "nameform": "?",
         "protoform": "28",
-        "assetsform": "38",
-        "baseStamina": 134,
-        "baseAttack": 136,
-        "baseDefense": 91,
         "formtypes": [
           {
             "type": "Psychic",
@@ -13235,9 +10803,6 @@
   "202": {
     "name": "Wobbuffet",
     "rarity": "Very Rare",
-    "baseStamina": 382,
-    "baseAttack": 60,
-    "baseDefense": 106,
     "types": [
       {
         "type": "Psychic",
@@ -13248,10 +10813,6 @@
       {
         "nameform": "Normal",
         "protoform": "602",
-        "assetsform": "00",
-        "baseStamina": 382,
-        "baseAttack": 60,
-        "baseDefense": 106,
         "formtypes": [
           {
             "type": "Psychic",
@@ -13262,10 +10823,6 @@
       {
         "nameform": "No Evolve",
         "protoform": "603",
-        "assetsform": "00",
-        "baseStamina": 382,
-        "baseAttack": 60,
-        "baseDefense": 106,
         "formtypes": [
           {
             "type": "Psychic",
@@ -13276,10 +10833,6 @@
       {
         "nameform": "Shadow",
         "protoform": "686",
-        "assetsform": "00",
-        "baseStamina": 382,
-        "baseAttack": 60,
-        "baseDefense": 106,
         "formtypes": [
           {
             "type": "Psychic",
@@ -13290,10 +10843,6 @@
       {
         "nameform": "Purified",
         "protoform": "687",
-        "assetsform": "00",
-        "baseStamina": 382,
-        "baseAttack": 60,
-        "baseDefense": 106,
         "formtypes": [
           {
             "type": "Psychic",
@@ -13306,9 +10855,6 @@
   "203": {
     "name": "Girafarig",
     "rarity": "Ultra Rare",
-    "baseStamina": 172,
-    "baseAttack": 182,
-    "baseDefense": 133,
     "types": [
       {
         "type": "Normal",
@@ -13323,7 +10869,6 @@
       {
         "nameform": "Normal",
         "protoform": "1241",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -13338,7 +10883,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1242",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -13353,7 +10897,6 @@
       {
         "nameform": "Purified",
         "protoform": "1243",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -13370,9 +10913,6 @@
   "204": {
     "name": "Pineco",
     "rarity": "Very Rare",
-    "baseStamina": 137,
-    "baseAttack": 108,
-    "baseDefense": 122,
     "types": [
       {
         "type": "Bug",
@@ -13383,7 +10923,6 @@
       {
         "nameform": "Normal",
         "protoform": "1244",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -13394,7 +10933,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1245",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -13405,7 +10943,6 @@
       {
         "nameform": "Purified",
         "protoform": "1246",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -13418,9 +10955,6 @@
   "205": {
     "name": "Forretress",
     "rarity": "Ultra Rare",
-    "baseStamina": 181,
-    "baseAttack": 161,
-    "baseDefense": 205,
     "types": [
       {
         "type": "Bug",
@@ -13435,7 +10969,6 @@
       {
         "nameform": "Normal",
         "protoform": "1247",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -13450,7 +10983,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1248",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -13465,7 +10997,6 @@
       {
         "nameform": "Purified",
         "protoform": "1249",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -13482,9 +11013,6 @@
   "206": {
     "name": "Dunsparce",
     "rarity": "Uncommon",
-    "baseStamina": 225,
-    "baseAttack": 131,
-    "baseDefense": 128,
     "types": [
       {
         "type": "Normal",
@@ -13495,7 +11023,6 @@
       {
         "nameform": "Normal",
         "protoform": "1250",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -13506,7 +11033,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1251",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -13517,7 +11043,6 @@
       {
         "nameform": "Purified",
         "protoform": "1252",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -13530,9 +11055,6 @@
   "207": {
     "name": "Gligar",
     "rarity": "Very Rare",
-    "baseStamina": 163,
-    "baseAttack": 143,
-    "baseDefense": 184,
     "types": [
       {
         "type": "Ground",
@@ -13547,10 +11069,6 @@
       {
         "nameform": "Normal",
         "protoform": "803",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 143,
-        "baseDefense": 184,
         "formtypes": [
           {
             "type": "Ground",
@@ -13565,10 +11083,6 @@
       {
         "nameform": "Shadow",
         "protoform": "804",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 143,
-        "baseDefense": 184,
         "formtypes": [
           {
             "type": "Ground",
@@ -13583,10 +11097,6 @@
       {
         "nameform": "Purified",
         "protoform": "805",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 143,
-        "baseDefense": 184,
         "formtypes": [
           {
             "type": "Ground",
@@ -13603,9 +11113,6 @@
   "208": {
     "name": "Steelix",
     "rarity": "Ultra Rare",
-    "baseStamina": 181,
-    "baseAttack": 148,
-    "baseDefense": 272,
     "types": [
       {
         "type": "Steel",
@@ -13620,10 +11127,6 @@
       {
         "nameform": "Normal",
         "protoform": "905",
-        "assetsform": "00",
-        "baseStamina": 181,
-        "baseAttack": 148,
-        "baseDefense": 272,
         "formtypes": [
           {
             "type": "Steel",
@@ -13638,10 +11141,6 @@
       {
         "nameform": "Shadow",
         "protoform": "906",
-        "assetsform": "00",
-        "baseStamina": 181,
-        "baseAttack": 148,
-        "baseDefense": 272,
         "formtypes": [
           {
             "type": "Steel",
@@ -13656,10 +11155,6 @@
       {
         "nameform": "Purified",
         "protoform": "907",
-        "assetsform": "00",
-        "baseStamina": 181,
-        "baseAttack": 148,
-        "baseDefense": 272,
         "formtypes": [
           {
             "type": "Steel",
@@ -13676,9 +11171,6 @@
   "209": {
     "name": "Snubbull",
     "rarity": "Uncommon",
-    "baseStamina": 155,
-    "baseAttack": 137,
-    "baseDefense": 85,
     "types": [
       {
         "type": "Fairy",
@@ -13689,7 +11181,6 @@
       {
         "nameform": "Normal",
         "protoform": "1253",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fairy",
@@ -13700,7 +11191,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1254",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fairy",
@@ -13711,7 +11201,6 @@
       {
         "nameform": "Purified",
         "protoform": "1255",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fairy",
@@ -13724,9 +11213,6 @@
   "210": {
     "name": "Granbull",
     "rarity": "Rare",
-    "baseStamina": 207,
-    "baseAttack": 212,
-    "baseDefense": 131,
     "types": [
       {
         "type": "Fairy",
@@ -13737,7 +11223,6 @@
       {
         "nameform": "Normal",
         "protoform": "1256",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fairy",
@@ -13748,7 +11233,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1257",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fairy",
@@ -13759,7 +11243,6 @@
       {
         "nameform": "Purified",
         "protoform": "1258",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fairy",
@@ -13772,9 +11255,6 @@
   "211": {
     "name": "Qwilfish",
     "rarity": "Very Rare",
-    "baseStamina": 163,
-    "baseAttack": 184,
-    "baseDefense": 138,
     "types": [
       {
         "type": "Water",
@@ -13789,7 +11269,6 @@
       {
         "nameform": "Normal",
         "protoform": "1259",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -13804,7 +11283,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1260",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -13819,7 +11297,6 @@
       {
         "nameform": "Purified",
         "protoform": "1261",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Poison",
@@ -13836,9 +11313,6 @@
   "212": {
     "name": "Scizor",
     "rarity": "Ultra Rare",
-    "baseStamina": 172,
-    "baseAttack": 236,
-    "baseDefense": 181,
     "types": [
       {
         "type": "Bug",
@@ -13853,10 +11327,6 @@
       {
         "nameform": "Normal",
         "protoform": "250",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 236,
-        "baseDefense": 181,
         "formtypes": [
           {
             "type": "Bug",
@@ -13871,10 +11341,6 @@
       {
         "nameform": "Shadow",
         "protoform": "251",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 236,
-        "baseDefense": 181,
         "formtypes": [
           {
             "type": "Bug",
@@ -13889,10 +11355,6 @@
       {
         "nameform": "Purified",
         "protoform": "252",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 236,
-        "baseDefense": 181,
         "formtypes": [
           {
             "type": "Bug",
@@ -13909,9 +11371,6 @@
   "213": {
     "name": "Shuckle",
     "rarity": "Ultra Rare",
-    "baseStamina": 85,
-    "baseAttack": 17,
-    "baseDefense": 396,
     "types": [
       {
         "type": "Bug",
@@ -13926,10 +11385,6 @@
       {
         "nameform": "Normal",
         "protoform": "827",
-        "assetsform": "00",
-        "baseStamina": 85,
-        "baseAttack": 17,
-        "baseDefense": 396,
         "formtypes": [
           {
             "type": "Bug",
@@ -13944,10 +11399,6 @@
       {
         "nameform": "Shadow",
         "protoform": "828",
-        "assetsform": "00",
-        "baseStamina": 85,
-        "baseAttack": 17,
-        "baseDefense": 396,
         "formtypes": [
           {
             "type": "Bug",
@@ -13962,10 +11413,6 @@
       {
         "nameform": "Purified",
         "protoform": "829",
-        "assetsform": "00",
-        "baseStamina": 85,
-        "baseAttack": 17,
-        "baseDefense": 396,
         "formtypes": [
           {
             "type": "Bug",
@@ -13982,9 +11429,6 @@
   "214": {
     "name": "Heracross",
     "rarity": "Ultra Rare",
-    "baseStamina": 190,
-    "baseAttack": 234,
-    "baseDefense": 179,
     "types": [
       {
         "type": "Bug",
@@ -13999,7 +11443,6 @@
       {
         "nameform": "Normal",
         "protoform": "1262",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -14014,7 +11457,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1263",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -14029,7 +11471,6 @@
       {
         "nameform": "Purified",
         "protoform": "1264",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -14046,9 +11487,6 @@
   "215": {
     "name": "Sneasel",
     "rarity": "Rare",
-    "baseStamina": 146,
-    "baseAttack": 189,
-    "baseDefense": 146,
     "types": [
       {
         "type": "Dark",
@@ -14063,10 +11501,6 @@
       {
         "nameform": "Normal",
         "protoform": "797",
-        "assetsform": "00",
-        "baseStamina": 146,
-        "baseAttack": 189,
-        "baseDefense": 146,
         "formtypes": [
           {
             "type": "Dark",
@@ -14081,10 +11515,6 @@
       {
         "nameform": "Shadow",
         "protoform": "798",
-        "assetsform": "00",
-        "baseStamina": 146,
-        "baseAttack": 189,
-        "baseDefense": 146,
         "formtypes": [
           {
             "type": "Dark",
@@ -14100,10 +11530,6 @@
       {
         "nameform": "Purified",
         "protoform": "799",
-        "assetsform": "00",
-        "baseStamina": 146,
-        "baseAttack": 189,
-        "baseDefense": 146,
         "formtypes": [
           {
             "type": "Dark",
@@ -14121,9 +11547,6 @@
   "216": {
     "name": "Teddiursa",
     "rarity": "Uncommon",
-    "baseStamina": 155,
-    "baseAttack": 142,
-    "baseDefense": 93,
     "types": [
       {
         "type": "Normal",
@@ -14134,7 +11557,6 @@
       {
         "nameform": "Normal",
         "protoform": "1265",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -14145,7 +11567,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1266",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -14156,7 +11577,6 @@
       {
         "nameform": "Purified",
         "protoform": "1267",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -14169,9 +11589,6 @@
   "217": {
     "name": "Ursaring",
     "rarity": "Rare",
-    "baseStamina": 207,
-    "baseAttack": 236,
-    "baseDefense": 144,
     "types": [
       {
         "type": "Normal",
@@ -14182,7 +11599,6 @@
       {
         "nameform": "Normal",
         "protoform": "1268",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -14193,7 +11609,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1269",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -14204,7 +11619,6 @@
       {
         "nameform": "Purified",
         "protoform": "1270",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -14217,9 +11631,6 @@
   "218": {
     "name": "Slugma",
     "rarity": "Uncommon",
-    "baseStamina": 120,
-    "baseAttack": 118,
-    "baseDefense": 71,
     "types": [
       {
         "type": "Fire",
@@ -14230,7 +11641,6 @@
       {
         "nameform": "Normal",
         "protoform": "1271",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -14241,7 +11651,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1272",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -14252,7 +11661,6 @@
       {
         "nameform": "Purified",
         "protoform": "1273",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -14265,9 +11673,6 @@
   "219": {
     "name": "Magcargo",
     "rarity": "Very Rare",
-    "baseStamina": 137,
-    "baseAttack": 139,
-    "baseDefense": 191,
     "types": [
       {
         "type": "Fire",
@@ -14282,7 +11687,6 @@
       {
         "nameform": "Normal",
         "protoform": "1274",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -14297,7 +11701,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1275",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -14312,7 +11715,6 @@
       {
         "nameform": "Purified",
         "protoform": "1276",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -14329,9 +11731,6 @@
   "220": {
     "name": "Swinub",
     "rarity": "Common",
-    "baseStamina": 137,
-    "baseAttack": 90,
-    "baseDefense": 69,
     "types": [
       {
         "type": "Ice",
@@ -14346,7 +11745,6 @@
       {
         "nameform": "Normal",
         "protoform": "1277",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -14361,7 +11759,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1278",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -14376,7 +11773,6 @@
       {
         "nameform": "Purified",
         "protoform": "1279",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -14393,9 +11789,6 @@
   "221": {
     "name": "Piloswine",
     "rarity": "Ultra Rare",
-    "baseStamina": 225,
-    "baseAttack": 181,
-    "baseDefense": 138,
     "types": [
       {
         "type": "Ice",
@@ -14410,7 +11803,6 @@
       {
         "nameform": "Normal",
         "protoform": "1280",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -14425,7 +11817,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1281",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -14440,7 +11831,6 @@
       {
         "nameform": "Purified",
         "protoform": "1282",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -14457,9 +11847,6 @@
   "222": {
     "name": "Corsola",
     "rarity": "Ultra Rare",
-    "baseStamina": 146,
-    "baseAttack": 118,
-    "baseDefense": 156,
     "types": [
       {
         "type": "Water",
@@ -14474,7 +11861,6 @@
       {
         "nameform": "Normal",
         "protoform": "1283",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -14489,7 +11875,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1284",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -14504,7 +11889,6 @@
       {
         "nameform": "Purified",
         "protoform": "1285",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -14519,7 +11903,6 @@
       {
         "nameform": "Galarian",
         "protoform": "2340",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -14536,9 +11919,6 @@
   "223": {
     "name": "Remoraid",
     "rarity": "Uncommon",
-    "baseStamina": 111,
-    "baseAttack": 127,
-    "baseDefense": 69,
     "types": [
       {
         "type": "Water",
@@ -14549,7 +11929,6 @@
       {
         "nameform": "Normal",
         "protoform": "1286",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -14560,7 +11939,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1287",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -14571,7 +11949,6 @@
       {
         "nameform": "Purified",
         "protoform": "1288",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -14584,9 +11961,6 @@
   "224": {
     "name": "Octillery",
     "rarity": "Uncommon",
-    "baseStamina": 181,
-    "baseAttack": 197,
-    "baseDefense": 141,
     "types": [
       {
         "type": "Water",
@@ -14597,7 +11971,6 @@
       {
         "nameform": "Normal",
         "protoform": "1289",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -14608,7 +11981,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1290",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -14619,7 +11991,6 @@
       {
         "nameform": "Purified",
         "protoform": "1291",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -14632,9 +12003,6 @@
   "225": {
     "name": "Delibird",
     "rarity": "Ultra Rare",
-    "baseStamina": 128,
-    "baseAttack": 128,
-    "baseDefense": 90,
     "types": [
       {
         "type": "Ice",
@@ -14649,10 +12017,6 @@
       {
         "nameform": "Normal",
         "protoform": "938",
-        "assetsform": "00",
-        "baseStamina": 128,
-        "baseAttack": 128,
-        "baseDefense": 90,
         "formtypes": [
           {
             "type": "Ice",
@@ -14667,10 +12031,6 @@
       {
         "nameform": "Shadow",
         "protoform": "939",
-        "assetsform": "00",
-        "baseStamina": 128,
-        "baseAttack": 128,
-        "baseDefense": 90,
         "formtypes": [
           {
             "type": "Ice",
@@ -14685,10 +12045,6 @@
       {
         "nameform": "Purified",
         "protoform": "940",
-        "assetsform": "00",
-        "baseStamina": 128,
-        "baseAttack": 128,
-        "baseDefense": 90,
         "formtypes": [
           {
             "type": "Ice",
@@ -14703,10 +12059,6 @@
       {
         "nameform": "Winter 2020",
         "protoform": "2671",
-        "assetsform": "00",
-        "baseStamina": 128,
-        "baseAttack": 128,
-        "baseDefense": 90,
         "formtypes": [
           {
             "type": "Ice",
@@ -14723,9 +12075,6 @@
   "226": {
     "name": "Mantine",
     "rarity": "Uncommon",
-    "baseStamina": 163,
-    "baseAttack": 148,
-    "baseDefense": 226,
     "types": [
       {
         "type": "Water",
@@ -14740,7 +12089,6 @@
       {
         "nameform": "Normal",
         "protoform": "1292",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -14755,7 +12103,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1293",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -14770,7 +12117,6 @@
       {
         "nameform": "Purified",
         "protoform": "1294",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -14787,9 +12133,6 @@
   "227": {
     "name": "Skarmory",
     "rarity": "Rare",
-    "baseStamina": 163,
-    "baseAttack": 148,
-    "baseDefense": 226,
     "types": [
       {
         "type": "Steel",
@@ -14804,7 +12147,6 @@
       {
         "nameform": "Normal",
         "protoform": "1295",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -14819,7 +12161,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1296",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -14834,7 +12175,6 @@
       {
         "nameform": "Purified",
         "protoform": "1297",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -14851,9 +12191,6 @@
   "228": {
     "name": "Houndour",
     "rarity": "Uncommon",
-    "baseStamina": 128,
-    "baseAttack": 152,
-    "baseDefense": 83,
     "types": [
       {
         "type": "Dark",
@@ -14868,10 +12205,6 @@
       {
         "nameform": "Normal",
         "protoform": "229",
-        "assetsform": "00",
-        "baseStamina": 128,
-        "baseAttack": 152,
-        "baseDefense": 83,
         "formtypes": [
           {
             "type": "Dark",
@@ -14886,10 +12219,6 @@
       {
         "nameform": "Shadow",
         "protoform": "230",
-        "assetsform": "00",
-        "baseStamina": 128,
-        "baseAttack": 152,
-        "baseDefense": 83,
         "formtypes": [
           {
             "type": "Dark",
@@ -14904,10 +12233,6 @@
       {
         "nameform": "Purified",
         "protoform": "231",
-        "assetsform": "00",
-        "baseStamina": 128,
-        "baseAttack": 152,
-        "baseDefense": 83,
         "formtypes": [
           {
             "type": "Dark",
@@ -14924,9 +12249,6 @@
   "229": {
     "name": "Houndoom",
     "rarity": "Very Rare",
-    "baseStamina": 181,
-    "baseAttack": 224,
-    "baseDefense": 144,
     "types": [
       {
         "type": "Dark",
@@ -14941,10 +12263,6 @@
       {
         "nameform": "Normal",
         "protoform": "232",
-        "assetsform": "00",
-        "baseStamina": 181,
-        "baseAttack": 224,
-        "baseDefense": 144,
         "formtypes": [
           {
             "type": "Dark",
@@ -14959,10 +12277,6 @@
       {
         "nameform": "Shadow",
         "protoform": "233",
-        "assetsform": "00",
-        "baseStamina": 181,
-        "baseAttack": 224,
-        "baseDefense": 144,
         "formtypes": [
           {
             "type": "Dark",
@@ -14977,10 +12291,6 @@
       {
         "nameform": "Purified",
         "protoform": "234",
-        "assetsform": "00",
-        "baseStamina": 181,
-        "baseAttack": 224,
-        "baseDefense": 144,
         "formtypes": [
           {
             "type": "Dark",
@@ -14998,9 +12308,6 @@
   "230": {
     "name": "Kingdra",
     "rarity": "Ultra Rare",
-    "baseStamina": 181,
-    "baseAttack": 194,
-    "baseDefense": 194,
     "types": [
       {
         "type": "Water",
@@ -15015,7 +12322,6 @@
       {
         "nameform": "Normal",
         "protoform": "1298",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -15030,7 +12336,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1299",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -15045,7 +12350,6 @@
       {
         "nameform": "Purified",
         "protoform": "1300",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -15062,9 +12366,6 @@
   "231": {
     "name": "Phanpy",
     "rarity": "Rare",
-    "baseStamina": 207,
-    "baseAttack": 107,
-    "baseDefense": 98,
     "types": [
       {
         "type": "Ground",
@@ -15075,7 +12376,6 @@
       {
         "nameform": "Normal",
         "protoform": "1301",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -15086,7 +12386,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1302",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -15097,7 +12396,6 @@
       {
         "nameform": "Purified",
         "protoform": "1303",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -15110,9 +12408,6 @@
   "232": {
     "name": "Donphan",
     "rarity": "Very Rare",
-    "baseStamina": 207,
-    "baseAttack": 214,
-    "baseDefense": 185,
     "types": [
       {
         "type": "Ground",
@@ -15123,7 +12418,6 @@
       {
         "nameform": "Normal",
         "protoform": "1304",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -15134,7 +12428,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1305",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -15145,7 +12438,6 @@
       {
         "nameform": "Purified",
         "protoform": "1306",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -15158,9 +12450,6 @@
   "233": {
     "name": "Porygon2",
     "rarity": "Ultra Rare",
-    "baseStamina": 198,
-    "baseAttack": 198,
-    "baseDefense": 180,
     "types": [
       {
         "type": "Normal",
@@ -15171,10 +12460,6 @@
       {
         "nameform": "Normal",
         "protoform": "680",
-        "assetsform": "00",
-        "baseStamina": 198,
-        "baseAttack": 198,
-        "baseDefense": 180,
         "formtypes": [
           {
             "type": "Normal",
@@ -15185,10 +12470,6 @@
       {
         "nameform": "Shadow",
         "protoform": "681",
-        "assetsform": "00",
-        "baseStamina": 198,
-        "baseAttack": 198,
-        "baseDefense": 180,
         "formtypes": [
           {
             "type": "Normal",
@@ -15199,10 +12480,6 @@
       {
         "nameform": "Purified",
         "protoform": "682",
-        "assetsform": "00",
-        "baseStamina": 198,
-        "baseAttack": 198,
-        "baseDefense": 180,
         "formtypes": [
           {
             "type": "Normal",
@@ -15215,9 +12492,6 @@
   "234": {
     "name": "Stantler",
     "rarity": "Rare",
-    "baseStamina": 177,
-    "baseAttack": 192,
-    "baseDefense": 131,
     "types": [
       {
         "type": "Normal",
@@ -15228,10 +12502,6 @@
       {
         "nameform": "Normal",
         "protoform": "941",
-        "assetsform": "00",
-        "baseStamina": 177,
-        "baseAttack": 192,
-        "baseDefense": 131,
         "formtypes": [
           {
             "type": "Normal",
@@ -15242,10 +12512,6 @@
       {
         "nameform": "Shadow",
         "protoform": "942",
-        "assetsform": "00",
-        "baseStamina": 177,
-        "baseAttack": 192,
-        "baseDefense": 131,
         "formtypes": [
           {
             "type": "Normal",
@@ -15256,10 +12522,6 @@
       {
         "nameform": "Purified",
         "protoform": "943",
-        "assetsform": "00",
-        "baseStamina": 177,
-        "baseAttack": 192,
-        "baseDefense": 131,
         "formtypes": [
           {
             "type": "Normal",
@@ -15272,9 +12534,6 @@
   "235": {
     "name": "Smeargle",
     "rarity": "Ultra Rare",
-    "baseStamina": 146,
-    "baseAttack": 40,
-    "baseDefense": 83,
     "types": [
       {
         "type": "Normal",
@@ -15285,7 +12544,6 @@
       {
         "nameform": "Normal",
         "protoform": "1307",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -15296,7 +12554,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1308",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -15307,7 +12564,6 @@
       {
         "nameform": "Purified",
         "protoform": "1309",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -15320,9 +12576,6 @@
   "236": {
     "name": "Tyrogue",
     "rarity": "Ultra Rare",
-    "baseStamina": 111,
-    "baseAttack": 64,
-    "baseDefense": 64,
     "types": [
       {
         "type": "Fighting",
@@ -15333,7 +12586,6 @@
       {
         "nameform": "Normal",
         "protoform": "1310",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -15344,7 +12596,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1311",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -15355,7 +12606,6 @@
       {
         "nameform": "Purified",
         "protoform": "1312",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -15368,9 +12618,6 @@
   "237": {
     "name": "Hitmontop",
     "rarity": "Ultra Rare",
-    "baseStamina": 137,
-    "baseAttack": 173,
-    "baseDefense": 207,
     "types": [
       {
         "type": "Fighting",
@@ -15381,7 +12628,6 @@
       {
         "nameform": "Normal",
         "protoform": "1313",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -15392,7 +12638,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1314",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -15403,7 +12648,6 @@
       {
         "nameform": "Purified",
         "protoform": "1315",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -15416,9 +12660,6 @@
   "238": {
     "name": "Smoochum",
     "rarity": "Very Rare",
-    "baseStamina": 128,
-    "baseAttack": 153,
-    "baseDefense": 91,
     "types": [
       {
         "type": "Ice",
@@ -15433,7 +12674,6 @@
       {
         "nameform": "Normal",
         "protoform": "1316",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -15448,7 +12688,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1317",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -15463,7 +12702,6 @@
       {
         "nameform": "Purified",
         "protoform": "1318",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -15480,9 +12718,6 @@
   "239": {
     "name": "Elekid",
     "rarity": "Very Rare",
-    "baseStamina": 128,
-    "baseAttack": 135,
-    "baseDefense": 101,
     "types": [
       {
         "type": "Electric",
@@ -15493,7 +12728,6 @@
       {
         "nameform": "Normal",
         "protoform": "1319",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -15504,7 +12738,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1320",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -15515,7 +12748,6 @@
       {
         "nameform": "Purified",
         "protoform": "1321",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -15528,9 +12760,6 @@
   "240": {
     "name": "Magby",
     "rarity": "Very Rare",
-    "baseStamina": 128,
-    "baseAttack": 151,
-    "baseDefense": 99,
     "types": [
       {
         "type": "Fire",
@@ -15541,7 +12770,6 @@
       {
         "nameform": "Normal",
         "protoform": "1322",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -15552,7 +12780,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1323",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -15563,7 +12790,6 @@
       {
         "nameform": "Purified",
         "protoform": "1324",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -15576,9 +12802,6 @@
   "241": {
     "name": "Miltank",
     "rarity": "Very Rare",
-    "baseStamina": 216,
-    "baseAttack": 157,
-    "baseDefense": 193,
     "types": [
       {
         "type": "Normal",
@@ -15589,7 +12812,6 @@
       {
         "nameform": "Normal",
         "protoform": "1325",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -15600,7 +12822,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1326",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -15611,7 +12832,6 @@
       {
         "nameform": "Purified",
         "protoform": "1327",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -15624,9 +12844,6 @@
   "242": {
     "name": "Blissey",
     "rarity": "Ultra Rare",
-    "baseStamina": 496,
-    "baseAttack": 129,
-    "baseDefense": 169,
     "types": [
       {
         "type": "Normal",
@@ -15637,7 +12854,6 @@
       {
         "nameform": "Normal",
         "protoform": "1328",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -15648,7 +12864,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1329",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -15659,7 +12874,6 @@
       {
         "nameform": "Purified",
         "protoform": "1330",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -15672,9 +12886,6 @@
   "243": {
     "name": "Raikou",
     "rarity": "Ultra Rare",
-    "baseStamina": 207,
-    "baseAttack": 241,
-    "baseDefense": 195,
     "types": [
       {
         "type": "Electric",
@@ -15685,7 +12896,6 @@
       {
         "nameform": "Normal",
         "protoform": "1331",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -15696,7 +12906,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1332",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -15707,7 +12916,6 @@
       {
         "nameform": "Purified",
         "protoform": "1333",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -15720,9 +12928,6 @@
   "244": {
     "name": "Entei",
     "rarity": "Ultra Rare",
-    "baseStamina": 251,
-    "baseAttack": 235,
-    "baseDefense": 171,
     "types": [
       {
         "type": "Fire",
@@ -15733,7 +12938,6 @@
       {
         "nameform": "Normal",
         "protoform": "1334",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -15744,7 +12948,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1335",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -15755,7 +12958,6 @@
       {
         "nameform": "Purified",
         "protoform": "1336",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -15768,9 +12970,6 @@
   "245": {
     "name": "Suicune",
     "rarity": "Ultra Rare",
-    "baseStamina": 225,
-    "baseAttack": 180,
-    "baseDefense": 235,
     "types": [
       {
         "type": "Water",
@@ -15781,7 +12980,6 @@
       {
         "nameform": "Normal",
         "protoform": "1337",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -15792,7 +12990,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1338",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -15803,7 +13000,6 @@
       {
         "nameform": "Purified",
         "protoform": "1339",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -15816,9 +13012,6 @@
   "246": {
     "name": "Larvitar",
     "rarity": "Very Rare",
-    "baseStamina": 137,
-    "baseAttack": 115,
-    "baseDefense": 93,
     "types": [
       {
         "type": "Rock",
@@ -15833,10 +13026,6 @@
       {
         "nameform": "Normal",
         "protoform": "313",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 115,
-        "baseDefense": 93,
         "formtypes": [
           {
             "type": "Rock",
@@ -15851,10 +13040,6 @@
       {
         "nameform": "Shadow",
         "protoform": "314",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 115,
-        "baseDefense": 93,
         "formtypes": [
           {
             "type": "Rock",
@@ -15869,10 +13054,6 @@
       {
         "nameform": "Purified",
         "protoform": "315",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 115,
-        "baseDefense": 93,
         "formtypes": [
           {
             "type": "Rock",
@@ -15889,9 +13070,6 @@
   "247": {
     "name": "Pupitar",
     "rarity": "Ultra Rare",
-    "baseStamina": 172,
-    "baseAttack": 155,
-    "baseDefense": 133,
     "types": [
       {
         "type": "Rock",
@@ -15906,10 +13084,6 @@
       {
         "nameform": "Normal",
         "protoform": "316",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 155,
-        "baseDefense": 133,
         "formtypes": [
           {
             "type": "Rock",
@@ -15924,10 +13098,6 @@
       {
         "nameform": "Shadow",
         "protoform": "317",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 155,
-        "baseDefense": 133,
         "formtypes": [
           {
             "type": "Rock",
@@ -15942,10 +13112,6 @@
       {
         "nameform": "Purified",
         "protoform": "318",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 155,
-        "baseDefense": 133,
         "formtypes": [
           {
             "type": "Rock",
@@ -15962,9 +13128,6 @@
   "248": {
     "name": "Tyranitar",
     "rarity": "Ultra Rare",
-    "baseStamina": 225,
-    "baseAttack": 251,
-    "baseDefense": 207,
     "types": [
       {
         "type": "Rock",
@@ -15979,10 +13142,6 @@
       {
         "nameform": "Normal",
         "protoform": "319",
-        "assetsform": "00",
-        "baseStamina": 225,
-        "baseAttack": 251,
-        "baseDefense": 207,
         "formtypes": [
           {
             "type": "Rock",
@@ -15997,10 +13156,6 @@
       {
         "nameform": "Shadow",
         "protoform": "320",
-        "assetsform": "00",
-        "baseStamina": 225,
-        "baseAttack": 251,
-        "baseDefense": 207,
         "formtypes": [
           {
             "type": "Rock",
@@ -16015,10 +13170,6 @@
       {
         "nameform": "Purified",
         "protoform": "321",
-        "assetsform": "00",
-        "baseStamina": 225,
-        "baseAttack": 251,
-        "baseDefense": 207,
         "formtypes": [
           {
             "type": "Rock",
@@ -16035,9 +13186,6 @@
   "249": {
     "name": "Lugia",
     "rarity": "Ultra Rare",
-    "baseStamina": 235,
-    "baseAttack": 193,
-    "baseDefense": 310,
     "types": [
       {
         "type": "Psychic",
@@ -16052,7 +13200,6 @@
       {
         "nameform": "Normal",
         "protoform": "1340",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -16067,7 +13214,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1341",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -16082,7 +13228,6 @@
       {
         "nameform": "Purified",
         "protoform": "1342",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -16099,9 +13244,6 @@
   "250": {
     "name": "Ho-Oh",
     "rarity": "Ultra Rare",
-    "baseStamina": 214,
-    "baseAttack": 239,
-    "baseDefense": 244,
     "types": [
       {
         "type": "Fire",
@@ -16116,7 +13258,6 @@
       {
         "nameform": "Normal",
         "protoform": "1343",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -16131,7 +13272,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1344",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -16146,7 +13286,6 @@
       {
         "nameform": "Purified",
         "protoform": "1345",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -16163,9 +13302,6 @@
   "251": {
     "name": "Celebi",
     "rarity": "Ultra Rare",
-    "baseStamina": 225,
-    "baseAttack": 210,
-    "baseDefense": 210,
     "types": [
       {
         "type": "Psychic",
@@ -16180,7 +13316,6 @@
       {
         "nameform": "Normal",
         "protoform": "1346",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -16195,7 +13330,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1347",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -16210,7 +13344,6 @@
       {
         "nameform": "Purified",
         "protoform": "1348",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -16227,9 +13360,6 @@
   "252":{
     "name": "Treecko",
     "rarity":"",
-    "baseStamina": 120,
-    "baseAttack": 124,
-    "baseDefense": 94,
     "types": [
       {
         "type": "Grass",
@@ -16240,7 +13370,6 @@
       {
         "nameform": "Normal",
         "protoform": "1349",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -16251,7 +13380,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1350",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -16262,7 +13390,6 @@
       {
         "nameform": "Purified",
         "protoform": "1351",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -16275,9 +13402,6 @@
   "253":{
     "name": "Grovyle",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 172,
-    "baseDefense": 120,
     "types": [
       {
         "type": "Grass",
@@ -16288,7 +13412,6 @@
       {
         "nameform": "Normal",
         "protoform": "1352",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -16299,7 +13422,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1353",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -16310,7 +13432,6 @@
       {
         "nameform": "Purified",
         "protoform": "1354",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -16323,9 +13444,6 @@
   "254":{
     "name": "Sceptile",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 223,
-    "baseDefense": 169,
     "types": [
       {
         "type": "Grass",
@@ -16336,7 +13454,6 @@
       {
         "nameform": "Normal",
         "protoform": "1355",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -16347,7 +13464,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1356",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -16358,7 +13474,6 @@
       {
         "nameform": "Purified",
         "protoform": "1357",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -16371,9 +13486,6 @@
   "255":{
     "name": "Torchic",
     "rarity":"",
-    "baseStamina": 128,
-    "baseAttack": 130,
-    "baseDefense": 87,
     "types": [
       {
         "type": "Fire",
@@ -16384,7 +13496,6 @@
       {
         "nameform": "Normal",
         "protoform": "1358",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -16395,7 +13506,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1359",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -16406,7 +13516,6 @@
       {
         "nameform": "Purified",
         "protoform": "1360",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -16419,9 +13528,6 @@
   "256":{
     "name": "Combusken",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 163,
-    "baseDefense": 115,
     "types": [
       {
         "type": "Fire",
@@ -16436,7 +13542,6 @@
       {
         "nameform": "Normal",
         "protoform": "1361",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -16447,7 +13552,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1362",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -16458,7 +13562,6 @@
       {
         "nameform": "Purified",
         "protoform": "1363",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -16471,9 +13574,6 @@
   "257":{
     "name": "Blaziken",
     "rarity":"",
-    "baseStamina": 190,
-    "baseAttack": 240,
-    "baseDefense": 141,
     "types": [
       {
         "type": "Fire",
@@ -16488,7 +13588,6 @@
       {
         "nameform": "Normal",
         "protoform": "1364",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -16503,7 +13602,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1365",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -16518,7 +13616,6 @@
       {
         "nameform": "Purified",
         "protoform": "1366",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -16535,9 +13632,6 @@
   "258":{
     "name": "Mudkip",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 126,
-    "baseDefense": 93,
     "types": [
       {
         "type": "Water",
@@ -16548,10 +13642,6 @@
       {
         "nameform": "Normal",
         "protoform": "205",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 126,
-        "baseDefense": 93,
         "formtypes": [
           {
             "type": "Water",
@@ -16562,10 +13652,6 @@
       {
         "nameform": "Shadow",
         "protoform": "206",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 126,
-        "baseDefense": 93,
         "formtypes": [
           {
             "type": "Water",
@@ -16576,10 +13662,6 @@
       {
         "nameform": "Purified",
         "protoform": "207",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 126,
-        "baseDefense": 93,
         "formtypes": [
           {
             "type": "Water",
@@ -16592,9 +13674,6 @@
   "259":{
     "name": "Marshtomp",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 156,
-    "baseDefense": 133,
     "types": [
       {
         "type": "Water",
@@ -16609,10 +13688,6 @@
       {
         "nameform": "Normal",
         "protoform": "208",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 156,
-        "baseDefense": 133,
         "formtypes": [
           {
             "type": "Water",
@@ -16627,10 +13702,6 @@
       {
         "nameform": "Shadow",
         "protoform": "209",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 156,
-        "baseDefense": 133,
         "formtypes": [
           {
             "type": "Water",
@@ -16645,10 +13716,6 @@
       {
         "nameform": "Purified",
         "protoform": "210",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 156,
-        "baseDefense": 133,
         "formtypes": [
           {
             "type": "Water",
@@ -16665,9 +13732,6 @@
   "260":{
     "name": "Swampert",
     "rarity":"",
-    "baseStamina": 225,
-    "baseAttack": 208,
-    "baseDefense": 175,
     "types": [
       {
         "type": "Water",
@@ -16682,10 +13746,6 @@
       {
         "nameform": "Normal",
         "protoform": "211",
-        "assetsform": "00",
-        "baseStamina": 225,
-        "baseAttack": 208,
-        "baseDefense": 175,
         "formtypes": [
           {
             "type": "Water",
@@ -16700,10 +13760,6 @@
       {
         "nameform": "Shadow",
         "protoform": "212",
-        "assetsform": "00",
-        "baseStamina": 225,
-        "baseAttack": 208,
-        "baseDefense": 175,
         "formtypes": [
           {
             "type": "Water",
@@ -16718,10 +13774,6 @@
       {
         "nameform": "Purified",
         "protoform": "213",
-        "assetsform": "00",
-        "baseStamina": 225,
-        "baseAttack": 208,
-        "baseDefense": 175,
         "formtypes": [
           {
             "type": "Water",
@@ -16738,9 +13790,6 @@
   "261":{
     "name": "Poochyena",
     "rarity":"",
-    "baseStamina": 111,
-    "baseAttack": 96,
-    "baseDefense": 61,
     "types": [
       {
         "type": "Dark",
@@ -16751,7 +13800,6 @@
       {
         "nameform": "Normal",
         "protoform": "1367",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -16762,7 +13810,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1368",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -16773,7 +13820,6 @@
       {
         "nameform": "Purified",
         "protoform": "1369",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -16786,9 +13832,6 @@
   "262":{
     "name": "Mightyena",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 171,
-    "baseDefense": 132,
     "types": [
       {
         "type": "Dark",
@@ -16799,7 +13842,6 @@
       {
         "nameform": "Normal",
         "protoform": "1370",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -16810,7 +13852,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1371",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -16821,7 +13862,6 @@
       {
         "nameform": "Purified",
         "protoform": "1372",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -16834,9 +13874,6 @@
   "263":{
     "name": "Zigzagoon",
     "rarity":"",
-    "baseStamina": 116,
-    "baseAttack": 58,
-    "baseDefense": 80,
     "types": [
       {
         "type": "Normal",
@@ -16847,10 +13884,6 @@
       {
         "nameform": "Normal",
         "protoform": "945",
-        "assetsform": "00",
-        "baseStamina": 116,
-        "baseAttack": 58,
-        "baseDefense": 80,
         "formtypes": [
           {
             "type": "Normal",
@@ -16861,10 +13894,6 @@
       {
         "nameform": "Galarian",
         "protoform": "946",
-        "assetsform": "00",
-        "baseStamina": 254,
-        "baseAttack": 58,
-        "baseDefense": 80,
         "formtypes": [
           {
             "type": "Dark",
@@ -16879,7 +13908,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1373",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -16890,7 +13918,6 @@
       {
         "nameform": "Purified",
         "protoform": "1374",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -16903,9 +13930,6 @@
   "264":{
     "name": "Linoone",
     "rarity":"",
-    "baseStamina": 186,
-    "baseAttack": 142,
-    "baseDefense": 128,
     "types": [
       {
         "type": "Normal",
@@ -16916,10 +13940,6 @@
       {
         "nameform": "Normal",
         "protoform": "947",
-        "assetsform": "00",
-        "baseStamina": 186,
-        "baseAttack": 142,
-        "baseDefense": 128,
         "formtypes": [
           {
             "type": "Normal",
@@ -16930,10 +13950,6 @@
       {
         "nameform": "Galarian",
         "protoform": "948",
-        "assetsform": "00",
-        "baseStamina": 186,
-        "baseAttack": 142,
-        "baseDefense": 128,
         "formtypes": [
           {
             "type": "Dark",
@@ -16948,7 +13964,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1375",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -16959,7 +13974,6 @@
       {
         "nameform": "Purified",
         "protoform": "1376",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -16972,9 +13986,6 @@
   "265":{
     "name": "Wurmple",
     "rarity":"",
-    "baseStamina": 128,
-    "baseAttack": 75,
-    "baseDefense": 59,
     "types": [
       {
         "type": "Bug",
@@ -16985,10 +13996,6 @@
       {
         "nameform": "Normal",
         "protoform": "600",
-        "assetsform": "00",
-        "baseStamina": 128,
-        "baseAttack": 75,
-        "baseDefense": 59,
         "formtypes": [
           {
             "type": "Bug",
@@ -16999,10 +14006,6 @@
       {
         "nameform": "No Evolve",
         "protoform": "601",
-        "assetsform": "00",
-        "baseStamina": 128,
-        "baseAttack": 75,
-        "baseDefense": 59,
         "formtypes": [
           {
             "type": "Bug",
@@ -17013,7 +14016,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1377",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -17024,7 +14026,6 @@
       {
         "nameform": "Purified",
         "protoform": "1378",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -17037,9 +14038,6 @@
   "266":{
     "name": "Silcoon",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 60,
-    "baseDefense": 77,
     "types": [
       {
         "type": "Bug",
@@ -17050,7 +14048,6 @@
       {
         "nameform": "Normal",
         "protoform": "1379",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -17061,7 +14058,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1380",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -17072,7 +14068,6 @@
       {
         "nameform": "Purified",
         "protoform": "1381",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -17085,9 +14080,6 @@
   "267":{
     "name": "Beautifly",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 189,
-    "baseDefense": 98,
     "types": [
       {
         "type": "Bug",
@@ -17102,7 +14094,6 @@
       {
         "nameform": "Normal",
         "protoform": "1379",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -17117,7 +14108,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1380",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -17132,7 +14122,6 @@
       {
         "nameform": "Purified",
         "protoform": "1381",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -17149,9 +14138,6 @@
   "268":{
     "name": "Cascoon",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 60,
-    "baseDefense": 77,
     "types": [
       {
         "type": "Bug",
@@ -17162,7 +14148,6 @@
       {
         "nameform": "Normal",
         "protoform": "1385",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -17173,7 +14158,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1386",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -17184,7 +14168,6 @@
       {
         "nameform": "Purified",
         "protoform": "1387",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -17197,9 +14180,6 @@
   "269":{
     "name": "Dustox",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 98,
-    "baseDefense": 162,
     "types": [
       {
         "type": "Bug",
@@ -17214,7 +14194,6 @@
       {
         "nameform": "Normal",
         "protoform": "1388",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -17229,7 +14208,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1389",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -17244,7 +14222,6 @@
       {
         "nameform": "Purified",
         "protoform": "1390",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -17261,9 +14238,6 @@
   "270":{
     "name": "Lotad",
     "rarity":"",
-    "baseStamina": 120,
-    "baseAttack": 71,
-    "baseDefense": 77,
     "types": [
       {
         "type": "Water",
@@ -17278,7 +14252,6 @@
       {
         "nameform": "Normal",
         "protoform": "1391",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -17293,7 +14266,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1392",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -17308,7 +14280,6 @@
       {
         "nameform": "Purified",
         "protoform": "1393",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -17325,9 +14296,6 @@
   "271":{
     "name": "Lombre",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 112,
-    "baseDefense": 119,
     "types": [
       {
         "type": "Water",
@@ -17342,7 +14310,6 @@
       {
         "nameform": "Normal",
         "protoform": "1394",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -17357,7 +14324,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1395",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -17372,7 +14338,6 @@
       {
         "nameform": "Purified",
         "protoform": "1396",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -17389,9 +14354,6 @@
   "272":{
     "name": "Ludicolo",
     "rarity":"",
-    "baseStamina": 190,
-    "baseAttack": 173,
-    "baseDefense": 176,
     "types": [
       {
         "type": "Water",
@@ -17406,7 +14368,6 @@
       {
         "nameform": "Normal",
         "protoform": "1397",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -17421,7 +14382,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1398",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -17436,7 +14396,6 @@
       {
         "nameform": "Purified",
         "protoform": "1399",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -17453,9 +14412,6 @@
   "273":{
     "name": "Seedot",
     "rarity":"",
-    "baseStamina": 120,
-    "baseAttack": 71,
-    "baseDefense": 77,
     "types": [
       {
         "type": "Grass",
@@ -17466,10 +14422,6 @@
       {
         "nameform": "Normal",
         "protoform": "625",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 71,
-        "baseDefense": 77,
         "formtypes": [
           {
             "type": "Grass",
@@ -17480,10 +14432,6 @@
       {
         "nameform": "Shadow",
         "protoform": "626",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 71,
-        "baseDefense": 77,
         "formtypes": [
           {
             "type": "Grass",
@@ -17494,10 +14442,6 @@
       {
         "nameform": "Purified",
         "protoform": "627",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 71,
-        "baseDefense": 77,
         "formtypes": [
           {
             "type": "Grass",
@@ -17510,9 +14454,6 @@
   "274":{
     "name": "Nuzleaf",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 134,
-    "baseDefense": 78,
     "types": [
       {
         "type": "Grass",
@@ -17527,10 +14468,6 @@
       {
         "nameform": "Normal",
         "protoform": "628",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 134,
-        "baseDefense": 78,
         "formtypes": [
           {
             "type": "Grass",
@@ -17545,10 +14482,6 @@
       {
         "nameform": "Shadow",
         "protoform": "629",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 134,
-        "baseDefense": 78,
         "formtypes": [
           {
             "type": "Grass",
@@ -17563,10 +14496,6 @@
       {
         "nameform": "Purified",
         "protoform": "630",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 134,
-        "baseDefense": 78,
         "formtypes": [
           {
             "type": "Grass",
@@ -17583,9 +14512,6 @@
   "275":{
     "name": "Shiftry",
     "rarity":"",
-    "baseStamina": 207,
-    "baseAttack": 200,
-    "baseDefense": 121,
     "types": [
       {
         "type": "Grass",
@@ -17600,10 +14526,6 @@
       {
         "nameform": "Normal",
         "protoform": "631",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 200,
-        "baseDefense": 121,
         "formtypes": [
           {
             "type": "Grass",
@@ -17618,10 +14540,6 @@
       {
         "nameform": "Shadow",
         "protoform": "632",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 200,
-        "baseDefense": 121,
         "formtypes": [
           {
             "type": "Grass",
@@ -17636,10 +14554,6 @@
       {
         "nameform": "Purified",
         "protoform": "633",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 200,
-        "baseDefense": 121,
         "formtypes": [
           {
             "type": "Grass",
@@ -17656,9 +14570,6 @@
   "276":{
     "name": "Taillow",
     "rarity":"",
-    "baseStamina": 120,
-    "baseAttack": 106,
-    "baseDefense": 61,
     "types": [
       {
         "type": "Normal",
@@ -17673,7 +14584,6 @@
       {
         "nameform": "Normal",
         "protoform": "1400",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -17688,7 +14598,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1401",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -17703,7 +14612,6 @@
       {
         "nameform": "Purified",
         "protoform": "1402",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -17720,9 +14628,6 @@
   "277":{
     "name": "Swellow",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 185,
-    "baseDefense": 124,
     "types": [
       {
         "type": "Normal",
@@ -17737,7 +14642,6 @@
       {
         "nameform": "Normal",
         "protoform": "1403",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -17752,7 +14656,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1404",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -17767,7 +14670,6 @@
       {
         "nameform": "Purified",
         "protoform": "1405",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -17784,9 +14686,6 @@
   "278":{
     "name": "Wingull",
     "rarity":"",
-    "baseStamina": 120,
-    "baseAttack": 106,
-    "baseDefense": 61,
     "types": [
       {
         "type": "Water",
@@ -17801,7 +14700,6 @@
       {
         "nameform": "Normal",
         "protoform": "1406",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -17816,7 +14714,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1407",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -17831,7 +14728,6 @@
       {
         "nameform": "Purified",
         "protoform": "1408",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -17848,9 +14744,6 @@
   "279":{
     "name": "Pelipper",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 175,
-    "baseDefense": 174,
     "types": [
       {
         "type": "Water",
@@ -17865,7 +14758,6 @@
       {
         "nameform": "Normal",
         "protoform": "1409",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -17880,7 +14772,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1410",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -17895,7 +14786,6 @@
       {
         "nameform": "Purified",
         "protoform": "1411",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -17912,9 +14802,6 @@
   "280":{
     "name": "Ralts",
     "rarity":"",
-    "baseStamina": 99,
-    "baseAttack": 79,
-    "baseDefense": 59,
     "types": [
       {
         "type": "Psychic",
@@ -17929,10 +14816,6 @@
       {
         "nameform": "Normal",
         "protoform": "292",
-        "assetsform": "00",
-        "baseStamina": 99,
-        "baseAttack": 79,
-        "baseDefense": 59,
         "formtypes": [
           {
             "type": "Psychic",
@@ -17947,10 +14830,6 @@
       {
         "nameform": "Shadow",
         "protoform": "293",
-        "assetsform": "00",
-        "baseStamina": 99,
-        "baseAttack": 79,
-        "baseDefense": 59,
         "formtypes": [
           {
             "type": "Psychic",
@@ -17965,10 +14844,6 @@
       {
         "nameform": "Purified",
         "protoform": "294",
-        "assetsform": "00",
-        "baseStamina": 99,
-        "baseAttack": 79,
-        "baseDefense": 59,
         "formtypes": [
           {
             "type": "Psychic",
@@ -17985,9 +14860,6 @@
   "281":{
     "name": "Kirlia",
     "rarity":"",
-    "baseStamina": 116,
-    "baseAttack": 117,
-    "baseDefense": 90,
     "types": [
       {
         "type": "Psychic",
@@ -18002,10 +14874,6 @@
       {
         "nameform": "Normal",
         "protoform": "295",
-        "assetsform": "00",
-        "baseStamina": 116,
-        "baseAttack": 117,
-        "baseDefense": 90,
         "formtypes": [
           {
             "type": "Psychic",
@@ -18020,10 +14888,6 @@
       {
         "nameform": "Shadow",
         "protoform": "296",
-        "assetsform": "00",
-        "baseStamina": 116,
-        "baseAttack": 117,
-        "baseDefense": 90,
         "formtypes": [
           {
             "type": "Psychic",
@@ -18038,10 +14902,6 @@
       {
         "nameform": "Purified",
         "protoform": "297",
-        "assetsform": "00",
-        "baseStamina": 116,
-        "baseAttack": 117,
-        "baseDefense": 90,
         "formtypes": [
           {
             "type": "Psychic",
@@ -18058,9 +14918,6 @@
   "282":{
     "name": "Gardevoir",
     "rarity":"",
-    "baseStamina": 169,
-    "baseAttack": 237,
-    "baseDefense": 195,
     "types": [
       {
         "type": "Psychic",
@@ -18075,10 +14932,6 @@
       {
         "nameform": "Normal",
         "protoform": "298",
-        "assetsform": "00",
-        "baseStamina": 169,
-        "baseAttack": 237,
-        "baseDefense": 195,
         "formtypes": [
           {
             "type": "Psychic",
@@ -18093,10 +14946,6 @@
       {
         "nameform": "Shadow",
         "protoform": "299",
-        "assetsform": "00",
-        "baseStamina": 169,
-        "baseAttack": 237,
-        "baseDefense": 195,
         "formtypes": [
           {
             "type": "Psychic",
@@ -18111,10 +14960,6 @@
       {
         "nameform": "Purified",
         "protoform": "300",
-        "assetsform": "00",
-        "baseStamina": 169,
-        "baseAttack": 237,
-        "baseDefense": 195,
         "formtypes": [
           {
             "type": "Psychic",
@@ -18131,9 +14976,6 @@
   "283":{
     "name": "Surskit",
     "rarity":"",
-    "baseStamina": 120,
-    "baseAttack": 93,
-    "baseDefense": 87,
     "types": [
       {
         "type": "Bug",
@@ -18148,7 +14990,6 @@
       {
         "nameform": "Normal",
         "protoform": "1412",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -18163,7 +15004,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1413",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -18178,7 +15018,6 @@
       {
         "nameform": "Purified",
         "protoform": "1414",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -18195,9 +15034,6 @@
   "284":{
     "name": "Masquerain",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 192,
-    "baseDefense": 150,
     "types": [
       {
         "type": "Bug",
@@ -18212,7 +15048,6 @@
       {
         "nameform": "Normal",
         "protoform": "1415",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -18227,7 +15062,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1416",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -18242,7 +15076,6 @@
       {
         "nameform": "Purified",
         "protoform": "1417",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -18259,9 +15092,6 @@
   "285":{
     "name": "Shroomish",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 74,
-    "baseDefense": 110,
     "types": [
       {
         "type": "Grass",
@@ -18272,7 +15102,6 @@
       {
         "nameform": "Normal",
         "protoform": "1418",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -18283,7 +15112,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1419",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -18294,7 +15122,6 @@
       {
         "nameform": "Purified",
         "protoform": "1420",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -18307,9 +15134,6 @@
   "286":{
     "name": "Breloom",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 241,
-    "baseDefense": 144,
     "types": [
       {
         "type": "Grass",
@@ -18324,7 +15148,6 @@
       {
         "nameform": "Normal",
         "protoform": "1421",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -18339,7 +15162,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1422",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -18354,7 +15176,6 @@
       {
         "nameform": "Purified",
         "protoform": "1423",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -18371,9 +15192,6 @@
   "287":{
     "name": "Slakoth",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 104,
-    "baseDefense": 92,
     "types": [
       {
         "type": "Normal",
@@ -18384,7 +15202,6 @@
       {
         "nameform": "Normal",
         "protoform": "1424",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -18395,7 +15212,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1425",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -18406,7 +15222,6 @@
       {
         "nameform": "Purified",
         "protoform": "1426",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -18419,9 +15234,6 @@
   "288":{
     "name": "Vigoroth",
     "rarity":"",
-    "baseStamina": 190,
-    "baseAttack": 159,
-    "baseDefense": 145,
     "types": [
       {
         "type": "Normal",
@@ -18432,7 +15244,6 @@
       {
         "nameform": "Normal",
         "protoform": "1427",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -18443,7 +15254,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1428",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -18454,7 +15264,6 @@
       {
         "nameform": "Purified",
         "protoform": "1429",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -18467,9 +15276,6 @@
   "289":{
     "name": "Slaking",
     "rarity":"",
-    "baseStamina": 284,
-    "baseAttack": 290,
-    "baseDefense": 166,
     "types": [
       {
         "type": "Normal",
@@ -18480,7 +15286,6 @@
       {
         "nameform": "Normal",
         "protoform": "1430",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -18491,7 +15296,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1431",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -18502,7 +15306,6 @@
       {
         "nameform": "Purified",
         "protoform": "1432",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -18515,9 +15318,6 @@
   "290":{
     "name": "Nincada",
     "rarity":"",
-    "baseStamina": 104,
-    "baseAttack": 80,
-    "baseDefense": 126,
     "types": [
       {
         "type": "Bug",
@@ -18532,7 +15332,6 @@
       {
         "nameform": "Normal",
         "protoform": "1433",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -18547,7 +15346,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1434",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -18562,7 +15360,6 @@
       {
         "nameform": "Purified",
         "protoform": "1435",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -18579,9 +15376,6 @@
   "291":{
     "name": "Ninjask",
     "rarity":"",
-    "baseStamina": 156,
-    "baseAttack": 199,
-    "baseDefense": 112,
     "types": [
       {
         "type": "Bug",
@@ -18596,7 +15390,6 @@
       {
         "nameform": "Normal",
         "protoform": "1436",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -18611,7 +15404,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1437",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -18626,7 +15418,6 @@
       {
         "nameform": "Purified",
         "protoform": "1438",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -18643,9 +15434,6 @@
   "292":{
     "name": "Shedinja",
     "rarity":"",
-    "baseStamina": 1,
-    "baseAttack": 153,
-    "baseDefense": 73,
     "types": [
       {
         "type": "Bug",
@@ -18660,7 +15448,6 @@
       {
         "nameform": "Normal",
         "protoform": "1439",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -18675,7 +15462,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1440",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -18690,7 +15476,6 @@
       {
         "nameform": "Purified",
         "protoform": "1441",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -18707,9 +15492,6 @@
   "293":{
     "name": "Whismur",
     "rarity":"",
-    "baseStamina": 162,
-    "baseAttack": 92,
-    "baseDefense": 42,
     "types": [
       {
         "type": "Normal",
@@ -18720,7 +15502,6 @@
       {
         "nameform": "Normal",
         "protoform": "1442",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -18731,7 +15512,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1443",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -18742,7 +15522,6 @@
       {
         "nameform": "Purified",
         "protoform": "1444",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -18755,9 +15534,6 @@
   "294":{
     "name": "Loudred",
     "rarity":"",
-    "baseStamina": 197,
-    "baseAttack": 134,
-    "baseDefense": 81,
     "types": [
       {
         "type": "Normal",
@@ -18768,7 +15544,6 @@
       {
         "nameform": "Normal",
         "protoform": "1445",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -18779,7 +15554,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1446",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -18790,7 +15564,6 @@
       {
         "nameform": "Purified",
         "protoform": "1447",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -18803,9 +15576,6 @@
   "295":{
     "name": "Exploud",
     "rarity":"",
-    "baseStamina": 232,
-    "baseAttack": 179,
-    "baseDefense": 137,
     "types": [
       {
         "type": "Normal",
@@ -18816,7 +15586,6 @@
       {
         "nameform": "Normal",
         "protoform": "1448",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -18827,7 +15596,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1449",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -18838,7 +15606,6 @@
       {
         "nameform": "Purified",
         "protoform": "1450",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -18851,9 +15618,6 @@
   "296":{
     "name": "Makuhita",
     "rarity":"",
-    "baseStamina": 176,
-    "baseAttack": 99,
-    "baseDefense": 54,
     "types": [
       {
         "type": "Fighting",
@@ -18864,7 +15628,6 @@
       {
         "nameform": "Normal",
         "protoform": "1451",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -18875,7 +15638,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1452",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -18886,7 +15648,6 @@
       {
         "nameform": "Purified",
         "protoform": "1453",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -18899,9 +15660,6 @@
   "297":{
     "name": "Hariyama",
     "rarity":"",
-    "baseStamina": 302,
-    "baseAttack": 209,
-    "baseDefense": 114,
     "types": [
       {
         "type": "Fighting",
@@ -18912,7 +15670,6 @@
       {
         "nameform": "Normal",
         "protoform": "1454",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -18923,7 +15680,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1455",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -18934,7 +15690,6 @@
       {
         "nameform": "Purified",
         "protoform": "1456",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -18947,9 +15702,6 @@
   "298":{
     "name": "Azurill",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 36,
-    "baseDefense": 71,
     "types": [
       {
         "type": "Normal",
@@ -18964,7 +15716,6 @@
       {
         "nameform": "Normal",
         "protoform": "1457",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -18979,7 +15730,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1458",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -18994,7 +15744,6 @@
       {
         "nameform": "Purified",
         "protoform": "1459",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -19011,9 +15760,6 @@
   "299":{
     "name": "Nosepass",
     "rarity":"",
-    "baseStamina": 102,
-    "baseAttack": 82,
-    "baseDefense": 215,
     "types": [
       {
         "type": "Rock",
@@ -19024,7 +15770,6 @@
       {
         "nameform": "Normal",
         "protoform": "1460",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -19035,7 +15780,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1461",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -19046,7 +15790,6 @@
       {
         "nameform": "Purified",
         "protoform": "1462",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -19059,9 +15802,6 @@
   "300":{
     "name": "Skitty",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 84,
-    "baseDefense": 79,
     "types": [
       {
         "type": "Normal",
@@ -19072,7 +15812,6 @@
       {
         "nameform": "Normal",
         "protoform": "1463",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -19083,7 +15822,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1464",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -19094,7 +15832,6 @@
       {
         "nameform": "Purified",
         "protoform": "1465",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -19107,9 +15844,6 @@
   "301":{
     "name": "Delcatty",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 132,
-    "baseDefense": 127,
     "types": [
       {
         "type": "Normal",
@@ -19120,7 +15854,6 @@
       {
         "nameform": "Normal",
         "protoform": "1466",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -19131,7 +15864,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1467",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -19142,7 +15874,6 @@
       {
         "nameform": "Purified",
         "protoform": "1468",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -19155,9 +15886,6 @@
   "302":{
     "name": "Sableye",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 141,
-    "baseDefense": 136,
     "types": [
       {
         "type": "Dark",
@@ -19172,10 +15900,6 @@
       {
         "nameform": "Normal",
         "protoform": "923",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 141,
-        "baseDefense": 136,
         "formtypes": [
           {
             "type": "Dark",
@@ -19190,10 +15914,6 @@
       {
         "nameform": "Shadow",
         "protoform": "924",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 141,
-        "baseDefense": 136,
         "formtypes": [
           {
             "type": "Dark",
@@ -19208,10 +15928,20 @@
       {
         "nameform": "Purified",
         "protoform": "925",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 141,
-        "baseDefense": 136,
+        "formtypes": [
+          {
+            "type": "Dark",
+            "color": "#707070"
+          },
+          {
+            "type": "Ghost",
+            "color": "#705898"
+          }
+        ]
+      },
+      {
+        "nameform": "Fall 2020 Deprecated",
+        "protoform": "2666",
         "formtypes": [
           {
             "type": "Dark",
@@ -19226,10 +15956,6 @@
       {
         "nameform": "Fall 2020",
         "protoform": "2668",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 141,
-        "baseDefense": 136,
         "formtypes": [
           {
             "type": "Dark",
@@ -19246,9 +15972,6 @@
   "303":{
     "name": "Mawile",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 155,
-    "baseDefense": 141,
     "types": [
       {
         "type": "Steel",
@@ -19263,10 +15986,6 @@
       {
         "nameform": "Normal",
         "protoform": "833",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 155,
-        "baseDefense": 141,
         "formtypes": [
           {
             "type": "Steel",
@@ -19281,10 +16000,6 @@
       {
         "nameform": "Shadow",
         "protoform": "834",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 155,
-        "baseDefense": 141,
         "formtypes": [
           {
             "type": "Steel",
@@ -19299,10 +16014,6 @@
       {
         "nameform": "Purified",
         "protoform": "835",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 155,
-        "baseDefense": 141,
         "formtypes": [
           {
             "type": "Steel",
@@ -19319,9 +16030,6 @@
   "304":{
     "name": "Aron",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 121,
-    "baseDefense": 141,
     "types": [
       {
         "type": "Steel",
@@ -19336,7 +16044,6 @@
       {
         "nameform": "Normal",
         "protoform": "1469",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -19351,7 +16058,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1470",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -19366,7 +16072,6 @@
       {
         "nameform": "Purified",
         "protoform": "1471",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -19383,9 +16088,6 @@
   "305":{
     "name": "Lairon",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 158,
-    "baseDefense": 198,
     "types": [
       {
         "type": "Steel",
@@ -19400,7 +16102,6 @@
       {
         "nameform": "Normal",
         "protoform": "1472",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -19415,7 +16116,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1473",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -19430,7 +16130,6 @@
       {
         "nameform": "Purified",
         "protoform": "1474",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -19447,9 +16146,6 @@
   "306":{
     "name": "Aggron",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 198,
-    "baseDefense": 257,
     "types": [
       {
         "type": "Steel",
@@ -19464,7 +16160,6 @@
       {
         "nameform": "Normal",
         "protoform": "1475",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -19479,7 +16174,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1476",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -19494,7 +16188,6 @@
       {
         "nameform": "Purified",
         "protoform": "1477",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -19511,9 +16204,6 @@
   "307":{
     "name": "Meditite",
     "rarity":"",
-    "baseStamina": 102,
-    "baseAttack": 78,
-    "baseDefense": 107,
     "types": [
       {
         "type": "Fighting",
@@ -19528,7 +16218,6 @@
       {
         "nameform": "Normal",
         "protoform": "1478",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -19543,7 +16232,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1479",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -19558,7 +16246,6 @@
       {
         "nameform": "Purified",
         "protoform": "1480",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -19575,9 +16262,6 @@
   "308":{
     "name": "Medicham",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 121,
-    "baseDefense": 152,
     "types": [
       {
         "type": "Fighting",
@@ -19592,7 +16276,6 @@
       {
         "nameform": "Normal",
         "protoform": "1481",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -19607,7 +16290,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1482",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -19622,7 +16304,6 @@
       {
         "nameform": "Purified",
         "protoform": "1483",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -19639,9 +16320,6 @@
   "309":{
     "name": "Electrike",
     "rarity":"",
-    "baseStamina": 120,
-    "baseAttack": 123,
-    "baseDefense": 78,
     "types": [
       {
         "type": "Electric",
@@ -19652,7 +16330,6 @@
       {
         "nameform": "Normal",
         "protoform": "1484",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -19663,7 +16340,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1485",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -19674,7 +16350,6 @@
       {
         "nameform": "Purified",
         "protoform": "1486",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -19687,9 +16362,6 @@
   "310":{
     "name": "Manectric",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 215,
-    "baseDefense": 127,
     "types": [
       {
         "type": "Electric",
@@ -19700,7 +16372,6 @@
       {
         "nameform": "Normal",
         "protoform": "1487",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -19711,7 +16382,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1488",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -19722,7 +16392,6 @@
       {
         "nameform": "Purified",
         "protoform": "1489",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -19735,9 +16404,6 @@
   "311":{
     "name": "Plusle",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 167,
-    "baseDefense": 129,
     "types": [
       {
         "type": "Electric",
@@ -19748,7 +16414,6 @@
       {
         "nameform": "Normal",
         "protoform": "1490",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -19759,7 +16424,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1491",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -19770,7 +16434,6 @@
       {
         "nameform": "Purified",
         "protoform": "1492",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -19783,9 +16446,6 @@
   "312":{
     "name": "Minun",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 147,
-    "baseDefense": 150,
     "types": [
       {
         "type": "Electric",
@@ -19796,7 +16456,6 @@
       {
         "nameform": "Normal",
         "protoform": "1493",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -19807,7 +16466,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1494",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -19818,7 +16476,6 @@
       {
         "nameform": "Purified",
         "protoform": "1495",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -19831,9 +16488,6 @@
   "313":{
     "name": "Volbeat",
     "rarity":"",
-    "baseStamina": 163,
-    "baseAttack": 143,
-    "baseDefense": 166,
     "types": [
       {
         "type": "Bug",
@@ -19844,7 +16498,6 @@
       {
         "nameform": "Normal",
         "protoform": "1496",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -19855,7 +16508,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1497",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -19866,7 +16518,6 @@
       {
         "nameform": "Purified",
         "protoform": "1498",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -19879,9 +16530,6 @@
   "314":{
     "name": "Illumise",
     "rarity":"",
-    "baseStamina": 163,
-    "baseAttack": 143,
-    "baseDefense": 166,
     "types": [
       {
         "type": "Bug",
@@ -19892,7 +16540,6 @@
       {
         "nameform": "Normal",
         "protoform": "1499",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -19903,7 +16550,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1500",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -19914,7 +16560,6 @@
       {
         "nameform": "Purified",
         "protoform": "1501",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -19927,9 +16572,6 @@
   "315":{
     "name": "Roselia",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 186,
-    "baseDefense": 131,
     "types": [
       {
         "type": "Grass",
@@ -19944,7 +16586,6 @@
       {
         "nameform": "Normal",
         "protoform": "1502",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -19959,7 +16600,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1503",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -19974,7 +16614,6 @@
       {
         "nameform": "Purified",
         "protoform": "1504",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -19991,9 +16630,6 @@
   "316":{
     "name": "Gulpin",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 80,
-    "baseDefense": 99,
     "types": [
       {
         "type": "Poison",
@@ -20004,7 +16640,6 @@
       {
         "nameform": "Normal",
         "protoform": "1505",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Poison",
@@ -20015,7 +16650,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1506",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Poison",
@@ -20026,7 +16660,6 @@
       {
         "nameform": "Purified",
         "protoform": "1507",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Poison",
@@ -20039,9 +16672,6 @@
   "317":{
     "name": "Swalot",
     "rarity":"",
-    "baseStamina": 225,
-    "baseAttack": 140,
-    "baseDefense": 159,
     "types": [
       {
         "type": "Poison",
@@ -20052,7 +16682,6 @@
       {
         "nameform": "Normal",
         "protoform": "1508",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Poison",
@@ -20063,7 +16692,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1509",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Poison",
@@ -20074,7 +16702,6 @@
       {
         "nameform": "Purified",
         "protoform": "1510",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Poison",
@@ -20087,9 +16714,6 @@
   "318":{
     "name": "Carvanha",
     "rarity":"",
-    "baseStamina": 128,
-    "baseAttack": 171,
-    "baseDefense": 39,
     "types": [
       {
         "type": "Water",
@@ -20104,10 +16728,6 @@
       {
         "nameform": "Normal",
         "protoform": "734",
-        "assetsform": "00",
-        "baseStamina": 128,
-        "baseAttack": 171,
-        "baseDefense": 39,
         "formtypes": [
           {
             "type": "Water",
@@ -20122,10 +16742,6 @@
       {
         "nameform": "Shadow",
         "protoform": "735",
-        "assetsform": "00",
-        "baseStamina": 128,
-        "baseAttack": 171,
-        "baseDefense": 39,
         "formtypes": [
           {
             "type": "Water",
@@ -20140,10 +16756,6 @@
       {
         "nameform": "Purified",
         "protoform": "736",
-        "assetsform": "00",
-        "baseStamina": 128,
-        "baseAttack": 171,
-        "baseDefense": 39,
         "formtypes": [
           {
             "type": "Water",
@@ -20160,9 +16772,6 @@
   "319":{
     "name": "Sharpedo",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 243,
-    "baseDefense": 83,
     "types": [
       {
         "type": "Water",
@@ -20177,10 +16786,6 @@
       {
         "nameform": "Normal",
         "protoform": "737",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 243,
-        "baseDefense": 83,
         "formtypes": [
           {
             "type": "Water",
@@ -20195,10 +16800,6 @@
       {
         "nameform": "Shadow",
         "protoform": "738",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 243,
-        "baseDefense": 83,
         "formtypes": [
           {
             "type": "Water",
@@ -20213,10 +16814,6 @@
       {
         "nameform": "Purified",
         "protoform": "739",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 243,
-        "baseDefense": 83,
         "formtypes": [
           {
             "type": "Water",
@@ -20233,9 +16830,6 @@
   "320":{
     "name": "Wailmer",
     "rarity":"",
-    "baseStamina": 277,
-    "baseAttack": 136,
-    "baseDefense": 68,
     "types": [
       {
         "type": "Water",
@@ -20246,7 +16840,6 @@
       {
         "nameform": "Normal",
         "protoform": "1511",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -20257,7 +16850,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1512",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -20268,7 +16860,6 @@
       {
         "nameform": "Purified",
         "protoform": "1513",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -20281,9 +16872,6 @@
   "321":{
     "name": "Wailord",
     "rarity":"",
-    "baseStamina": 347,
-    "baseAttack": 175,
-    "baseDefense": 87,
     "types": [
       {
         "type": "Water",
@@ -20294,7 +16882,6 @@
       {
         "nameform": "Normal",
         "protoform": "1514",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -20305,7 +16892,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1515",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -20316,7 +16902,6 @@
       {
         "nameform": "Purified",
         "protoform": "1516",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -20329,9 +16914,6 @@
   "322":{
     "name": "Numel",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 119,
-    "baseDefense": 79,
     "types": [
       {
         "type": "Fire",
@@ -20346,7 +16928,6 @@
       {
         "nameform": "Normal",
         "protoform": "1517",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -20361,7 +16942,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1518",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -20376,7 +16956,6 @@
       {
         "nameform": "Purified",
         "protoform": "1518",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -20393,9 +16972,6 @@
   "323":{
     "name": "Camerupt",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 194,
-    "baseDefense": 136,
     "types": [
       {
         "type": "Fire",
@@ -20410,7 +16986,6 @@
       {
         "nameform": "Normal",
         "protoform": "1520",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -20425,7 +17000,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1521",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -20440,7 +17014,6 @@
       {
         "nameform": "Purified",
         "protoform": "1522",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -20457,9 +17030,6 @@
   "324":{
     "name": "Torkoal",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 151,
-    "baseDefense": 203,
     "types": [
       {
         "type": "Fire",
@@ -20470,7 +17040,6 @@
       {
         "nameform": "Normal",
         "protoform": "1523",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -20481,7 +17050,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1524",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -20492,7 +17060,6 @@
       {
         "nameform": "Purified",
         "protoform": "1525",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -20505,9 +17072,6 @@
   "325":{
     "name": "Spoink",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 125,
-    "baseDefense": 122,
     "types": [
       {
         "type": "Psychic",
@@ -20518,7 +17082,6 @@
       {
         "nameform": "Normal",
         "protoform": "1526",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -20529,7 +17092,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1527",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -20540,7 +17102,6 @@
       {
         "nameform": "Purified",
         "protoform": "1528",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -20553,9 +17114,6 @@
   "326":{
     "name": "Grumpig",
     "rarity":"",
-    "baseStamina": 190,
-    "baseAttack": 171,
-    "baseDefense": 188,
     "types": [
       {
         "type": "Psychic",
@@ -20566,7 +17124,6 @@
       {
         "nameform": "Normal",
         "protoform": "1529",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -20577,7 +17134,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1530",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -20588,7 +17144,6 @@
       {
         "nameform": "Purified",
         "protoform": "1531",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -20601,9 +17156,6 @@
   "327":{
     "name": "Spinda",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 116,
-    "baseDefense": 116,
     "types": [
       {
         "type": "Normal",
@@ -20614,10 +17166,6 @@
       {
         "nameform": "1",
         "protoform": "37",
-        "assetsform": "11",
-        "baseStamina": 155,
-        "baseAttack": 116,
-        "baseDefense": 116,
         "formtypes": [
           {
             "type": "Normal",
@@ -20628,10 +17176,6 @@
       {
         "nameform": "2",
         "protoform": "38",
-        "assetsform": "12",
-        "baseStamina": 155,
-        "baseAttack": 116,
-        "baseDefense": 116,
         "formtypes": [
           {
             "type": "Normal",
@@ -20642,10 +17186,6 @@
       {
         "nameform": "3",
         "protoform": "39",
-        "assetsform": "13",
-        "baseStamina": 155,
-        "baseAttack": 116,
-        "baseDefense": 116,
         "formtypes": [
           {
             "type": "Normal",
@@ -20656,10 +17196,6 @@
       {
         "nameform": "4",
         "protoform": "40",
-        "assetsform": "14",
-        "baseStamina": 155,
-        "baseAttack": 116,
-        "baseDefense": 116,
         "formtypes": [
           {
             "type": "Normal",
@@ -20670,10 +17206,6 @@
       {
         "nameform": "5",
         "protoform": "41",
-        "assetsform": "15",
-        "baseStamina": 155,
-        "baseAttack": 116,
-        "baseDefense": 116,
         "formtypes": [
           {
             "type": "Normal",
@@ -20684,10 +17216,6 @@
       {
         "nameform": "6",
         "protoform": "42",
-        "assetsform": "16",
-        "baseStamina": 155,
-        "baseAttack": 116,
-        "baseDefense": 116,
         "formtypes": [
           {
             "type": "Normal",
@@ -20698,10 +17226,6 @@
       {
         "nameform": "7",
         "protoform": "43",
-        "assetsform": "17",
-        "baseStamina": 155,
-        "baseAttack": 116,
-        "baseDefense": 116,
         "formtypes": [
           {
             "type": "Normal",
@@ -20712,10 +17236,6 @@
       {
         "nameform": "8",
         "protoform": "44",
-        "assetsform": "18",
-        "baseStamina": 155,
-        "baseAttack": 116,
-        "baseDefense": 116,
         "formtypes": [
           {
             "type": "Normal",
@@ -20726,10 +17246,6 @@
       {
         "nameform": "9",
         "protoform": "122",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 116,
-        "baseDefense": 116,
         "formtypes": [
           {
             "type": "Normal",
@@ -20740,10 +17256,6 @@
       {
         "nameform": "10",
         "protoform": "123",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 116,
-        "baseDefense": 116,
         "formtypes": [
           {
             "type": "Normal",
@@ -20754,10 +17266,6 @@
       {
         "nameform": "11",
         "protoform": "124",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 116,
-        "baseDefense": 116,
         "formtypes": [
           {
             "type": "Normal",
@@ -20768,10 +17276,6 @@
       {
         "nameform": "12",
         "protoform": "125",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 116,
-        "baseDefense": 116,
         "formtypes": [
           {
             "type": "Normal",
@@ -20782,10 +17286,6 @@
       {
         "nameform": "13",
         "protoform": "126",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 116,
-        "baseDefense": 116,
         "formtypes": [
           {
             "type": "Normal",
@@ -20796,10 +17296,6 @@
       {
         "nameform": "14",
         "protoform": "127",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 116,
-        "baseDefense": 116,
         "formtypes": [
           {
             "type": "Normal",
@@ -20810,10 +17306,6 @@
       {
         "nameform": "15",
         "protoform": "128",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 116,
-        "baseDefense": 116,
         "formtypes": [
           {
             "type": "Normal",
@@ -20824,10 +17316,6 @@
       {
         "nameform": "16",
         "protoform": "129",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 116,
-        "baseDefense": 116,
         "formtypes": [
           {
             "type": "Normal",
@@ -20838,10 +17326,6 @@
       {
         "nameform": "17",
         "protoform": "130",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 116,
-        "baseDefense": 116,
         "formtypes": [
           {
             "type": "Normal",
@@ -20852,10 +17336,6 @@
       {
         "nameform": "18",
         "protoform": "131",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 116,
-        "baseDefense": 116,
         "formtypes": [
           {
             "type": "Normal",
@@ -20866,10 +17346,6 @@
       {
         "nameform": "19",
         "protoform": "132",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 116,
-        "baseDefense": 116,
         "formtypes": [
           {
             "type": "Normal",
@@ -20882,9 +17358,6 @@
   "328":{
     "name": "Trapinch",
     "rarity":"",
-    "baseStamina": 128,
-    "baseAttack": 162,
-    "baseDefense": 78,
     "types": [
       {
         "type": "Ground",
@@ -20895,10 +17368,6 @@
       {
         "nameform": "Normal",
         "protoform": "746",
-        "assetsform": "00",
-        "baseStamina": 128,
-        "baseAttack": 162,
-        "baseDefense": 78,
         "formtypes": [
           {
             "type": "Ground",
@@ -20909,10 +17378,6 @@
       {
         "nameform": "Shadow",
         "protoform": "747",
-        "assetsform": "00",
-        "baseStamina": 128,
-        "baseAttack": 162,
-        "baseDefense": 78,
         "formtypes": [
           {
             "type": "Ground",
@@ -20923,10 +17388,6 @@
       {
         "nameform": "Purified",
         "protoform": "748",
-        "assetsform": "00",
-        "baseStamina": 128,
-        "baseAttack": 162,
-        "baseDefense": 78,
         "formtypes": [
           {
             "type": "Ground",
@@ -20939,9 +17400,6 @@
   "329":{
     "name": "Vibrava",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 134,
-    "baseDefense": 99,
     "types": [
       {
         "type": "Ground",
@@ -20956,10 +17414,6 @@
       {
         "nameform": "Normal",
         "protoform": "749",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 134,
-        "baseDefense": 99,
         "formtypes": [
           {
             "type": "Ground",
@@ -20974,10 +17428,6 @@
       {
         "nameform": "Shadow",
         "protoform": "750",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 134,
-        "baseDefense": 99,
         "formtypes": [
           {
             "type": "Ground",
@@ -20992,10 +17442,6 @@
       {
         "nameform": "Purified",
         "protoform": "751",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 134,
-        "baseDefense": 99,
         "formtypes": [
           {
             "type": "Ground",
@@ -21012,9 +17458,6 @@
   "330":{
     "name": "Flygon",
     "rarity":"",
-    "baseStamina": 190,
-    "baseAttack": 205,
-    "baseDefense": 168,
     "types": [
       {
         "type": "Ground",
@@ -21029,10 +17472,6 @@
       {
         "nameform": "Normal",
         "protoform": "752",
-        "assetsform": "00",
-        "baseStamina": 190,
-        "baseAttack": 205,
-        "baseDefense": 168,
         "formtypes": [
           {
             "type": "Ground",
@@ -21047,10 +17486,6 @@
       {
         "nameform": "Shadow",
         "protoform": "753",
-        "assetsform": "00",
-        "baseStamina": 190,
-        "baseAttack": 205,
-        "baseDefense": 168,
         "formtypes": [
           {
             "type": "Ground",
@@ -21065,10 +17500,6 @@
       {
         "nameform": "Purified",
         "protoform": "754",
-        "assetsform": "00",
-        "baseStamina": 190,
-        "baseAttack": 205,
-        "baseDefense": 168,
         "formtypes": [
           {
             "type": "Ground",
@@ -21085,9 +17516,6 @@
   "331":{
     "name": "Cacnea",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 156,
-    "baseDefense": 74,
     "types": [
       {
         "type": "Grass",
@@ -21098,10 +17526,6 @@
       {
         "nameform": "Normal",
         "protoform": "610",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 156,
-        "baseDefense": 74,
         "formtypes": [
           {
             "type": "Grass",
@@ -21112,10 +17536,6 @@
       {
         "nameform": "Shadow",
         "protoform": "611",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 156,
-        "baseDefense": 74,
         "formtypes": [
           {
             "type": "Grass",
@@ -21126,10 +17546,6 @@
       {
         "nameform": "Purified",
         "protoform": "612",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 156,
-        "baseDefense": 74,
         "formtypes": [
           {
             "type": "Grass",
@@ -21142,9 +17558,6 @@
   "332":{
     "name": "Cacturne",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 221,
-    "baseDefense": 115,
     "types": [
       {
         "type": "Grass",
@@ -21159,10 +17572,6 @@
       {
         "nameform": "Normal",
         "protoform": "613",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 221,
-        "baseDefense": 115,
         "formtypes": [
           {
             "type": "Grass",
@@ -21177,10 +17586,6 @@
       {
         "nameform": "Shadow",
         "protoform": "614",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 221,
-        "baseDefense": 115,
         "formtypes": [
           {
             "type": "Grass",
@@ -21195,10 +17600,6 @@
       {
         "nameform": "Purified",
         "protoform": "615",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 221,
-        "baseDefense": 115,
         "formtypes": [
           {
             "type": "Grass",
@@ -21215,9 +17616,6 @@
   "333":{
     "name": "Swablu",
     "rarity":"",
-    "baseStamina": 128,
-    "baseAttack": 76,
-    "baseDefense": 132,
     "types": [
       {
         "type": "Normal",
@@ -21232,7 +17630,6 @@
       {
         "nameform": "Normal",
         "protoform": "1532",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -21247,7 +17644,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1533",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -21262,7 +17658,6 @@
       {
         "nameform": "Purified",
         "protoform": "1534",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -21279,9 +17674,6 @@
   "334":{
     "name": "Altaria",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 141,
-    "baseDefense": 201,
     "types": [
       {
         "type": "Dragon",
@@ -21296,7 +17688,6 @@
       {
         "nameform": "Normal",
         "protoform": "1535",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -21311,7 +17702,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1536",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -21326,7 +17716,6 @@
       {
         "nameform": "Purified",
         "protoform": "1537",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -21343,9 +17732,6 @@
   "335":{
     "name": "Zangoose",
     "rarity":"",
-    "baseStamina": 177,
-    "baseAttack": 222,
-    "baseDefense": 124,
     "types": [
       {
         "type": "Normal",
@@ -21356,7 +17742,6 @@
       {
         "nameform": "Normal",
         "protoform": "1538",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -21367,7 +17752,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1539",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -21378,7 +17762,6 @@
       {
         "nameform": "Purified",
         "protoform": "1540",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -21391,9 +17774,6 @@
   "336":{
     "name": "Seviper",
     "rarity":"",
-    "baseStamina": 177,
-    "baseAttack": 196,
-    "baseDefense": 118,
     "types": [
       {
         "type": "Poison",
@@ -21404,7 +17784,6 @@
       {
         "nameform": "Normal",
         "protoform": "1541",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Poison",
@@ -21415,7 +17794,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1542",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Poison",
@@ -21426,7 +17804,6 @@
       {
         "nameform": "Purified",
         "protoform": "1543",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Poison",
@@ -21439,9 +17816,6 @@
   "337":{
     "name": "Lunatone",
     "rarity":"",
-    "baseStamina": 207,
-    "baseAttack": 178,
-    "baseDefense": 153,
     "types": [
       {
         "type": "Rock",
@@ -21456,7 +17830,6 @@
       {
         "nameform": "Normal",
         "protoform": "1544",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -21471,7 +17844,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1545",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -21486,7 +17858,6 @@
       {
         "nameform": "Purified",
         "protoform": "1546",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -21503,9 +17874,6 @@
   "338":{
     "name": "Solrock",
     "rarity":"",
-    "baseStamina": 207,
-    "baseAttack": 178,
-    "baseDefense": 153,
     "types": [
       {
         "type": "Rock",
@@ -21520,7 +17888,6 @@
       {
         "nameform": "Normal",
         "protoform": "1547",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -21535,7 +17902,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1548",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -21550,7 +17916,6 @@
       {
         "nameform": "Purified",
         "protoform": "1549",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -21567,9 +17932,6 @@
   "339":{
     "name": "Barboach",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 93,
-    "baseDefense": 82,
     "types": [
       {
         "type": "Water",
@@ -21584,7 +17946,6 @@
       {
         "nameform": "Normal",
         "protoform": "1550",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -21599,7 +17960,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1551",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -21614,7 +17974,6 @@
       {
         "nameform": "Purified",
         "protoform": "1552",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -21631,9 +17990,6 @@
   "340":{
     "name": "Whiscash",
     "rarity":"",
-    "baseStamina": 242,
-    "baseAttack": 151,
-    "baseDefense": 141,
     "types": [
       {
         "type": "Water",
@@ -21648,7 +18004,6 @@
       {
         "nameform": "Normal",
         "protoform": "1553",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -21663,7 +18018,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1554",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -21678,7 +18032,6 @@
       {
         "nameform": "Purified",
         "protoform": "1555",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -21695,9 +18048,6 @@
   "341":{
     "name": "Corphish",
     "rarity":"",
-    "baseStamina": 125,
-    "baseAttack": 141,
-    "baseDefense": 99,
     "types": [
       {
         "type": "Water",
@@ -21708,7 +18058,6 @@
       {
         "nameform": "Normal",
         "protoform": "1556",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -21719,7 +18068,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1557",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -21730,7 +18078,6 @@
       {
         "nameform": "Purified",
         "protoform": "1558",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -21743,9 +18090,6 @@
   "342":{
     "name": "Crawdaunt",
     "rarity":"",
-    "baseStamina": 160,
-    "baseAttack": 224,
-    "baseDefense": 142,
     "types": [
       {
         "type": "Water",
@@ -21760,7 +18104,6 @@
       {
         "nameform": "Normal",
         "protoform": "1559",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -21775,7 +18118,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1560",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -21790,7 +18132,6 @@
       {
         "nameform": "Purified",
         "protoform": "1561",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -21807,9 +18148,6 @@
   "343":{
     "name": "Baltoy",
     "rarity":"",
-    "baseStamina": 120,
-    "baseAttack": 77,
-    "baseDefense": 124,
     "types": [
       {
         "type": "Ground",
@@ -21824,7 +18162,6 @@
       {
         "nameform": "Normal",
         "protoform": "1562",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -21839,7 +18176,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1563",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -21854,7 +18190,6 @@
       {
         "nameform": "Purified",
         "protoform": "1564",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -21871,9 +18206,6 @@
   "344":{
     "name": "Claydol",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 140,
-    "baseDefense": 229,
     "types": [
       {
         "type": "Ground",
@@ -21888,7 +18220,6 @@
       {
         "nameform": "Normal",
         "protoform": "1565",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -21903,7 +18234,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1566",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -21918,7 +18248,6 @@
       {
         "nameform": "Purified",
         "protoform": "1567",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -21935,9 +18264,6 @@
   "345":{
     "name": "Lileep",
     "rarity":"",
-    "baseStamina": 165,
-    "baseAttack": 105,
-    "baseDefense": 150,
     "types": [
       {
         "type": "Rock",
@@ -21952,7 +18278,6 @@
       {
         "nameform": "Normal",
         "protoform": "1568",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -21967,7 +18292,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1569",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -21982,7 +18306,6 @@
       {
         "nameform": "Purified",
         "protoform": "1570",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -21999,9 +18322,6 @@
   "346":{
     "name": "Cradily",
     "rarity":"",
-    "baseStamina": 200,
-    "baseAttack": 152,
-    "baseDefense": 194,
     "types": [
       {
         "type": "Rock",
@@ -22016,7 +18336,6 @@
       {
         "nameform": "Normal",
         "protoform": "1571",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -22031,7 +18350,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1572",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -22046,7 +18364,6 @@
       {
         "nameform": "Purified",
         "protoform": "1573",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -22063,9 +18380,6 @@
   "347":{
     "name": "Anorith",
     "rarity":"",
-    "baseStamina": 128,
-    "baseAttack": 176,
-    "baseDefense": 100,
     "types": [
       {
         "type": "Rock",
@@ -22080,7 +18394,6 @@
       {
         "nameform": "Normal",
         "protoform": "1574",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -22095,7 +18408,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1575",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -22110,7 +18422,6 @@
       {
         "nameform": "Purified",
         "protoform": "1576",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -22127,9 +18438,6 @@
   "348":{
     "name": "Armaldo",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 222,
-    "baseDefense": 174,
     "types": [
       {
         "type": "Rock",
@@ -22144,7 +18452,6 @@
       {
         "nameform": "Normal",
         "protoform": "1577",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -22159,7 +18466,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1578",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -22174,7 +18480,6 @@
       {
         "nameform": "Purified",
         "protoform": "1579",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -22191,9 +18496,6 @@
   "349":{
     "name": "Feebas",
     "rarity":"",
-    "baseStamina": 85,
-    "baseAttack": 29,
-    "baseDefense": 85,
     "types": [
       {
         "type": "Water",
@@ -22204,7 +18506,6 @@
       {
         "nameform": "Normal",
         "protoform": "1580",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -22215,7 +18516,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1581",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -22226,7 +18526,6 @@
       {
         "nameform": "Purified",
         "protoform": "1582",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -22239,9 +18538,6 @@
   "350":{
     "name": "Milotic",
     "rarity":"",
-    "baseStamina": 216,
-    "baseAttack": 192,
-    "baseDefense": 219,
     "types": [
       {
         "type": "Water",
@@ -22252,7 +18548,6 @@
       {
         "nameform": "Normal",
         "protoform": "1583",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -22263,7 +18558,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1584",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -22274,7 +18568,6 @@
       {
         "nameform": "Purified",
         "protoform": "1585",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -22287,9 +18580,6 @@
   "351":{
     "name": "Castform",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 139,
-    "baseDefense": 139,
     "types": [
       {
         "type": "Normal",
@@ -22300,10 +18590,6 @@
       {
         "nameform": "Normal",
         "protoform": "29",
-        "assetsform": "11",
-        "baseStamina": 172,
-        "baseAttack": 139,
-        "baseDefense": 139,
         "formtypes": [
           {
             "type": "Normal",
@@ -22314,10 +18600,6 @@
       {
         "nameform": "Sunny",
         "protoform": "30",
-        "assetsform": "12",
-        "baseStamina": 172,
-        "baseAttack": 139,
-        "baseDefense": 139,
         "formtypes": [
           {
             "type": "Fire",
@@ -22328,10 +18610,6 @@
       {
         "nameform": "Rainy",
         "protoform": "31",
-        "assetsform": "13",
-        "baseStamina": 172,
-        "baseAttack": 139,
-        "baseDefense": 139,
         "formtypes": [
           {
             "type": "Water",
@@ -22342,10 +18620,6 @@
       {
         "nameform": "Snowy",
         "protoform": "32",
-        "assetsform": "14",
-        "baseStamina": 172,
-        "baseAttack": 139,
-        "baseDefense": 139,
         "formtypes": [
           {
             "type": "Ice",
@@ -22358,9 +18632,6 @@
   "352":{
     "name": "Kecleon",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 161,
-    "baseDefense": 189,
     "types": [
       {
         "type": "Normal",
@@ -22371,7 +18642,6 @@
       {
         "nameform": "Normal",
         "protoform": "1586",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -22382,7 +18652,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1587",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -22393,7 +18662,6 @@
       {
         "nameform": "Purified",
         "protoform": "1588",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -22406,9 +18674,6 @@
   "353":{
     "name": "Shuppet",
     "rarity":"",
-    "baseStamina": 127,
-    "baseAttack": 138,
-    "baseDefense": 65,
     "types": [
       {
         "type": "Ghost",
@@ -22419,10 +18684,6 @@
       {
         "nameform": "Normal",
         "protoform": "908",
-        "assetsform": "00",
-        "baseStamina": 127,
-        "baseAttack": 138,
-        "baseDefense": 65,
         "formtypes": [
           {
             "type": "Ghost",
@@ -22433,10 +18694,6 @@
       {
         "nameform": "Shadow",
         "protoform": "909",
-        "assetsform": "00",
-        "baseStamina": 127,
-        "baseAttack": 138,
-        "baseDefense": 65,
         "formtypes": [
           {
             "type": "Ghost",
@@ -22447,10 +18704,6 @@
       {
         "nameform": "Purified",
         "protoform": "910",
-        "assetsform": "00",
-        "baseStamina": 127,
-        "baseAttack": 138,
-        "baseDefense": 65,
         "formtypes": [
           {
             "type": "Ghost",
@@ -22463,9 +18716,6 @@
   "354":{
     "name": "Banette",
     "rarity":"",
-    "baseStamina": 162,
-    "baseAttack": 218,
-    "baseDefense": 126,
     "types": [
       {
         "type": "Ghost",
@@ -22476,7 +18726,6 @@
       {
         "nameform": "Normal",
         "protoform": "911",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -22487,10 +18736,6 @@
       {
         "nameform": "Shadow",
         "protoform": "912",
-        "assetsform": "00",
-        "baseStamina": 162,
-        "baseAttack": 218,
-        "baseDefense": 126,
         "formtypes": [
           {
             "type": "Ghost",
@@ -22501,10 +18746,6 @@
       {
         "nameform": "Purified",
         "protoform": "913",
-        "assetsform": "00",
-        "baseStamina": 162,
-        "baseAttack": 218,
-        "baseDefense": 126,
         "formtypes": [
           {
             "type": "Ghost",
@@ -22517,9 +18758,6 @@
   "355":{
     "name": "Duskull",
     "rarity":"",
-    "baseStamina": 85,
-    "baseAttack": 70,
-    "baseDefense": 162,
     "types": [
       {
         "type": "Ghost",
@@ -22530,10 +18768,6 @@
       {
         "nameform": "Normal",
         "protoform": "914",
-        "assetsform": "00",
-        "baseStamina": 85,
-        "baseAttack": 70,
-        "baseDefense": 162,
         "formtypes": [
           {
             "type": "Ghost",
@@ -22544,10 +18778,6 @@
       {
         "nameform": "Shadow",
         "protoform": "915",
-        "assetsform": "00",
-        "baseStamina": 85,
-        "baseAttack": 70,
-        "baseDefense": 162,
         "formtypes": [
           {
             "type": "Ghost",
@@ -22558,10 +18788,6 @@
       {
         "nameform": "Purified",
         "protoform": "916",
-        "assetsform": "00",
-        "baseStamina": 85,
-        "baseAttack": 70,
-        "baseDefense": 162,
         "formtypes": [
           {
             "type": "Ghost",
@@ -22574,9 +18800,6 @@
   "356":{
     "name": "Dusclops",
     "rarity":"",
-    "baseStamina": 120,
-    "baseAttack": 124,
-    "baseDefense": 234,
     "types": [
       {
         "type": "Ghost",
@@ -22587,10 +18810,6 @@
       {
         "nameform": "Normal",
         "protoform": "917",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 124,
-        "baseDefense": 234,
         "formtypes": [
           {
             "type": "Ghost",
@@ -22601,10 +18820,6 @@
       {
         "nameform": "Shadow",
         "protoform": "918",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 124,
-        "baseDefense": 234,
         "formtypes": [
           {
             "type": "Ghost",
@@ -22615,10 +18830,6 @@
       {
         "nameform": "Purified",
         "protoform": "919",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 124,
-        "baseDefense": 234,
         "formtypes": [
           {
             "type": "Ghost",
@@ -22631,9 +18842,6 @@
   "357":{
     "name": "Tropius",
     "rarity":"",
-    "baseStamina": 223,
-    "baseAttack": 136,
-    "baseDefense": 163,
     "types": [
       {
         "type": "Grass",
@@ -22648,7 +18856,6 @@
       {
         "nameform": "Normal",
         "protoform": "1589",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -22663,7 +18870,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1590",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -22678,7 +18884,6 @@
       {
         "nameform": "Purified",
         "protoform": "1591",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -22695,9 +18900,6 @@
   "358":{
     "name": "Chimecho",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 175,
-    "baseDefense": 170,
     "types": [
       {
         "type": "Psychic",
@@ -22708,7 +18910,6 @@
       {
         "nameform": "Normal",
         "protoform": "1592",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -22719,7 +18920,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1593",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -22730,7 +18930,6 @@
       {
         "nameform": "Purified",
         "protoform": "1594",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -22743,9 +18942,6 @@
   "359":{
     "name": "Absol",
     "rarity":"",
-    "baseStamina": 163,
-    "baseAttack": 246,
-    "baseDefense": 120,
     "types": [
       {
         "type": "Dark",
@@ -22756,10 +18952,6 @@
       {
         "nameform": "Normal",
         "protoform": "830",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 246,
-        "baseDefense": 120,
         "formtypes": [
           {
             "type": "Dark",
@@ -22770,10 +18962,6 @@
       {
         "nameform": "Shadow",
         "protoform": "831",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 246,
-        "baseDefense": 120,
         "formtypes": [
           {
             "type": "Dark",
@@ -22784,10 +18972,6 @@
       {
         "nameform": "Purified",
         "protoform": "832",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 246,
-        "baseDefense": 120,
         "formtypes": [
           {
             "type": "Dark",
@@ -22800,9 +18984,6 @@
   "360":{
     "name": "Wynaut",
     "rarity":"",
-    "baseStamina": 216,
-    "baseAttack": 41,
-    "baseDefense": 86,
     "types": [
       {
         "type": "Psychic",
@@ -22813,7 +18994,6 @@
       {
         "nameform": "Normal",
         "protoform": "1595",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -22824,7 +19004,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1596",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -22835,7 +19014,6 @@
       {
         "nameform": "Purified",
         "protoform": "1597",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -22848,9 +19026,6 @@
   "361":{
     "name": "Snorunt",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 95,
-    "baseDefense": 95,
     "types": [
       {
         "type": "Ice",
@@ -22861,10 +19036,6 @@
       {
         "nameform": "Normal",
         "protoform": "926",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 95,
-        "baseDefense": 95,
         "formtypes": [
           {
             "type": "Ice",
@@ -22875,10 +19046,6 @@
       {
         "nameform": "Shadow",
         "protoform": "927",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 95,
-        "baseDefense": 95,
         "formtypes": [
           {
             "type": "Ice",
@@ -22889,10 +19056,6 @@
       {
         "nameform": "Purified",
         "protoform": "928",
-        "assetsform": "00",
-        "baseStamina": 137,
-        "baseAttack": 95,
-        "baseDefense": 95,
         "formtypes": [
           {
             "type": "Ice",
@@ -22905,9 +19068,6 @@
   "362":{
     "name": "Glalie",
     "rarity":"",
-    "baseStamina": 190,
-    "baseAttack": 162,
-    "baseDefense": 162,
     "types": [
       {
         "type": "Ice",
@@ -22918,10 +19078,6 @@
       {
         "nameform": "Normal",
         "protoform": "929",
-        "assetsform": "00",
-        "baseStamina": 190,
-        "baseAttack": 162,
-        "baseDefense": 162,
         "formtypes": [
           {
             "type": "Ice",
@@ -22932,10 +19088,6 @@
       {
         "nameform": "Shadow",
         "protoform": "930",
-        "assetsform": "00",
-        "baseStamina": 190,
-        "baseAttack": 162,
-        "baseDefense": 162,
         "formtypes": [
           {
             "type": "Ice",
@@ -22946,10 +19098,6 @@
       {
         "nameform": "Purified",
         "protoform": "931",
-        "assetsform": "00",
-        "baseStamina": 190,
-        "baseAttack": 162,
-        "baseDefense": 162,
         "formtypes": [
           {
             "type": "Ice",
@@ -22962,9 +19110,6 @@
   "363":{
     "name": "Spheal",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 95,
-    "baseDefense": 90,
     "types": [
       {
         "type": "Ice",
@@ -22979,7 +19124,6 @@
       {
         "nameform": "Normal",
         "protoform": "1598",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -22994,7 +19138,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1599",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -23009,7 +19152,6 @@
       {
         "nameform": "Purified",
         "protoform": "1600",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -23026,9 +19168,6 @@
   "364":{
     "name": "Sealeo",
     "rarity":"",
-    "baseStamina": 207,
-    "baseAttack": 137,
-    "baseDefense": 132,
     "types": [
       {
         "type": "Ice",
@@ -23043,7 +19182,6 @@
       {
         "nameform": "Normal",
         "protoform": "1601",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -23058,7 +19196,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1602",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -23073,7 +19210,6 @@
       {
         "nameform": "Purified",
         "protoform": "1603",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -23090,9 +19226,6 @@
   "365":{
     "name": "Walrein",
     "rarity":"",
-    "baseStamina": 242,
-    "baseAttack": 182,
-    "baseDefense": 176,
     "types": [
       {
         "type": "Ice",
@@ -23107,7 +19240,6 @@
       {
         "nameform": "Normal",
         "protoform": "1604",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -23122,7 +19254,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1605",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -23137,7 +19268,6 @@
       {
         "nameform": "Purified",
         "protoform": "1606",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -23154,9 +19284,6 @@
   "366":{
     "name": "Clamperl",
     "rarity":"",
-    "baseStamina": 111,
-    "baseAttack": 133,
-    "baseDefense": 135,
     "types": [
       {
         "type": "Water",
@@ -23167,7 +19294,6 @@
       {
         "nameform": "Normal",
         "protoform": "1607",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -23178,7 +19304,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1608",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -23189,7 +19314,6 @@
       {
         "nameform": "Purified",
         "protoform": "1609",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -23202,9 +19326,6 @@
   "367":{
     "name": "Huntail",
     "rarity":"",
-    "baseStamina": 146,
-    "baseAttack": 197,
-    "baseDefense": 179,
     "types": [
       {
         "type": "Water",
@@ -23215,7 +19336,6 @@
       {
         "nameform": "Normal",
         "protoform": "1610",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -23226,7 +19346,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1611",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -23237,7 +19356,6 @@
       {
         "nameform": "Purified",
         "protoform": "1612",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -23250,9 +19368,6 @@
   "368":{
     "name": "Gorebyss",
     "rarity":"",
-    "baseStamina": 146,
-    "baseAttack": 211,
-    "baseDefense": 179,
     "types": [
       {
         "type": "Water",
@@ -23263,7 +19378,6 @@
       {
         "nameform": "Normal",
         "protoform": "1613",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -23274,7 +19388,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1614",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -23285,7 +19398,6 @@
       {
         "nameform": "Purified",
         "protoform": "1615",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -23298,9 +19410,6 @@
   "369":{
     "name": "Relicanth",
     "rarity":"",
-    "baseStamina": 225,
-    "baseAttack": 162,
-    "baseDefense": 203,
     "types": [
       {
         "type": "Water",
@@ -23315,7 +19424,6 @@
       {
         "nameform": "Normal",
         "protoform": "1616",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -23330,7 +19438,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1617",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -23345,7 +19452,6 @@
       {
         "nameform": "Purified",
         "protoform": "1618",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -23362,9 +19468,6 @@
   "370":{
     "name": "Luvdisc",
     "rarity":"",
-    "baseStamina": 125,
-    "baseAttack": 81,
-    "baseDefense": 128,
     "types": [
       {
         "type": "Water",
@@ -23375,7 +19478,6 @@
       {
         "nameform": "Normal",
         "protoform": "1619",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -23386,7 +19488,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1620",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -23397,7 +19498,6 @@
       {
         "nameform": "Purified",
         "protoform": "1621",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -23410,9 +19510,6 @@
   "371":{
     "name": "Bagon",
     "rarity":"",
-    "baseStamina": 128,
-    "baseAttack": 134,
-    "baseDefense": 93,
     "types": [
       {
         "type": "Dragon",
@@ -23423,10 +19520,6 @@
       {
         "nameform": "Normal",
         "protoform": "755",
-        "assetsform": "00",
-        "baseStamina": 128,
-        "baseAttack": 134,
-        "baseDefense": 93,
         "formtypes": [
           {
             "type": "Dragon",
@@ -23437,10 +19530,6 @@
       {
         "nameform": "Shadow",
         "protoform": "756",
-        "assetsform": "00",
-        "baseStamina": 128,
-        "baseAttack": 134,
-        "baseDefense": 93,
         "formtypes": [
           {
             "type": "Dragon",
@@ -23451,10 +19540,6 @@
       {
         "nameform": "Purified",
         "protoform": "757",
-        "assetsform": "00",
-        "baseStamina": 128,
-        "baseAttack": 134,
-        "baseDefense": 93,
         "formtypes": [
           {
             "type": "Dragon",
@@ -23467,9 +19552,6 @@
   "372":{
     "name": "Shelgon",
     "rarity":"",
-    "baseStamina": 163,
-    "baseAttack": 172,
-    "baseDefense": 155,
     "types": [
       {
         "type": "Dragon",
@@ -23480,10 +19562,6 @@
       {
         "nameform": "Normal",
         "protoform": "758",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 172,
-        "baseDefense": 155,
         "formtypes": [
           {
             "type": "Dragon",
@@ -23494,10 +19572,6 @@
       {
         "nameform": "Shadow",
         "protoform": "759",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 172,
-        "baseDefense": 155,
         "formtypes": [
           {
             "type": "Dragon",
@@ -23508,10 +19582,6 @@
       {
         "nameform": "Purified",
         "protoform": "760",
-        "assetsform": "00",
-        "baseStamina": 163,
-        "baseAttack": 172,
-        "baseDefense": 155,
         "formtypes": [
           {
             "type": "Dragon",
@@ -23524,9 +19594,6 @@
   "373":{
     "name": "Salamence",
     "rarity":"",
-    "baseStamina": 216,
-    "baseAttack": 277,
-    "baseDefense": 168,
     "types": [
       {
         "type": "Dragon",
@@ -23541,10 +19608,6 @@
       {
         "nameform": "Normal",
         "protoform": "761",
-        "assetsform": "00",
-        "baseStamina": 216,
-        "baseAttack": 277,
-        "baseDefense": 168,
         "formtypes": [
           {
             "type": "Dragon",
@@ -23559,10 +19622,6 @@
       {
         "nameform": "Shadow",
         "protoform": "762",
-        "assetsform": "00",
-        "baseStamina": 216,
-        "baseAttack": 277,
-        "baseDefense": 168,
         "formtypes": [
           {
             "type": "Dragon",
@@ -23577,10 +19636,6 @@
       {
         "nameform": "Purified",
         "protoform": "763",
-        "assetsform": "00",
-        "baseStamina": 216,
-        "baseAttack": 277,
-        "baseDefense": 168,
         "formtypes": [
           {
             "type": "Dragon",
@@ -23597,9 +19652,6 @@
   "374":{
     "name": "Beldum",
     "rarity":"",
-    "baseStamina": 120,
-    "baseAttack": 96,
-    "baseDefense": 132,
     "types": [
       {
         "type": "Steel",
@@ -23614,10 +19666,6 @@
       {
         "nameform": "Normal",
         "protoform": "764",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 96,
-        "baseDefense": 132,
         "formtypes": [
           {
             "type": "Steel",
@@ -23632,10 +19680,6 @@
       {
         "nameform": "Shadow",
         "protoform": "765",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 96,
-        "baseDefense": 132,
         "formtypes": [
           {
             "type": "Steel",
@@ -23650,10 +19694,6 @@
       {
         "nameform": "Purified",
         "protoform": "766",
-        "assetsform": "00",
-        "baseStamina": 120,
-        "baseAttack": 96,
-        "baseDefense": 132,
         "formtypes": [
           {
             "type": "Steel",
@@ -23670,9 +19710,6 @@
   "375":{
     "name": "Metang",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 138,
-    "baseDefense": 176,
     "types": [
       {
         "type": "Steel",
@@ -23687,10 +19724,6 @@
       {
         "nameform": "Normal",
         "protoform": "767",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 138,
-        "baseDefense": 176,
         "formtypes": [
           {
             "type": "Steel",
@@ -23705,10 +19738,6 @@
       {
         "nameform": "Shadow",
         "protoform": "768",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 138,
-        "baseDefense": 176,
         "formtypes": [
           {
             "type": "Steel",
@@ -23723,10 +19752,6 @@
       {
         "nameform": "Purified",
         "protoform": "769",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 138,
-        "baseDefense": 176,
         "formtypes": [
           {
             "type": "Steel",
@@ -23743,9 +19768,6 @@
   "376":{
     "name": "Metagross",
     "rarity":"",
-    "baseStamina": 190,
-    "baseAttack": 257,
-    "baseDefense": 228,
     "types": [
       {
         "type": "Steel",
@@ -23760,10 +19782,6 @@
       {
         "nameform": "Normal",
         "protoform": "770",
-        "assetsform": "00",
-        "baseStamina": 190,
-        "baseAttack": 257,
-        "baseDefense": 228,
         "formtypes": [
           {
             "type": "Steel",
@@ -23778,10 +19796,6 @@
       {
         "nameform": "Shadow",
         "protoform": "771",
-        "assetsform": "00",
-        "baseStamina": 190,
-        "baseAttack": 257,
-        "baseDefense": 228,
         "formtypes": [
           {
             "type": "Steel",
@@ -23796,10 +19810,6 @@
       {
         "nameform": "Purified",
         "protoform": "772",
-        "assetsform": "00",
-        "baseStamina": 190,
-        "baseAttack": 257,
-        "baseDefense": 228,
         "formtypes": [
           {
             "type": "Steel",
@@ -23816,9 +19826,6 @@
   "377":{
     "name": "Regirock",
     "rarity":"",
-    "baseStamina": 190,
-    "baseAttack": 179,
-    "baseDefense": 309,
     "types": [
       {
         "type": "Rock",
@@ -23829,7 +19836,6 @@
       {
         "nameform": "Normal",
         "protoform": "1622",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -23840,7 +19846,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1623",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -23851,7 +19856,6 @@
       {
         "nameform": "Purified",
         "protoform": "1624",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -23864,9 +19868,6 @@
   "378":{
     "name": "Regice",
     "rarity":"",
-    "baseStamina": 190,
-    "baseAttack": 179,
-    "baseDefense": 309,
     "types": [
       {
         "type": "Ice",
@@ -23877,7 +19878,6 @@
       {
         "nameform": "Normal",
         "protoform": "1625",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -23888,7 +19888,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1626",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -23899,7 +19898,6 @@
       {
         "nameform": "Purified",
         "protoform": "1627",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -23912,9 +19910,6 @@
   "379":{
     "name": "Registeel",
     "rarity":"",
-    "baseStamina": 190,
-    "baseAttack": 143,
-    "baseDefense": 285,
     "types": [
       {
         "type": "Steel",
@@ -23925,7 +19920,6 @@
       {
         "nameform": "Normal",
         "protoform": "1628",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -23936,7 +19930,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1629",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -23947,7 +19940,6 @@
       {
         "nameform": "Purified",
         "protoform": "1630",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -23960,9 +19952,6 @@
   "380":{
     "name": "Latias",
     "rarity":"",
-    "baseStamina": 190,
-    "baseAttack": 228,
-    "baseDefense": 246,
     "types": [
       {
         "type": "Dragon",
@@ -23977,7 +19966,6 @@
       {
         "nameform": "Normal",
         "protoform": "1631",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -23992,7 +19980,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1632",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -24007,7 +19994,6 @@
       {
         "nameform": "Purified",
         "protoform": "1633",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -24024,9 +20010,6 @@
   "381":{
     "name": "Latios",
     "rarity":"",
-    "baseStamina": 190,
-    "baseAttack": 268,
-    "baseDefense": 212,
     "types": [
       {
         "type": "Dragon",
@@ -24041,7 +20024,6 @@
       {
         "nameform": "Normal",
         "protoform": "1634",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -24056,7 +20038,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1635",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -24071,7 +20052,6 @@
       {
         "nameform": "Purified",
         "protoform": "1636",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -24088,9 +20068,6 @@
   "382":{
     "name": "Kyogre",
     "rarity":"",
-    "baseStamina": 205,
-    "baseAttack": 270,
-    "baseDefense": 228,
     "types": [
       {
         "type": "Water",
@@ -24101,7 +20078,6 @@
       {
         "nameform": "Normal",
         "protoform": "1637",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -24112,7 +20088,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1638",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -24123,7 +20098,6 @@
       {
         "nameform": "Purified",
         "protoform": "1639",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -24136,9 +20110,6 @@
   "383":{
     "name": "Groudon",
     "rarity":"",
-    "baseStamina": 205,
-    "baseAttack": 270,
-    "baseDefense": 228,
     "types": [
       {
         "type": "Ground",
@@ -24149,7 +20120,6 @@
       {
         "nameform": "Normal",
         "protoform": "1640",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -24160,7 +20130,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1641",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -24171,7 +20140,6 @@
       {
         "nameform": "Purified",
         "protoform": "1642",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -24184,9 +20152,6 @@
   "384":{
     "name": "Rayquaza",
     "rarity":"",
-    "baseStamina": 213,
-    "baseAttack": 284,
-    "baseDefense": 170,
     "types": [
       {
         "type": "Dragon",
@@ -24201,7 +20166,6 @@
       {
         "nameform": "Normal",
         "protoform": "1643",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -24216,7 +20180,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1644",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -24231,7 +20194,6 @@
       {
         "nameform": "Purified",
         "protoform": "1645",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -24248,9 +20210,6 @@
   "385":{
     "name": "Jirachi",
     "rarity":"",
-    "baseStamina": 225,
-    "baseAttack": 210,
-    "baseDefense": 210,
     "types": [
       {
         "type": "Steel",
@@ -24265,7 +20224,6 @@
       {
         "nameform": "Normal",
         "protoform": "1646",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -24280,7 +20238,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1647",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -24295,7 +20252,6 @@
       {
         "nameform": "Purified",
         "protoform": "1648",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -24312,9 +20268,6 @@
   "386":{
     "name": "Deoxys",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 345,
-    "baseDefense": 115,
     "types": [
       {
         "type": "Psychic",
@@ -24325,10 +20278,6 @@
       {
         "nameform": "Normal",
         "protoform": "33",
-        "assetsform": "11",
-        "baseStamina": 137,
-        "baseAttack": 345,
-        "baseDefense": 115,
         "formtypes": [
           {
             "type": "Psychic",
@@ -24339,10 +20288,6 @@
       {
         "nameform": "Attack",
         "protoform": "34",
-        "assetsform": "12",
-        "baseStamina": 137,
-        "baseAttack": 414,
-        "baseDefense": 46,
         "formtypes": [
           {
             "type": "Psychic",
@@ -24353,10 +20298,6 @@
       {
         "nameform": "Defence",
         "protoform": "35",
-        "assetsform": "13",
-        "baseStamina": 137,
-        "baseAttack": 144,
-        "baseDefense": 330,
         "formtypes": [
           {
             "type": "Psychic",
@@ -24367,10 +20308,6 @@
       {
         "nameform": "Speed",
         "protoform": "36",
-        "assetsform": "14",
-        "baseStamina": 137,
-        "baseAttack": 230,
-        "baseDefense": 218,
         "formtypes": [
           {
             "type": "Psychic",
@@ -24383,9 +20320,6 @@
   "387":{
     "name": "Turtwig",
     "rarity":"",
-    "baseStamina": 146,
-    "baseAttack": 119,
-    "baseDefense": 110,
     "types": [
       {
         "type": "Grass",
@@ -24396,10 +20330,6 @@
       {
         "nameform": "Normal",
         "protoform": "688",
-        "assetsform": "00",
-        "baseStamina": 146,
-        "baseAttack": 119,
-        "baseDefense": 110,
         "formtypes": [
           {
             "type": "Grass",
@@ -24410,10 +20340,6 @@
       {
         "nameform": "Shadow",
         "protoform": "689",
-        "assetsform": "00",
-        "baseStamina": 146,
-        "baseAttack": 119,
-        "baseDefense": 110,
         "formtypes": [
           {
             "type": "Grass",
@@ -24424,10 +20350,6 @@
       {
         "nameform": "Purified",
         "protoform": "690",
-        "assetsform": "00",
-        "baseStamina": 146,
-        "baseAttack": 119,
-        "baseDefense": 110,
         "formtypes": [
           {
             "type": "Grass",
@@ -24440,9 +20362,6 @@
   "388":{
     "name": "Grotle",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 157,
-    "baseDefense": 143,
     "types": [
       {
         "type": "Grass",
@@ -24453,10 +20372,6 @@
       {
         "nameform": "Normal",
         "protoform": "691",
-        "assetsform": "00",
-        "baseStamina": 181,
-        "baseAttack": 157,
-        "baseDefense": 143,
         "formtypes": [
           {
             "type": "Grass",
@@ -24467,10 +20382,6 @@
       {
         "nameform": "Shadow",
         "protoform": "692",
-        "assetsform": "00",
-        "baseStamina": 181,
-        "baseAttack": 157,
-        "baseDefense": 143,
         "formtypes": [
           {
             "type": "Grass",
@@ -24481,10 +20392,6 @@
       {
         "nameform": "Purified",
         "protoform": "693",
-        "assetsform": "00",
-        "baseStamina": 181,
-        "baseAttack": 157,
-        "baseDefense": 143,
         "formtypes": [
           {
             "type": "Grass",
@@ -24497,9 +20404,6 @@
   "389":{
     "name": "Torterra",
     "rarity":"",
-    "baseStamina": 216,
-    "baseAttack": 202,
-    "baseDefense": 188,
     "types": [
       {
         "type": "Grass",
@@ -24514,10 +20418,6 @@
       {
         "nameform": "Normal",
         "protoform": "694",
-        "assetsform": "00",
-        "baseStamina": 216,
-        "baseAttack": 202,
-        "baseDefense": 188,
         "formtypes": [
           {
             "type": "Grass",
@@ -24532,10 +20432,6 @@
       {
         "nameform": "Shadow",
         "protoform": "695",
-        "assetsform": "00",
-        "baseStamina": 216,
-        "baseAttack": 202,
-        "baseDefense": 188,
         "formtypes": [
           {
             "type": "Grass",
@@ -24550,10 +20446,6 @@
       {
         "nameform": "Purified",
         "protoform": "696",
-        "assetsform": "00",
-        "baseStamina": 216,
-        "baseAttack": 202,
-        "baseDefense": 188,
         "formtypes": [
           {
             "type": "Grass",
@@ -24570,9 +20462,6 @@
   "390":{
     "name": "Chimchar",
     "rarity":"",
-    "baseStamina": 127,
-    "baseAttack": 113,
-    "baseDefense": 86,
     "types": [
       {
         "type": "Fire",
@@ -24583,10 +20472,6 @@
       {
         "nameform": "Normal",
         "protoform": "818",
-        "assetsform": "00",
-        "baseStamina": 127,
-        "baseAttack": 113,
-        "baseDefense": 86,
         "formtypes": [
           {
             "type": "Fire",
@@ -24597,10 +20482,6 @@
       {
         "nameform": "Shadow",
         "protoform": "819",
-        "assetsform": "00",
-        "baseStamina": 127,
-        "baseAttack": 113,
-        "baseDefense": 86,
         "formtypes": [
           {
             "type": "Fire",
@@ -24611,10 +20492,6 @@
       {
         "nameform": "Purified",
         "protoform": "820",
-        "assetsform": "00",
-        "baseStamina": 127,
-        "baseAttack": 113,
-        "baseDefense": 86,
         "formtypes": [
           {
             "type": "Fire",
@@ -24627,9 +20504,6 @@
   "391":{
     "name": "Monferno",
     "rarity":"",
-    "baseStamina": 162,
-    "baseAttack": 158,
-    "baseDefense": 105,
     "types": [
       {
         "type": "Fire",
@@ -24644,10 +20518,6 @@
       {
         "nameform": "Normal",
         "protoform": "821",
-        "assetsform": "00",
-        "baseStamina": 162,
-        "baseAttack": 158,
-        "baseDefense": 105,
         "formtypes": [
           {
             "type": "Fire",
@@ -24662,10 +20532,6 @@
       {
         "nameform": "Shadow",
         "protoform": "822",
-        "assetsform": "00",
-        "baseStamina": 162,
-        "baseAttack": 158,
-        "baseDefense": 105,
         "formtypes": [
           {
             "type": "Fire",
@@ -24680,10 +20546,6 @@
       {
         "nameform": "Purified",
         "protoform": "823",
-        "assetsform": "00",
-        "baseStamina": 162,
-        "baseAttack": 158,
-        "baseDefense": 105,
         "formtypes": [
           {
             "type": "Fire",
@@ -24700,9 +20562,6 @@
   "392":{
     "name": "Infernape",
     "rarity":"",
-    "baseStamina": 183,
-    "baseAttack": 222,
-    "baseDefense": 151,
     "types": [
       {
         "type": "Fire",
@@ -24717,10 +20576,6 @@
       {
         "nameform": "Normal",
         "protoform": "824",
-        "assetsform": "00",
-        "baseStamina": 183,
-        "baseAttack": 222,
-        "baseDefense": 151,
         "formtypes": [
           {
             "type": "Fire",
@@ -24735,10 +20590,6 @@
       {
         "nameform": "Shadow",
         "protoform": "825",
-        "assetsform": "00",
-        "baseStamina": 183,
-        "baseAttack": 222,
-        "baseDefense": 151,
         "formtypes": [
           {
             "type": "Fire",
@@ -24753,10 +20604,6 @@
       {
         "nameform": "Purified",
         "protoform": "826",
-        "assetsform": "00",
-        "baseStamina": 183,
-        "baseAttack": 222,
-        "baseDefense": 151,
         "formtypes": [
           {
             "type": "Fire",
@@ -24773,9 +20620,6 @@
   "393":{
     "name": "Piplup",
     "rarity":"",
-    "baseStamina": 142,
-    "baseAttack": 112,
-    "baseDefense": 102,
     "types": [
       {
         "type": "Water",
@@ -24786,7 +20630,6 @@
       {
         "nameform": "Normal",
         "protoform": "1649",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -24797,7 +20640,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1650",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -24808,7 +20650,6 @@
       {
         "nameform": "Purified",
         "protoform": "1651",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -24821,9 +20662,6 @@
   "394":{
     "name": "Prinplup",
     "rarity":"",
-    "baseStamina": 162,
-    "baseAttack": 150,
-    "baseDefense": 139,
     "types": [
       {
         "type": "Water",
@@ -24834,7 +20672,6 @@
       {
         "nameform": "Normal",
         "protoform": "1652",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -24845,7 +20682,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1653",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -24856,7 +20692,6 @@
       {
         "nameform": "Purified",
         "protoform": "1654",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -24869,9 +20704,6 @@
   "395":{
     "name": "Empoleon",
     "rarity":"",
-    "baseStamina": 197,
-    "baseAttack": 210,
-    "baseDefense": 186,
     "types": [
       {
         "type": "Water",
@@ -24886,7 +20718,6 @@
       {
         "nameform": "Normal",
         "protoform": "1655",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -24901,7 +20732,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1656",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -24916,7 +20746,6 @@
       {
         "nameform": "Purified",
         "protoform": "1657",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -24933,9 +20762,6 @@
   "396":{
     "name": "Starly",
     "rarity":"",
-    "baseStamina": 120,
-    "baseAttack": 101,
-    "baseDefense": 58,
     "types": [
       {
         "type": "Normal",
@@ -24950,7 +20776,6 @@
       {
         "nameform": "Normal",
         "protoform": "1658",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -24965,7 +20790,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1659",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -24980,7 +20804,6 @@
       {
         "nameform": "Purified",
         "protoform": "1660",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -24997,9 +20820,6 @@
   "397":{
     "name": "Staravia",
     "rarity":"",
-    "baseStamina": 146,
-    "baseAttack": 142,
-    "baseDefense": 94,
     "types": [
       {
         "type": "Normal",
@@ -25014,7 +20834,6 @@
       {
         "nameform": "Normal",
         "protoform": "1661",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -25029,7 +20848,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1662",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -25044,7 +20862,6 @@
       {
         "nameform": "Purified",
         "protoform": "1663",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -25061,9 +20878,6 @@
   "398":{
     "name": "Staraptor",
     "rarity":"",
-    "baseStamina": 198,
-    "baseAttack": 234,
-    "baseDefense": 140,
     "types": [
       {
         "type": "Normal",
@@ -25078,7 +20892,6 @@
       {
         "nameform": "Normal",
         "protoform": "1664",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -25093,7 +20906,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1665",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -25108,7 +20920,6 @@
       {
         "nameform": "Purified",
         "protoform": "1666",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -25125,9 +20936,6 @@
   "399":{
     "name": "Bidoof",
     "rarity":"",
-    "baseStamina": 153,
-    "baseAttack": 80,
-    "baseDefense": 73,
     "types": [
       {
         "type": "Normal",
@@ -25138,7 +20946,6 @@
       {
         "nameform": "Normal",
         "protoform": "1667",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -25149,7 +20956,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1668",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -25160,7 +20966,6 @@
       {
         "nameform": "Purified",
         "protoform": "1669",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -25173,9 +20978,6 @@
   "400":{
     "name": "Bibarel",
     "rarity":"",
-    "baseStamina": 188,
-    "baseAttack": 162,
-    "baseDefense": 119,
     "types": [
       {
         "type": "Normal",
@@ -25190,7 +20992,6 @@
       {
         "nameform": "Normal",
         "protoform": "1670",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -25205,7 +21006,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1671",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -25220,7 +21020,6 @@
       {
         "nameform": "Purified",
         "protoform": "1672",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -25237,9 +21036,6 @@
   "401":{
     "name": "Kricketot",
     "rarity":"",
-    "baseStamina": 114,
-    "baseAttack": 45,
-    "baseDefense": 74,
     "types": [
       {
         "type": "Bug",
@@ -25250,7 +21046,6 @@
       {
         "nameform": "Normal",
         "protoform": "1673",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -25261,7 +21056,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1674",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -25272,7 +21066,6 @@
       {
         "nameform": "Purified",
         "protoform": "1675",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -25285,9 +21078,6 @@
   "402":{
     "name": "Kricketune",
     "rarity":"",
-    "baseStamina": 184,
-    "baseAttack": 160,
-    "baseDefense": 100,
     "types": [
       {
         "type": "Bug",
@@ -25298,7 +21088,6 @@
       {
         "nameform": "Normal",
         "protoform": "1676",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -25309,7 +21098,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1677",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -25320,7 +21108,6 @@
       {
         "nameform": "Purified",
         "protoform": "1678",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -25333,9 +21120,6 @@
   "403":{
     "name": "Shinx",
     "rarity":"",
-    "baseStamina": 128,
-    "baseAttack": 117,
-    "baseDefense": 64,
     "types": [
       {
         "type": "Electric",
@@ -25346,7 +21130,6 @@
       {
         "nameform": "Normal",
         "protoform": "1679",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -25357,7 +21140,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1680",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -25368,7 +21150,6 @@
       {
         "nameform": "Purified",
         "protoform": "1681",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -25381,9 +21162,6 @@
   "404":{
     "name": "Luxio",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 159,
-    "baseDefense": 95,
     "types": [
       {
         "type": "Electric",
@@ -25394,7 +21172,6 @@
       {
         "nameform": "Normal",
         "protoform": "1682",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -25405,7 +21182,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1683",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -25416,7 +21192,6 @@
       {
         "nameform": "Purified",
         "protoform": "1684",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -25429,9 +21204,6 @@
   "405":{
     "name": "Luxray",
     "rarity":"",
-    "baseStamina": 190,
-    "baseAttack": 232,
-    "baseDefense": 156,
     "types": [
       {
         "type": "Electric",
@@ -25442,7 +21214,6 @@
       {
         "nameform": "Normal",
         "protoform": "1685",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -25453,7 +21224,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1686",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -25464,7 +21234,6 @@
       {
         "nameform": "Purified",
         "protoform": "1687",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -25477,9 +21246,6 @@
   "406":{
     "name": "Budew",
     "rarity":"",
-    "baseStamina": 120,
-    "baseAttack": 91,
-    "baseDefense": 109,
     "types": [
       {
         "type": "Grass",
@@ -25494,7 +21260,6 @@
       {
         "nameform": "Normal",
         "protoform": "1688",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -25509,7 +21274,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1689",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -25524,7 +21288,6 @@
       {
         "nameform": "Purified",
         "protoform": "1690",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -25541,9 +21304,6 @@
   "407":{
     "name": "Roserade",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 243,
-    "baseDefense": 185,
     "types": [
       {
         "type": "Grass",
@@ -25558,7 +21318,6 @@
       {
         "nameform": "Normal",
         "protoform": "1691",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -25573,7 +21332,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1692",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -25588,7 +21346,6 @@
       {
         "nameform": "Purified",
         "protoform": "1693",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -25605,9 +21362,6 @@
   "408":{
     "name": "Cranidos",
     "rarity":"",
-    "baseStamina": 167,
-    "baseAttack": 218,
-    "baseDefense": 71,
     "types": [
       {
         "type": "Rock",
@@ -25618,7 +21372,6 @@
       {
         "nameform": "Normal",
         "protoform": "1694",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -25629,7 +21382,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1695",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -25640,7 +21392,6 @@
       {
         "nameform": "Purified",
         "protoform": "1696",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -25653,9 +21404,6 @@
   "409":{
     "name": "Rampardos",
     "rarity":"",
-    "baseStamina": 219,
-    "baseAttack": 295,
-    "baseDefense": 109,
     "types": [
       {
         "type": "Rock",
@@ -25666,7 +21414,6 @@
       {
         "nameform": "Normal",
         "protoform": "1697",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -25677,7 +21424,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1698",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -25688,7 +21434,6 @@
       {
         "nameform": "Purified",
         "protoform": "1699",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -25701,9 +21446,6 @@
   "410":{
     "name": "Shieldon",
     "rarity":"",
-    "baseStamina": 102,
-    "baseAttack": 76,
-    "baseDefense": 195,
     "types": [
       {
         "type": "Rock",
@@ -25718,7 +21460,6 @@
       {
         "nameform": "Normal",
         "protoform": "1700",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -25733,7 +21474,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1701",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -25748,7 +21488,6 @@
       {
         "nameform": "Purified",
         "protoform": "1702",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -25765,9 +21504,6 @@
   "411":{
     "name": "Bastiodon",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 94,
-    "baseDefense": 286,
     "types": [
       {
         "type": "Rock",
@@ -25782,7 +21518,6 @@
       {
         "nameform": "Normal",
         "protoform": "1703",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -25797,7 +21532,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1704",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -25812,7 +21546,6 @@
       {
         "nameform": "Purified",
         "protoform": "1705",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -25829,9 +21562,6 @@
   "412":{
     "name": "Burmy",
     "rarity":"",
-    "baseStamina": 120,
-    "baseAttack": 53,
-    "baseDefense": 83,
     "types": [
       {
         "type": "Bug",
@@ -25842,10 +21572,6 @@
       {
         "nameform": "Plant",
         "protoform": "118",
-        "assetsform": "11",
-        "baseStamina": 120,
-        "baseAttack": 53,
-        "baseDefense": 83,
         "formtypes": [
           {
             "type": "Bug",
@@ -25860,10 +21586,6 @@
       {
         "nameform": "Sandy",
         "protoform": "119",
-        "assetsform": "12",
-        "baseStamina": 120,
-        "baseAttack": 53,
-        "baseDefense": 83,
         "formtypes": [
           {
             "type": "Bug",
@@ -25878,10 +21600,6 @@
       {
         "nameform": "Trash",
         "protoform": "120",
-        "assetsform": "13",
-        "baseStamina": 120,
-        "baseAttack": 53,
-        "baseDefense": 83,
         "formtypes": [
           {
             "type": "Bug",
@@ -25896,7 +21614,6 @@
       {
         "nameform": "Normal",
         "protoform": "1706",
-        "assetsform": "12",
         "formtypes": [
           {
             "type": "Bug",
@@ -25911,7 +21628,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1707",
-        "assetsform": "12",
         "formtypes": [
           {
             "type": "Bug",
@@ -25926,7 +21642,6 @@
       {
         "nameform": "Purified",
         "protoform": "1708",
-        "assetsform": "12",
         "formtypes": [
           {
             "type": "Bug",
@@ -25943,9 +21658,6 @@
   "413":{
     "name": "Wormadam",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 127,
-    "baseDefense": 175,
     "types": [
       {
         "type": "Bug",
@@ -25960,10 +21672,6 @@
       {
         "nameform": "Plant",
         "protoform": "87",
-        "assetsform": "11",
-        "baseStamina": 155,
-        "baseAttack": 141,
-        "baseDefense": 180,
         "formtypes": [
           {
             "type": "Bug",
@@ -25978,10 +21686,6 @@
       {
         "nameform": "Sandy",
         "protoform": "88",
-        "assetsform": "12",
-        "baseStamina": 155,
-        "baseAttack": 127,
-        "baseDefense": 175,
         "formtypes": [
           {
             "type": "Bug",
@@ -25996,10 +21700,6 @@
       {
         "nameform": "Trash",
         "protoform": "89",
-        "assetsform": "13",
-        "baseStamina": 155,
-        "baseAttack": 127,
-        "baseDefense": 175,
         "formtypes": [
           {
             "type": "Bug",
@@ -26014,7 +21714,6 @@
       {
         "nameform": "Normal",
         "protoform": "1709",
-        "assetsform": "12",
         "formtypes": [
           {
             "type": "Bug",
@@ -26029,7 +21728,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1710",
-        "assetsform": "12",
         "formtypes": [
           {
             "type": "Bug",
@@ -26044,7 +21742,6 @@
       {
         "nameform": "Purified",
         "protoform": "1711",
-        "assetsform": "12",
         "formtypes": [
           {
             "type": "Bug",
@@ -26061,9 +21758,6 @@
   "414":{
     "name": "Mothim",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 185,
-    "baseDefense": 98,
     "types": [
       {
         "type": "Bug",
@@ -26078,7 +21772,6 @@
       {
         "nameform": "Normal",
         "protoform": "1712",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -26093,7 +21786,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1713",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -26108,7 +21800,6 @@
       {
         "nameform": "Purified",
         "protoform": "1714",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -26125,9 +21816,6 @@
   "415":{
     "name": "Combee",
     "rarity":"",
-    "baseStamina": 102,
-    "baseAttack": 59,
-    "baseDefense": 83,
     "types": [
       {
         "type": "Bug",
@@ -26142,7 +21830,6 @@
       {
         "nameform": "Normal",
         "protoform": "1715",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -26157,7 +21844,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1716",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -26172,7 +21858,6 @@
       {
         "nameform": "Purified",
         "protoform": "1717",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -26189,9 +21874,6 @@
   "416":{
     "name": "Vespiquen",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 149,
-    "baseDefense": 190,
     "types": [
       {
         "type": "Bug",
@@ -26206,7 +21888,6 @@
       {
         "nameform": "Normal",
         "protoform": "1718",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -26221,7 +21902,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1719",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -26236,7 +21916,6 @@
       {
         "nameform": "Purified",
         "protoform": "1720",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -26253,9 +21932,6 @@
   "417":{
     "name": "Pachirisu",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 94,
-    "baseDefense": 172,
     "types": [
       {
         "type": "Electric",
@@ -26266,7 +21942,6 @@
       {
         "nameform": "Normal",
         "protoform": "1721",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -26277,7 +21952,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1722",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -26288,7 +21962,6 @@
       {
         "nameform": "Purified",
         "protoform": "1723",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -26301,9 +21974,6 @@
   "418":{
     "name": "Buizel",
     "rarity":"",
-    "baseStamina": 146,
-    "baseAttack": 132,
-    "baseDefense": 67,
     "types": [
       {
         "type": "Water",
@@ -26314,7 +21984,6 @@
       {
         "nameform": "Normal",
         "protoform": "1724",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -26325,7 +21994,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1725",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -26336,7 +22004,6 @@
       {
         "nameform": "Purified",
         "protoform": "1726",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -26349,9 +22016,6 @@
   "419":{
     "name": "Floatzel",
     "rarity":"",
-    "baseStamina": 198,
-    "baseAttack": 221,
-    "baseDefense": 114,
     "types": [
       {
         "type": "Water",
@@ -26362,7 +22026,6 @@
       {
         "nameform": "Normal",
         "protoform": "1727",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -26373,7 +22036,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1728",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -26384,7 +22046,6 @@
       {
         "nameform": "Purified",
         "protoform": "1729",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -26397,9 +22058,6 @@
   "420":{
     "name": "Cherubi",
     "rarity":"",
-    "baseStamina": 128,
-    "baseAttack": 108,
-    "baseDefense": 92,
     "types": [
       {
         "type": "Grass",
@@ -26410,7 +22068,6 @@
       {
         "nameform": "Normal",
         "protoform": "1730",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -26421,7 +22078,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1731",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -26432,7 +22088,6 @@
       {
         "nameform": "Purified",
         "protoform": "1732",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -26445,9 +22100,6 @@
   "421":{
     "name": "Cherrim",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 170,
-    "baseDefense": 153,
     "types": [
       {
         "type": "Grass",
@@ -26458,10 +22110,6 @@
       {
         "nameform": "Overcast",
         "protoform": "94",
-        "assetsform": "11",
-        "baseStamina": 172,
-        "baseAttack": 170,
-        "baseDefense": 153,
         "formtypes": [
           {
             "type": "Grass",
@@ -26472,10 +22120,6 @@
       {
         "nameform": "Sunny",
         "protoform": "95",
-        "assetsform": "12",
-        "baseStamina": 172,
-        "baseAttack": 170,
-        "baseDefense": 153,
         "formtypes": [
           {
             "type": "Grass",
@@ -26486,7 +22130,6 @@
       {
         "nameform": "Normal",
         "protoform": "1733",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -26497,7 +22140,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1734",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -26508,7 +22150,6 @@
       {
         "nameform": "Purified",
         "protoform": "1735",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -26521,9 +22162,6 @@
   "422":{
     "name": "Shellos",
     "rarity":"",
-    "baseStamina": 183,
-    "baseAttack": 103,
-    "baseDefense": 105,
     "types": [
       {
         "type": "Water",
@@ -26534,10 +22172,6 @@
       {
         "nameform": "West Sea",
         "protoform": "96",
-        "assetsform": "11",
-        "baseStamina": 183,
-        "baseAttack": 103,
-        "baseDefense": 105,
         "formtypes": [
           {
             "type": "Water",
@@ -26548,10 +22182,6 @@
       {
         "nameform": "East Sea",
         "protoform": "97",
-        "assetsform": "12",
-        "baseStamina": 183,
-        "baseAttack": 103,
-        "baseDefense": 105,
         "formtypes": [
           {
             "type": "Water",
@@ -26562,7 +22192,6 @@
       {
         "nameform": "Normal",
         "protoform": "1736",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -26573,7 +22202,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1737",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -26584,7 +22212,6 @@
       {
         "nameform": "Purified",
         "protoform": "1738",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -26597,9 +22224,6 @@
   "423":{
     "name": "Gastrodon",
     "rarity":"",
-    "baseStamina": 244,
-    "baseAttack": 169,
-    "baseDefense": 143,
     "types": [
       {
         "type": "Water",
@@ -26614,9 +22238,6 @@
       {
         "nameform": "West Sea",
         "protoform": "98",
-        "baseStamina": 244,
-        "baseAttack": 169,
-        "baseDefense": 143,
         "formtypes": [
           {
             "type": "Water",
@@ -26631,9 +22252,6 @@
       {
         "nameform": "East Sea",
         "protoform": "99",
-        "baseStamina": 244,
-        "baseAttack": 169,
-        "baseDefense": 143,
         "formtypes": [
           {
             "type": "Water",
@@ -26648,7 +22266,6 @@
       {
         "nameform": "Normal",
         "protoform": "1739",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -26659,7 +22276,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1740",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -26670,7 +22286,6 @@
       {
         "nameform": "Purified",
         "protoform": "1741",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -26683,9 +22298,6 @@
   "424":{
     "name": "Ambipom",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 205,
-    "baseDefense": 143,
     "types": [
       {
         "type": "Normal",
@@ -26696,7 +22308,6 @@
       {
         "nameform": "Normal",
         "protoform": "1742",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -26707,7 +22318,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1743",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -26718,7 +22328,6 @@
       {
         "nameform": "Purified",
         "protoform": "1744",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -26731,9 +22340,6 @@
   "425":{
     "name": "Drifloon",
     "rarity":"",
-    "baseStamina": 207,
-    "baseAttack": 117,
-    "baseDefense": 80,
     "types": [
       {
         "type": "Ghost",
@@ -26748,7 +22354,6 @@
       {
         "nameform": "Normal",
         "protoform": "1745",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -26763,7 +22368,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1746",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -26778,7 +22382,6 @@
       {
         "nameform": "Purified",
         "protoform": "1747",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -26795,9 +22398,6 @@
   "426":{
     "name": "Drifblim",
     "rarity":"",
-    "baseStamina": 312,
-    "baseAttack": 180,
-    "baseDefense": 102,
     "types": [
       {
         "type": "Ghost",
@@ -26812,7 +22412,6 @@
       {
         "nameform": "Normal",
         "protoform": "1748",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -26827,7 +22426,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1749",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -26842,7 +22440,6 @@
       {
         "nameform": "Purified",
         "protoform": "1750",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -26859,9 +22456,6 @@
   "427":{
     "name": "Buneary",
     "rarity":"",
-    "baseStamina": 146,
-    "baseAttack": 130,
-    "baseDefense": 105,
     "types": [
       {
         "type": "Normal",
@@ -26872,7 +22466,6 @@
       {
         "nameform": "Normal",
         "protoform": "1751",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -26883,7 +22476,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1752",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -26894,7 +22486,6 @@
       {
         "nameform": "Purified",
         "protoform": "1753",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -26907,9 +22498,6 @@
   "428":{
     "name": "Lopunny",
     "rarity":"",
-    "baseStamina": 163,
-    "baseAttack": 156,
-    "baseDefense": 194,
     "types": [
       {
         "type": "Normal",
@@ -26920,7 +22508,6 @@
       {
         "nameform": "Normal",
         "protoform": "1754",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -26931,7 +22518,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1755",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -26942,7 +22528,6 @@
       {
         "nameform": "Purified",
         "protoform": "1756",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -26955,9 +22540,6 @@
   "429":{
     "name": "Mismagius",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 211,
-    "baseDefense": 187,
     "types": [
       {
         "type": "Ghost",
@@ -26968,10 +22550,6 @@
       {
         "nameform": "Normal",
         "protoform": "722",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 211,
-        "baseDefense": 187,
         "formtypes": [
           {
             "type": "Ghost",
@@ -26982,10 +22560,6 @@
       {
         "nameform": "Shadow",
         "protoform": "723",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 211,
-        "baseDefense": 187,
         "formtypes": [
           {
             "type": "Ghost",
@@ -26996,10 +22570,6 @@
       {
         "nameform": "Purified",
         "protoform": "724",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 211,
-        "baseDefense": 187,
         "formtypes": [
           {
             "type": "Ghost",
@@ -27012,9 +22582,6 @@
   "430":{
     "name": "Honchkrow",
     "rarity":"",
-    "baseStamina": 225,
-    "baseAttack": 243,
-    "baseDefense": 103,
     "types": [
       {
         "type": "Dark",
@@ -27029,10 +22596,6 @@
       {
         "nameform": "Normal",
         "protoform": "858",
-        "assetsform": "00",
-        "baseStamina": 225,
-        "baseAttack": 243,
-        "baseDefense": 103,
         "formtypes": [
           {
             "type": "Dark",
@@ -27047,10 +22610,6 @@
       {
         "nameform": "Shadow",
         "protoform": "859",
-        "assetsform": "00",
-        "baseStamina": 225,
-        "baseAttack": 243,
-        "baseDefense": 103,
         "formtypes": [
           {
             "type": "Dark",
@@ -27065,10 +22624,6 @@
       {
         "nameform": "Purified",
         "protoform": "860",
-        "assetsform": "00",
-        "baseStamina": 225,
-        "baseAttack": 243,
-        "baseDefense": 103,
         "formtypes": [
           {
             "type": "Dark",
@@ -27085,9 +22640,6 @@
   "431":{
     "name": "Glameow",
     "rarity":"",
-    "baseStamina": 135,
-    "baseAttack": 109,
-    "baseDefense": 82,
     "types": [
       {
         "type": "Normal",
@@ -27098,7 +22650,6 @@
       {
         "nameform": "Normal",
         "protoform": "1757",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -27109,7 +22660,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1758",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -27120,7 +22670,6 @@
       {
         "nameform": "Purified",
         "protoform": "1759",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -27133,9 +22682,6 @@
   "432":{
     "name": "Purugly",
     "rarity":"",
-    "baseStamina": 174,
-    "baseAttack": 172,
-    "baseDefense": 133,
     "types": [
       {
         "type": "Normal",
@@ -27146,7 +22692,6 @@
       {
         "nameform": "Normal",
         "protoform": "1760",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -27157,7 +22702,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1761",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -27168,7 +22712,6 @@
       {
         "nameform": "Purified",
         "protoform": "1762",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -27181,9 +22724,6 @@
   "433":{
     "name": "Chingling",
     "rarity":"",
-    "baseStamina": 128,
-    "baseAttack": 114,
-    "baseDefense": 94,
     "types": [
       {
         "type": "Psychic",
@@ -27194,7 +22734,6 @@
       {
         "nameform": "Normal",
         "protoform": "1763",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -27205,7 +22744,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1764",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -27216,7 +22754,6 @@
       {
         "nameform": "Purified",
         "protoform": "1765",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -27229,9 +22766,6 @@
   "434":{
     "name": "Stunky",
     "rarity":"",
-    "baseStamina": 160,
-    "baseAttack": 121,
-    "baseDefense": 90,
     "types": [
       {
         "type": "Poison",
@@ -27246,10 +22780,6 @@
       {
         "nameform": "Normal",
         "protoform": "791",
-        "assetsform": "00",
-        "baseStamina": 160,
-        "baseAttack": 121,
-        "baseDefense": 90,
         "formtypes": [
           {
             "type": "Poison",
@@ -27264,10 +22794,6 @@
       {
         "nameform": "Shadow",
         "protoform": "792",
-        "assetsform": "00",
-        "baseStamina": 160,
-        "baseAttack": 121,
-        "baseDefense": 90,
         "formtypes": [
           {
             "type": "Poison",
@@ -27282,10 +22808,6 @@
       {
         "nameform": "Purified",
         "protoform": "793",
-        "assetsform": "00",
-        "baseStamina": 160,
-        "baseAttack": 121,
-        "baseDefense": 90,
         "formtypes": [
           {
             "type": "Poison",
@@ -27302,9 +22824,6 @@
   "435":{
     "name": "Skuntank",
     "rarity":"",
-    "baseStamina": 230,
-    "baseAttack": 184,
-    "baseDefense": 132,
     "types": [
       {
         "type": "Poison",
@@ -27319,10 +22838,6 @@
       {
         "nameform": "Normal",
         "protoform": "794",
-        "assetsform": "00",
-        "baseStamina": 230,
-        "baseAttack": 184,
-        "baseDefense": 132,
         "formtypes": [
           {
             "type": "Poison",
@@ -27337,10 +22852,6 @@
       {
         "nameform": "Shadow",
         "protoform": "795",
-        "assetsform": "00",
-        "baseStamina": 230,
-        "baseAttack": 184,
-        "baseDefense": 132,
         "formtypes": [
           {
             "type": "Poison",
@@ -27355,10 +22866,6 @@
       {
         "nameform": "Purified",
         "protoform": "796",
-        "assetsform": "00",
-        "baseStamina": 230,
-        "baseAttack": 184,
-        "baseDefense": 132,
         "formtypes": [
           {
             "type": "Poison",
@@ -27375,9 +22882,6 @@
   "436":{
     "name": "Bronzor",
     "rarity":"",
-    "baseStamina": 149,
-    "baseAttack": 43,
-    "baseDefense": 154,
     "types": [
       {
         "type": "Steel",
@@ -27392,7 +22896,6 @@
       {
         "nameform": "Normal",
         "protoform": "1766",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -27407,7 +22910,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1767",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -27422,7 +22924,6 @@
       {
         "nameform": "Purified",
         "protoform": "1768",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -27439,9 +22940,6 @@
   "437":{
     "name": "Bronzong",
     "rarity":"",
-    "baseStamina": 167,
-    "baseAttack": 161,
-    "baseDefense": 213,
     "types": [
       {
         "type": "Steel",
@@ -27456,7 +22954,6 @@
       {
         "nameform": "Normal",
         "protoform": "1769",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -27471,7 +22968,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1770",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -27486,7 +22982,6 @@
       {
         "nameform": "Purified",
         "protoform": "1771",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -27503,9 +22998,6 @@
   "438":{
     "name": "Bonsly",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 124,
-    "baseDefense": 133,
     "types": [
       {
         "type": "Rock",
@@ -27516,7 +23008,6 @@
       {
         "nameform": "Normal",
         "protoform": "1772",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -27527,7 +23018,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1773",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -27538,7 +23028,6 @@
       {
         "nameform": "Purified",
         "protoform": "1774",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -27551,9 +23040,6 @@
   "439":{
     "name": "Mime Jr.",
     "rarity":"",
-    "baseStamina": 85,
-    "baseAttack": 125,
-    "baseDefense": 142,
     "types": [
       {
         "type": "Psychic",
@@ -27568,7 +23054,6 @@
       {
         "nameform": "Normal",
         "protoform": "1775",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -27583,7 +23068,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1776",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -27598,7 +23082,6 @@
       {
         "nameform": "Purified",
         "protoform": "1777",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -27615,9 +23098,6 @@
   "440":{
     "name": "Happiny",
     "rarity":"",
-    "baseStamina": 225,
-    "baseAttack": 25,
-    "baseDefense": 77,
     "types": [
       {
         "type": "Normal",
@@ -27628,7 +23108,6 @@
       {
         "nameform": "Normal",
         "protoform": "1778",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -27639,7 +23118,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1779",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -27650,7 +23128,6 @@
       {
         "nameform": "Purified",
         "protoform": "1780",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -27663,9 +23140,6 @@
   "441":{
     "name": "Chatot",
     "rarity":"",
-    "baseStamina": 183,
-    "baseAttack": 183,
-    "baseDefense": 91,
     "types": [
       {
         "type": "Normal",
@@ -27680,7 +23154,6 @@
       {
         "nameform": "Normal",
         "protoform": "1781",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -27695,7 +23168,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1782",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -27710,7 +23182,6 @@
       {
         "nameform": "Purified",
         "protoform": "1783",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -27727,9 +23198,6 @@
   "442":{
     "name": "Spiritomb",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 169,
-    "baseDefense": 199,
     "types": [
       {
         "type": "Ghost",
@@ -27744,7 +23212,6 @@
       {
         "nameform": "Normal",
         "protoform": "1784",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -27759,7 +23226,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1785",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -27774,7 +23240,6 @@
       {
         "nameform": "Purified",
         "protoform": "1786",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -27791,9 +23256,6 @@
   "443":{
     "name": "Gible",
     "rarity":"",
-    "baseStamina": 151,
-    "baseAttack": 124,
-    "baseDefense": 84,
     "types": [
       {
         "type": "Dragon",
@@ -27808,10 +23270,6 @@
       {
         "nameform": "Normal",
         "protoform": "861",
-        "assetsform": "00",
-        "baseStamina": 151,
-        "baseAttack": 124,
-        "baseDefense": 84,
         "formtypes": [
           {
             "type": "Dragon",
@@ -27826,10 +23284,6 @@
       {
         "nameform": "Shadow",
         "protoform": "862",
-        "assetsform": "00",
-        "baseStamina": 151,
-        "baseAttack": 124,
-        "baseDefense": 84,
         "formtypes": [
           {
             "type": "Dragon",
@@ -27844,10 +23298,6 @@
       {
         "nameform": "Purified",
         "protoform": "863",
-        "assetsform": "00",
-        "baseStamina": 151,
-        "baseAttack": 124,
-        "baseDefense": 84,
         "formtypes": [
           {
             "type": "Dragon",
@@ -27864,9 +23314,6 @@
   "444":{
     "name": "Gabite",
     "rarity":"",
-    "baseStamina": 169,
-    "baseAttack": 172,
-    "baseDefense": 125,
     "types": [
       {
         "type": "Dragon",
@@ -27881,10 +23328,6 @@
       {
         "nameform": "Normal",
         "protoform": "864",
-        "assetsform": "00",
-        "baseStamina": 169,
-        "baseAttack": 172,
-        "baseDefense": 125,
         "formtypes": [
           {
             "type": "Dragon",
@@ -27899,10 +23342,6 @@
       {
         "nameform": "Shadow",
         "protoform": "865",
-        "assetsform": "00",
-        "baseStamina": 169,
-        "baseAttack": 172,
-        "baseDefense": 125,
         "formtypes": [
           {
             "type": "Dragon",
@@ -27917,10 +23356,6 @@
       {
         "nameform": "Purified",
         "protoform": "866",
-        "assetsform": "00",
-        "baseStamina": 169,
-        "baseAttack": 172,
-        "baseDefense": 125,
         "formtypes": [
           {
             "type": "Dragon",
@@ -27937,9 +23372,6 @@
   "445":{
     "name": "Garchomp",
     "rarity":"",
-    "baseStamina": 239,
-    "baseAttack": 261,
-    "baseDefense": 193,
     "types": [
       {
         "type": "Dragon",
@@ -27954,10 +23386,6 @@
       {
         "nameform": "Normal",
         "protoform": "867",
-        "assetsform": "00",
-        "baseStamina": 239,
-        "baseAttack": 261,
-        "baseDefense": 193,
         "formtypes": [
           {
             "type": "Dragon",
@@ -27972,10 +23400,6 @@
       {
         "nameform": "Shadow",
         "protoform": "868",
-        "assetsform": "00",
-        "baseStamina": 239,
-        "baseAttack": 261,
-        "baseDefense": 193,
         "formtypes": [
           {
             "type": "Dragon",
@@ -27990,10 +23414,6 @@
       {
         "nameform": "Purified",
         "protoform": "869",
-        "assetsform": "00",
-        "baseStamina": 239,
-        "baseAttack": 261,
-        "baseDefense": 193,
         "formtypes": [
           {
             "type": "Dragon",
@@ -28010,9 +23430,6 @@
   "446":{
     "name": "Munchlax",
     "rarity":"",
-    "baseStamina": 286,
-    "baseAttack": 137,
-    "baseDefense": 117,
     "types": [
       {
         "type": "Normal",
@@ -28023,7 +23440,6 @@
       {
         "nameform": "Normal",
         "protoform": "1787",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -28034,7 +23450,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1788",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -28045,7 +23460,6 @@
       {
         "nameform": "Purified",
         "protoform": "1789",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -28058,9 +23472,6 @@
   "447":{
     "name": "Riolu",
     "rarity":"",
-    "baseStamina": 120,
-    "baseAttack": 127,
-    "baseDefense": 78,
     "types": [
       {
         "type": "Fighting",
@@ -28071,7 +23482,6 @@
       {
         "nameform": "Normal",
         "protoform": "1790",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -28082,7 +23492,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1791",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -28093,7 +23502,6 @@
       {
         "nameform": "Purified",
         "protoform": "1792",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -28106,9 +23514,6 @@
   "448":{
     "name": "Lucario",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 236,
-    "baseDefense": 144,
     "types": [
       {
         "type": "Fighting",
@@ -28123,7 +23528,6 @@
       {
         "nameform": "Normal",
         "protoform": "1793",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -28138,7 +23542,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1794",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -28153,7 +23556,6 @@
       {
         "nameform": "Purified",
         "protoform": "1795",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -28170,9 +23572,6 @@
   "449":{
     "name": "Hippopotas",
     "rarity":"",
-    "baseStamina": 169,
-    "baseAttack": 124,
-    "baseDefense": 118,
     "types": [
       {
         "type": "Ground",
@@ -28183,10 +23582,6 @@
       {
         "nameform": "Normal",
         "protoform": "888",
-        "assetsform": "00",
-        "baseStamina": 169,
-        "baseAttack": 124,
-        "baseDefense": 118,
         "formtypes": [
           {
             "type": "Ground",
@@ -28197,10 +23592,6 @@
       {
         "nameform": "Shadow",
         "protoform": "889",
-        "assetsform": "00",
-        "baseStamina": 169,
-        "baseAttack": 124,
-        "baseDefense": 118,
         "formtypes": [
           {
             "type": "Ground",
@@ -28211,10 +23602,6 @@
       {
         "nameform": "Purified",
         "protoform": "890",
-        "assetsform": "00",
-        "baseStamina": 169,
-        "baseAttack": 124,
-        "baseDefense": 118,
         "formtypes": [
           {
             "type": "Ground",
@@ -28227,9 +23614,6 @@
   "450":{
     "name": "Hippowdon",
     "rarity":"",
-    "baseStamina": 239,
-    "baseAttack": 201,
-    "baseDefense": 191,
     "types": [
       {
         "type": "Ground",
@@ -28240,10 +23624,6 @@
       {
         "nameform": "Normal",
         "protoform": "891",
-        "assetsform": "00",
-        "baseStamina": 239,
-        "baseAttack": 201,
-        "baseDefense": 191,
         "formtypes": [
           {
             "type": "Ground",
@@ -28254,10 +23634,6 @@
       {
         "nameform": "Shadow",
         "protoform": "892",
-        "assetsform": "00",
-        "baseStamina": 239,
-        "baseAttack": 201,
-        "baseDefense": 191,
         "formtypes": [
           {
             "type": "Ground",
@@ -28268,10 +23644,6 @@
       {
         "nameform": "Purified",
         "protoform": "893",
-        "assetsform": "00",
-        "baseStamina": 239,
-        "baseAttack": 201,
-        "baseDefense": 191,
         "formtypes": [
           {
             "type": "Ground",
@@ -28284,9 +23656,6 @@
   "451":{
     "name": "Skorupi",
     "rarity":"",
-    "baseStamina": 120,
-    "baseAttack": 93,
-    "baseDefense": 151,
     "types": [
       {
         "type": "Poison",
@@ -28301,7 +23670,6 @@
       {
         "nameform": "Normal",
         "protoform": "1796",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Poison",
@@ -28316,7 +23684,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1797",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Poison",
@@ -28331,7 +23698,6 @@
       {
         "nameform": "Purified",
         "protoform": "1798",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Poison",
@@ -28348,9 +23714,6 @@
   "452":{
     "name": "Drapion",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 180,
-    "baseDefense": 202,
     "types": [
       {
         "type": "Poison",
@@ -28365,7 +23728,6 @@
       {
         "nameform": "Normal",
         "protoform": "1799",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Poison",
@@ -28380,7 +23742,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1800",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Poison",
@@ -28395,7 +23756,6 @@
       {
         "nameform": "Purified",
         "protoform": "1801",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Poison",
@@ -28412,9 +23772,6 @@
   "453":{
     "name": "Croagunk",
     "rarity":"",
-    "baseStamina": 134,
-    "baseAttack": 116,
-    "baseDefense": 76,
     "types": [
       {
         "type": "Poison",
@@ -28429,7 +23786,6 @@
       {
         "nameform": "Normal",
         "protoform": "1802",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Poison",
@@ -28444,7 +23800,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1803",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Poison",
@@ -28459,7 +23814,6 @@
       {
         "nameform": "Purified",
         "protoform": "1804",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Poison",
@@ -28476,9 +23830,6 @@
   "454":{
     "name": "Toxicroak",
     "rarity":"",
-    "baseStamina": 195,
-    "baseAttack": 211,
-    "baseDefense": 133,
     "types": [
       {
         "type": "Poison",
@@ -28493,7 +23844,6 @@
       {
         "nameform": "Normal",
         "protoform": "1805",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Poison",
@@ -28508,7 +23858,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1806",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Poison",
@@ -28523,7 +23872,6 @@
       {
         "nameform": "Purified",
         "protoform": "1807",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Poison",
@@ -28540,9 +23888,6 @@
   "455":{
     "name": "Carnivine",
     "rarity":"",
-    "baseStamina": 179,
-    "baseAttack": 187,
-    "baseDefense": 136,
     "types": [
       {
         "type": "Grass",
@@ -28553,7 +23898,6 @@
       {
         "nameform": "Normal",
         "protoform": "1808",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -28564,7 +23908,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1809",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -28575,7 +23918,6 @@
       {
         "nameform": "Purified",
         "protoform": "1810",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -28588,9 +23930,6 @@
   "456":{
     "name": "Finneon",
     "rarity":"",
-    "baseStamina": 135,
-    "baseAttack": 96,
-    "baseDefense": 116,
     "types": [
       {
         "type": "Water",
@@ -28601,7 +23940,6 @@
       {
         "nameform": "Normal",
         "protoform": "1811",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -28612,7 +23950,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1812",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -28623,7 +23960,6 @@
       {
         "nameform": "Purified",
         "protoform": "1813",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -28636,9 +23972,6 @@
   "457":{
     "name": "Lumineon",
     "rarity":"",
-    "baseStamina": 170,
-    "baseAttack": 142,
-    "baseDefense": 170,
     "types": [
       {
         "type": "Water",
@@ -28649,7 +23982,6 @@
       {
         "nameform": "Normal",
         "protoform": "1814",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -28660,7 +23992,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1815",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -28671,7 +24002,6 @@
       {
         "nameform": "Purified",
         "protoform": "1816",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -28684,9 +24014,6 @@
   "458":{
     "name": "Mantyke",
     "rarity":"",
-    "baseStamina": 128,
-    "baseAttack": 105,
-    "baseDefense": 179,
     "types": [
       {
         "type": "Water",
@@ -28701,7 +24028,6 @@
       {
         "nameform": "Normal",
         "protoform": "1817",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -28716,7 +24042,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1818",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -28731,7 +24056,6 @@
       {
         "nameform": "Purified",
         "protoform": "1819",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -28748,9 +24072,6 @@
   "459":{
     "name": "Snover",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 115,
-    "baseDefense": 105,
     "types": [
       {
         "type": "Grass",
@@ -28765,10 +24086,6 @@
       {
         "nameform": "Normal",
         "protoform": "932",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 115,
-        "baseDefense": 105,
         "formtypes": [
           {
             "type": "Grass",
@@ -28783,10 +24100,6 @@
       {
         "nameform": "Shadow",
         "protoform": "933",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 115,
-        "baseDefense": 105,
         "formtypes": [
           {
             "type": "Grass",
@@ -28801,10 +24114,6 @@
       {
         "nameform": "Purified",
         "protoform": "934",
-        "assetsform": "00",
-        "baseStamina": 155,
-        "baseAttack": 115,
-        "baseDefense": 105,
         "formtypes": [
           {
             "type": "Grass",
@@ -28821,9 +24130,6 @@
   "460":{
     "name": "Abomasnow",
     "rarity":"",
-    "baseStamina": 207,
-    "baseAttack": 178,
-    "baseDefense": 158,
     "types": [
       {
         "type": "Grass",
@@ -28838,10 +24144,6 @@
       {
         "nameform": "Normal",
         "protoform": "935",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 178,
-        "baseDefense": 158,
         "formtypes": [
           {
             "type": "Grass",
@@ -28856,10 +24158,6 @@
       {
         "nameform": "Shadow",
         "protoform": "936",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 178,
-        "baseDefense": 158,
         "formtypes": [
           {
             "type": "Grass",
@@ -28874,10 +24172,6 @@
       {
         "nameform": "Purified",
         "protoform": "937",
-        "assetsform": "00",
-        "baseStamina": 207,
-        "baseAttack": 178,
-        "baseDefense": 158,
         "formtypes": [
           {
             "type": "Grass",
@@ -28894,9 +24188,6 @@
   "461":{
     "name": "Weavile",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 243,
-    "baseDefense": 171,
     "types": [
       {
         "type": "Dark",
@@ -28911,10 +24202,6 @@
       {
         "nameform": "Normal",
         "protoform": "800",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 243,
-        "baseDefense": 171,
         "formtypes": [
           {
             "type": "Dark",
@@ -28929,10 +24216,6 @@
       {
         "nameform": "Shadow",
         "protoform": "801",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 243,
-        "baseDefense": 171,
         "formtypes": [
           {
             "type": "Dark",
@@ -28948,10 +24231,6 @@
       {
         "nameform": "Purified",
         "protoform": "802",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 243,
-        "baseDefense": 171,
         "formtypes": [
           {
             "type": "Dark",
@@ -28969,9 +24248,6 @@
   "462":{
     "name": "Magnezone",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 238,
-    "baseDefense": 205,
     "types": [
       {
         "type": "Electric",
@@ -28986,10 +24262,6 @@
       {
         "nameform": "Normal",
         "protoform": "661",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 238,
-        "baseDefense": 205,
         "formtypes": [
           {
             "type": "Electric",
@@ -29004,10 +24276,6 @@
       {
         "nameform": "Shadow",
         "protoform": "662",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 238,
-        "baseDefense": 205,
         "formtypes": [
           {
             "type": "Electric",
@@ -29022,10 +24290,6 @@
       {
         "nameform": "Purified",
         "protoform": "663",
-        "assetsform": "00",
-        "baseStamina": 172,
-        "baseAttack": 238,
-        "baseDefense": 205,
         "formtypes": [
           {
             "type": "Electric",
@@ -29042,9 +24306,6 @@
   "463":{
     "name": "Lickilicky",
     "rarity":"",
-    "baseStamina": 242,
-    "baseAttack": 161,
-    "baseDefense": 181,
     "types": [
       {
         "type": "Normal",
@@ -29055,7 +24316,6 @@
       {
         "nameform": "Normal",
         "protoform": "1820",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -29066,7 +24326,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1821",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -29077,7 +24336,6 @@
       {
         "nameform": "Purified",
         "protoform": "1822",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -29090,9 +24348,6 @@
   "464":{
     "name": "Rhyperior",
     "rarity":"",
-    "baseStamina": 251,
-    "baseAttack": 241,
-    "baseDefense": 190,
     "types": [
       {
         "type": "Ground",
@@ -29107,10 +24362,6 @@
       {
         "nameform": "Normal",
         "protoform": "852",
-        "assetsform": "00",
-        "baseStamina": 251,
-        "baseAttack": 241,
-        "baseDefense": 190,
         "formtypes": [
           {
             "type": "Ground",
@@ -29125,10 +24376,6 @@
       {
         "nameform": "Shadow",
         "protoform": "853",
-        "assetsform": "00",
-        "baseStamina": 251,
-        "baseAttack": 241,
-        "baseDefense": 190,
         "formtypes": [
           {
             "type": "Ground",
@@ -29143,10 +24390,6 @@
       {
         "nameform": "Purified",
         "protoform": "854",
-        "assetsform": "00",
-        "baseStamina": 251,
-        "baseAttack": 241,
-        "baseDefense": 190,
         "formtypes": [
           {
             "type": "Ground",
@@ -29163,9 +24406,6 @@
   "465":{
     "name": "Tangrowth",
     "rarity":"",
-    "baseStamina": 225,
-    "baseAttack": 207,
-    "baseDefense": 184,
     "types": [
       {
         "type": "Grass",
@@ -29176,7 +24416,6 @@
       {
         "nameform": "Normal",
         "protoform": "1823",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -29187,7 +24426,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1824",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -29198,7 +24436,6 @@
       {
         "nameform": "Purified",
         "protoform": "1825",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -29211,9 +24448,6 @@
   "466":{
     "name": "Electivire",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 249,
-    "baseDefense": 163,
     "types": [
       {
         "type": "Electric",
@@ -29224,10 +24458,6 @@
       {
         "nameform": "Normal",
         "protoform": "643",
-        "assetsform": "00",
-        "baseStamina": 181,
-        "baseAttack": 249,
-        "baseDefense": 163,
         "formtypes": [
           {
             "type": "Electric",
@@ -29238,10 +24468,6 @@
       {
         "nameform": "Shadow",
         "protoform": "644",
-        "assetsform": "00",
-        "baseStamina": 181,
-        "baseAttack": 249,
-        "baseDefense": 163,
         "formtypes": [
           {
             "type": "Electric",
@@ -29252,10 +24478,6 @@
       {
         "nameform": "Purified",
         "protoform": "645",
-        "assetsform": "00",
-        "baseStamina": 181,
-        "baseAttack": 249,
-        "baseDefense": 163,
         "formtypes": [
           {
             "type": "Electric",
@@ -29268,9 +24490,6 @@
   "467":{
     "name": "Magmortar",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 247,
-    "baseDefense": 172,
     "types": [
       {
         "type": "Fire",
@@ -29281,10 +24500,6 @@
       {
         "nameform": "Normal",
         "protoform": "637",
-        "assetsform": "00",
-        "baseStamina": 181,
-        "baseAttack": 247,
-        "baseDefense": 172,
         "formtypes": [
           {
             "type": "Fire",
@@ -29295,10 +24510,6 @@
       {
         "nameform": "Shadow",
         "protoform": "638",
-        "assetsform": "00",
-        "baseStamina": 181,
-        "baseAttack": 247,
-        "baseDefense": 172,
         "formtypes": [
           {
             "type": "Fire",
@@ -29309,10 +24520,6 @@
       {
         "nameform": "Purified",
         "protoform": "639",
-        "assetsform": "00",
-        "baseStamina": 181,
-        "baseAttack": 247,
-        "baseDefense": 172,
         "formtypes": [
           {
             "type": "Fire",
@@ -29325,9 +24532,6 @@
   "468":{
     "name": "Togekiss",
     "rarity":"",
-    "baseStamina": 198,
-    "baseAttack": 225,
-    "baseDefense": 217,
     "types": [
       {
         "type": "Fairy",
@@ -29342,7 +24546,6 @@
       {
         "nameform": "Normal",
         "protoform": "1826",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fairy",
@@ -29357,7 +24560,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1827",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fairy",
@@ -29372,7 +24574,6 @@
       {
         "nameform": "Purified",
         "protoform": "1828",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fairy",
@@ -29389,9 +24590,6 @@
   "469":{
     "name": "Yanmega",
     "rarity":"",
-    "baseStamina": 200,
-    "baseAttack": 231,
-    "baseDefense": 156,
     "types": [
       {
         "type": "Bug",
@@ -29406,7 +24604,6 @@
       {
         "nameform": "Normal",
         "protoform": "1829",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -29421,7 +24618,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1830",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -29436,7 +24632,6 @@
       {
         "nameform": "Purified",
         "protoform": "1831",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -29453,9 +24648,6 @@
   "470":{
     "name": "Leafeon",
     "rarity":"",
-    "baseStamina": 163,
-    "baseAttack": 216,
-    "baseDefense": 219,
     "types": [
       {
         "type": "Grass",
@@ -29466,7 +24658,6 @@
       {
         "nameform": "Normal",
         "protoform": "1832",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -29477,7 +24668,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1833",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -29488,7 +24678,6 @@
       {
         "nameform": "Purified",
         "protoform": "1834",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -29501,9 +24690,6 @@
   "471":{
     "name": "Glaceon",
     "rarity":"",
-    "baseStamina": 163,
-    "baseAttack": 238,
-    "baseDefense": 205,
     "types": [
       {
         "type": "Ice",
@@ -29514,7 +24700,6 @@
       {
         "nameform": "Normal",
         "protoform": "1835",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -29525,7 +24710,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1836",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -29536,7 +24720,6 @@
       {
         "nameform": "Purified",
         "protoform": "1837",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -29549,9 +24732,6 @@
   "472":{
     "name": "Gliscor",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 185,
-    "baseDefense": 222,
     "types": [
       {
         "type": "Ground",
@@ -29566,10 +24746,6 @@
       {
         "nameform": "Normal",
         "protoform": "806",
-        "assetsform": "00",
-        "baseStamina": 181,
-        "baseAttack": 185,
-        "baseDefense": 222,
         "formtypes": [
           {
             "type": "Ground",
@@ -29584,10 +24760,6 @@
       {
         "nameform": "Shadow",
         "protoform": "807",
-        "assetsform": "00",
-        "baseStamina": 181,
-        "baseAttack": 185,
-        "baseDefense": 222,
         "formtypes": [
           {
             "type": "Ground",
@@ -29602,10 +24774,6 @@
       {
         "nameform": "Purified",
         "protoform": "808",
-        "assetsform": "00",
-        "baseStamina": 181,
-        "baseAttack": 185,
-        "baseDefense": 222,
         "formtypes": [
           {
             "type": "Ground",
@@ -29622,9 +24790,6 @@
   "473":{
     "name": "Mamoswine",
     "rarity":"",
-    "baseStamina": 242,
-    "baseAttack": 247,
-    "baseDefense": 146,
     "types": [
       {
         "type": "Ice",
@@ -29639,7 +24804,6 @@
       {
         "nameform": "Normal",
         "protoform": "1838",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -29654,7 +24818,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1839",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -29669,7 +24832,6 @@
       {
         "nameform": "Purified",
         "protoform": "1840",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -29686,9 +24848,6 @@
   "474":{
     "name": "Porygon-Z",
     "rarity":"",
-    "baseStamina": 198,
-    "baseAttack": 264,
-    "baseDefense": 150,
     "types": [
       {
         "type": "Normal",
@@ -29699,10 +24858,6 @@
       {
         "nameform": "Normal",
         "protoform": "683",
-        "assetsform": "00",
-        "baseStamina": 198,
-        "baseAttack": 264,
-        "baseDefense": 150,
         "formtypes": [
           {
             "type": "Normal",
@@ -29713,10 +24868,6 @@
       {
         "nameform": "Shadow",
         "protoform": "684",
-        "assetsform": "00",
-        "baseStamina": 198,
-        "baseAttack": 264,
-        "baseDefense": 150,
         "formtypes": [
           {
             "type": "Normal",
@@ -29727,10 +24878,6 @@
       {
         "nameform": "Purified",
         "protoform": "685",
-        "assetsform": "00",
-        "baseStamina": 198,
-        "baseAttack": 264,
-        "baseDefense": 150,
         "formtypes": [
       {
             "type": "Normal",
@@ -29743,9 +24890,6 @@
   "475":{
     "name": "Gallade",
     "rarity":"",
-    "baseStamina": 169,
-    "baseAttack": 237,
-    "baseDefense": 195,
     "types": [
       {
         "type": "Psychic",
@@ -29760,10 +24904,6 @@
       {
         "nameform": "Normal",
         "protoform": "301",
-        "assetsform": "00",
-        "baseStamina": 169,
-        "baseAttack": 237,
-        "baseDefense": 195,
         "formtypes": [
           {
             "type": "Psychic",
@@ -29778,10 +24918,6 @@
       {
         "nameform": "Shadow",
         "protoform": "302",
-        "assetsform": "00",
-        "baseStamina": 169,
-        "baseAttack": 237,
-        "baseDefense": 195,
         "formtypes": [
           {
             "type": "Psychic",
@@ -29796,10 +24932,6 @@
       {
         "nameform": "Purified",
         "protoform": "303",
-        "assetsform": "00",
-        "baseStamina": 169,
-        "baseAttack": 237,
-        "baseDefense": 195,
         "formtypes": [
           {
             "type": "Psychic",
@@ -29816,9 +24948,6 @@
   "476":{
     "name": "Probopass",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 135,
-    "baseDefense": 275,
     "types": [
       {
         "type": "Rock",
@@ -29833,7 +24962,6 @@
       {
         "nameform": "Normal",
         "protoform": "1841",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -29848,7 +24976,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1842",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -29863,7 +24990,6 @@
       {
         "nameform": "Purified",
         "protoform": "1843",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -29880,9 +25006,6 @@
   "477":{
     "name": "Dusknoir",
     "rarity":"",
-    "baseStamina": 128,
-    "baseAttack": 180,
-    "baseDefense": 254,
     "types": [
       {
         "type": "Ghost",
@@ -29893,10 +25016,6 @@
       {
         "nameform": "Normal",
         "protoform": "920",
-        "assetsform": "00",
-        "baseStamina": 128,
-        "baseAttack": 180,
-        "baseDefense": 254,
         "formtypes": [
           {
             "type": "Ghost",
@@ -29907,10 +25026,6 @@
       {
         "nameform": "Shadow",
         "protoform": "921",
-        "assetsform": "00",
-        "baseStamina": 128,
-        "baseAttack": 180,
-        "baseDefense": 254,
         "formtypes": [
           {
             "type": "Ghost",
@@ -29921,10 +25036,6 @@
       {
         "nameform": "Purified",
         "protoform": "922",
-        "assetsform": "00",
-        "baseStamina": 128,
-        "baseAttack": 180,
-        "baseDefense": 254,
         "formtypes": [
           {
             "type": "Ghost",
@@ -29937,9 +25048,6 @@
   "478":{
     "name": "Froslass",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 171,
-    "baseDefense": 150,
     "types": [
       {
         "type": "Ice",
@@ -29954,7 +25062,6 @@
       {
         "nameform": "Normal",
         "protoform": "1844",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -29969,7 +25076,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1845",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -29984,7 +25090,6 @@
       {
         "nameform": "Purified",
         "protoform": "1846",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -30001,9 +25106,6 @@
   "479":{
     "name": "Rotom",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 204,
-    "baseDefense": 219,
     "types": [
       {
         "type": "Electric",
@@ -30018,9 +25120,6 @@
       {
         "nameform": "Normal",
         "protoform": "82",
-        "baseStamina": 137,
-        "baseAttack": 204,
-        "baseDefense": 219,
         "formtypes": [
           {
             "type": "Electric",
@@ -30035,9 +25134,6 @@
       {
         "nameform": "Frost",
         "protoform": "83",
-        "baseStamina": 137,
-        "baseAttack": 204,
-        "baseDefense": 219,
         "formtypes": [
           {
             "type": "Electric",
@@ -30052,9 +25148,6 @@
       {
         "nameform": "Fan",
         "protoform": "84",
-        "baseStamina": 137,
-        "baseAttack": 204,
-        "baseDefense": 219,
         "formtypes": [
           {
             "type": "Electric",
@@ -30069,9 +25162,6 @@
       {
         "nameform": "Mow",
         "protoform": "85",
-        "baseStamina": 137,
-        "baseAttack": 204,
-        "baseDefense": 219,
         "formtypes": [
           {
             "type": "Electric",
@@ -30086,9 +25176,6 @@
       {
         "nameform": "Wash",
         "protoform": "86",
-        "baseStamina": 137,
-        "baseAttack": 204,
-        "baseDefense": 219,
         "formtypes": [
           {
             "type": "Electric",
@@ -30103,9 +25190,6 @@
       {
         "nameform": "Heat",
         "protoform": "87",
-        "baseStamina": 137,
-        "baseAttack": 204,
-        "baseDefense": 219,
         "formtypes": [
           {
             "type": "Electric",
@@ -30122,9 +25206,6 @@
   "480":{
     "name": "Uxie",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 156,
-    "baseDefense": 270,
     "types": [
       {
         "type": "Psychic",
@@ -30135,7 +25216,6 @@
       {
         "nameform": "Normal",
         "protoform": "1847",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -30146,7 +25226,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1848",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -30157,7 +25236,6 @@
       {
         "nameform": "Purified",
         "protoform": "1849",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -30170,9 +25248,6 @@
   "481":{
     "name": "Mesprit",
     "rarity":"",
-    "baseStamina": 190,
-    "baseAttack": 212,
-    "baseDefense": 212,
     "types": [
       {
         "type": "Psychic",
@@ -30183,7 +25258,6 @@
       {
         "nameform": "Normal",
         "protoform": "1850",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -30194,7 +25268,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1851",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -30205,7 +25278,6 @@
       {
         "nameform": "Purified",
         "protoform": "1852",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -30218,9 +25290,6 @@
   "482":{
     "name": "Azelf",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 270,
-    "baseDefense": 151,
     "types": [
       {
         "type": "Psychic",
@@ -30231,7 +25300,6 @@
       {
         "nameform": "Normal",
         "protoform": "1853",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -30242,7 +25310,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1854",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -30253,7 +25320,6 @@
       {
         "nameform": "Purified",
         "protoform": "1855",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -30266,9 +25332,6 @@
   "483":{
     "name": "Dialga",
     "rarity":"",
-    "baseStamina": 205,
-    "baseAttack": 275,
-    "baseDefense": 211,
     "types": [
       {
         "type": "Steel",
@@ -30283,7 +25346,6 @@
       {
         "nameform": "Normal",
         "protoform": "1856",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -30298,7 +25360,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1857",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -30313,7 +25374,6 @@
       {
         "nameform": "Purified",
         "protoform": "1858",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -30330,9 +25390,6 @@
   "484":{
     "name": "Palkia",
     "rarity":"",
-    "baseStamina": 189,
-    "baseAttack": 280,
-    "baseDefense": 215,
     "types": [
       {
         "type": "Water",
@@ -30347,7 +25404,6 @@
       {
         "nameform": "Normal",
         "protoform": "1859",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -30362,7 +25418,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1860",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -30377,7 +25432,6 @@
       {
         "nameform": "Purified",
         "protoform": "1861",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -30394,9 +25448,6 @@
   "485":{
     "name": "Heatran",
     "rarity":"",
-    "baseStamina": 209,
-    "baseAttack": 251,
-    "baseDefense": 213,
     "types": [
       {
         "type": "Fire",
@@ -30411,7 +25462,6 @@
       {
         "nameform": "Normal",
         "protoform": "1862",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -30426,7 +25476,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1863",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -30441,7 +25490,6 @@
       {
         "nameform": "Purified",
         "protoform": "1864",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -30458,9 +25506,6 @@
   "486":{
     "name": "Regigigas",
     "rarity":"",
-    "baseStamina": 221,
-    "baseAttack": 287,
-    "baseDefense": 210,
     "types": [
       {
         "type": "Normal",
@@ -30471,7 +25516,6 @@
       {
         "nameform": "Normal",
         "protoform": "1865",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -30482,7 +25526,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1866",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -30493,7 +25536,6 @@
       {
         "nameform": "Purified",
         "protoform": "1867",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -30506,9 +25548,6 @@
   "487":{
     "name": "Giratina",
     "rarity":"",
-    "baseStamina": 284,
-    "baseAttack": 187,
-    "baseDefense": 225,
     "types": [
       {
         "type": "Ghost",
@@ -30523,10 +25562,6 @@
       {
         "nameform": "Altered",
         "protoform": "90",
-        "assetsform": "11",
-        "baseStamina": 284,
-        "baseAttack": 187,
-        "baseDefense": 225,
         "formtypes": [
           {
             "type": "Ghost",
@@ -30541,10 +25576,6 @@
       {
         "nameform": "Origin",
         "protoform": "91",
-        "assetsform": "12",
-        "baseStamina": 284,
-        "baseAttack": 225,
-        "baseDefense": 187,
         "formtypes": [
           {
             "type": "Ghost",
@@ -30559,7 +25590,6 @@
       {
         "nameform": "Normal",
         "protoform": "1868",
-        "assetsform": "12",
         "formtypes": [
           {
             "type": "Ghost",
@@ -30574,7 +25604,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1869",
-        "assetsform": "12",
         "formtypes": [
           {
             "type": "Ghost",
@@ -30589,7 +25618,6 @@
       {
         "nameform": "Purified",
         "protoform": "1870",
-        "assetsform": "12",
         "formtypes": [
           {
             "type": "Ghost",
@@ -30606,9 +25634,6 @@
   "488":{
     "name": "Cresselia",
     "rarity":"",
-    "baseStamina": 260,
-    "baseAttack": 152,
-    "baseDefense": 258,
     "types": [
       {
         "type": "Psychic",
@@ -30619,7 +25644,6 @@
       {
         "nameform": "Normal",
         "protoform": "1871",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -30630,7 +25654,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1872",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -30641,7 +25664,6 @@
       {
         "nameform": "Purified",
         "protoform": "1873",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -30654,9 +25676,6 @@
   "489":{
     "name": "Phione",
     "rarity":"",
-    "baseStamina": 190,
-    "baseAttack": 162,
-    "baseDefense": 162,
     "types": [
       {
         "type": "Water",
@@ -30667,7 +25686,6 @@
       {
         "nameform": "Normal",
         "protoform": "1874",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -30678,7 +25696,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1875",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -30689,7 +25706,6 @@
       {
         "nameform": "Purified",
         "protoform": "1876",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -30702,9 +25718,6 @@
   "490":{
     "name": "Manaphy",
     "rarity":"",
-    "baseStamina": 225,
-    "baseAttack": 210,
-    "baseDefense": 210,
     "types": [
       {
         "type": "Water",
@@ -30715,7 +25728,6 @@
       {
         "nameform": "Normal",
         "protoform": "1877",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -30726,7 +25738,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1878",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -30737,7 +25748,6 @@
       {
         "nameform": "Purified",
         "protoform": "1879",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -30750,9 +25760,6 @@
   "491":{
     "name": "Darkrai",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 285,
-    "baseDefense": 198,
     "types": [
       {
         "type": "Dark",
@@ -30763,7 +25770,6 @@
       {
         "nameform": "Normal",
         "protoform": "1880",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -30774,7 +25780,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1881",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -30785,7 +25790,6 @@
       {
         "nameform": "Purified",
         "protoform": "1882",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -30798,9 +25802,6 @@
   "492":{
     "name": "Shaymin",
     "rarity":"",
-    "baseStamina": 225,
-    "baseAttack": 261,
-    "baseDefense": 166,
     "types": [
       {
         "type": "Grass",
@@ -30811,10 +25812,6 @@
       {
         "nameform": "Sky",
         "protoform": "92",
-        "assetsform": "12",
-        "baseStamina": 225,
-        "baseAttack": 261,
-        "baseDefense": 166,
         "formtypes": [
           {
             "type": "Grass",
@@ -30829,10 +25826,6 @@
       {
         "nameform": "Land",
         "protoform": "93",
-        "assetsform": "11",
-        "baseStamina": 225,
-        "baseAttack": 210,
-        "baseDefense": 210,
         "formtypes": [
           {
             "type": "Grass",
@@ -30843,7 +25836,6 @@
       {
         "nameform": "Normal",
         "protoform": "1883",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -30854,7 +25846,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1884",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -30865,7 +25856,6 @@
       {
         "nameform": "Purified",
         "protoform": "1885",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -30878,9 +25868,6 @@
   "493":{
     "name": "Arceus",
     "rarity":"",
-    "baseStamina": 237,
-    "baseAttack": 238,
-    "baseDefense": 238,
     "types": [
       {
         "type": "Normal",
@@ -30891,9 +25878,6 @@
       {
         "nameform": "Normal",
         "protoform": "100",
-        "baseStamina": 237,
-        "baseAttack": 238,
-        "baseDefense": 238,
         "formtypes": [
           {
             "type": "Normal",
@@ -30904,9 +25888,6 @@
       {
         "nameform": "Fighting",
         "protoform": "101",
-        "baseStamina": 237,
-        "baseAttack": 238,
-        "baseDefense": 238,
         "formtypes": [
           {
             "type": "Fighting",
@@ -30917,9 +25898,6 @@
       {
         "nameform": "Flying",
         "protoform": "102",
-        "baseStamina": 237,
-        "baseAttack": 238,
-        "baseDefense": 238,
         "formtypes": [
           {
             "type": "Flying",
@@ -30930,9 +25908,6 @@
       {
         "nameform": "Poison",
         "protoform": "103",
-        "baseStamina": 237,
-        "baseAttack": 238,
-        "baseDefense": 238,
         "formtypes": [
           {
             "type": "Poison",
@@ -30943,9 +25918,6 @@
       {
         "nameform": "Ground",
         "protoform": "104",
-        "baseStamina": 237,
-        "baseAttack": 238,
-        "baseDefense": 238,
         "formtypes": [
           {
             "type": "Ground",
@@ -30956,9 +25928,6 @@
       {
         "nameform": "Rock",
         "protoform": "105",
-        "baseStamina": 237,
-        "baseAttack": 238,
-        "baseDefense": 238,
         "formtypes": [
           {
             "type": "Rock",
@@ -30969,9 +25938,6 @@
       {
         "nameform": "Bug",
         "protoform": "106",
-        "baseStamina": 237,
-        "baseAttack": 238,
-        "baseDefense": 238,
         "formtypes": [
           {
             "type": "Bug",
@@ -30982,9 +25948,6 @@
       {
         "nameform": "Ghost",
         "protoform": "107",
-        "baseStamina": 237,
-        "baseAttack": 238,
-        "baseDefense": 238,
         "formtypes": [
           {
             "type": "Ghost",
@@ -30995,9 +25958,6 @@
       {
         "nameform": "Steel",
         "protoform": "108",
-        "baseStamina": 237,
-        "baseAttack": 238,
-        "baseDefense": 238,
         "formtypes": [
           {
             "type": "Steel",
@@ -31008,9 +25968,6 @@
       {
         "nameform": "Fire",
         "protoform": "109",
-        "baseStamina": 237,
-        "baseAttack": 238,
-        "baseDefense": 238,
         "formtypes": [
           {
             "type": "Fire",
@@ -31021,9 +25978,6 @@
       {
         "nameform": "Water",
         "protoform": "110",
-        "baseStamina": 237,
-        "baseAttack": 238,
-        "baseDefense": 238,
         "formtypes": [
           {
             "type": "Water",
@@ -31034,9 +25988,6 @@
       {
         "nameform": "Grass",
         "protoform": "111",
-        "baseStamina": 237,
-        "baseAttack": 238,
-        "baseDefense": 238,
         "formtypes": [
           {
             "type": "Grass",
@@ -31047,9 +25998,6 @@
       {
         "nameform": "Electric",
         "protoform": "112",
-        "baseStamina": 237,
-        "baseAttack": 238,
-        "baseDefense": 238,
         "formtypes": [
           {
             "type": "Electric",
@@ -31060,9 +26008,6 @@
       {
         "nameform": "Psychic",
         "protoform": "113",
-        "baseStamina": 237,
-        "baseAttack": 238,
-        "baseDefense": 238,
         "formtypes": [
           {
             "type": "Psychic",
@@ -31073,9 +26018,6 @@
       {
         "nameform": "Ice",
         "protoform": "114",
-        "baseStamina": 237,
-        "baseAttack": 238,
-        "baseDefense": 238,
         "formtypes": [
           {
             "type": "Ice",
@@ -31086,9 +26028,6 @@
       {
         "nameform": "Dragon",
         "protoform": "115",
-        "baseStamina": 237,
-        "baseAttack": 238,
-        "baseDefense": 238,
         "formtypes": [
           {
             "type": "Dragon",
@@ -31099,9 +26038,6 @@
       {
         "nameform": "Dark",
         "protoform": "116",
-        "baseStamina": 237,
-        "baseAttack": 238,
-        "baseDefense": 238,
         "formtypes": [
           {
             "type": "Dark",
@@ -31112,9 +26048,6 @@
       {
         "nameform": "Fairy",
         "protoform": "117",
-        "baseStamina": 237,
-        "baseAttack": 238,
-        "baseDefense": 238,
         "formtypes": [
           {
             "type": "Fairy",
@@ -31127,9 +26060,6 @@
   "494":{
     "name": "Victini",
     "rarity":"",
-    "baseStamina": 225,
-    "baseAttack": 210,
-    "baseDefense": 210,
     "types": [
       {
         "type": "Psychic",
@@ -31144,7 +26074,6 @@
       {
         "nameform": "Normal",
         "protoform": "1886",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -31159,7 +26088,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1887",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -31174,7 +26102,6 @@
       {
         "nameform": "Purified",
         "protoform": "1888",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -31191,9 +26118,6 @@
   "495":{
     "name": "Snivy",
     "rarity":"",
-    "baseStamina": 128,
-    "baseAttack": 88,
-    "baseDefense": 107,
     "types": [
       {
         "type": "Grass",
@@ -31204,7 +26128,6 @@
       {
         "nameform": "Normal",
         "protoform": "1889",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -31215,7 +26138,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1890",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -31226,7 +26148,6 @@
       {
         "nameform": "Purified",
         "protoform": "1891",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -31239,9 +26160,6 @@
   "496":{
     "name": "Servine",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 122,
-    "baseDefense": 152,
     "types": [
       {
         "type": "Grass",
@@ -31252,7 +26170,6 @@
       {
         "nameform": "Normal",
         "protoform": "1892",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -31263,7 +26180,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1893",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -31274,7 +26190,6 @@
       {
         "nameform": "Purified",
         "protoform": "1894",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -31287,9 +26202,6 @@
   "497":{
     "name": "Serperior",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 161,
-    "baseDefense": 204,
     "types": [
       {
         "type": "Grass",
@@ -31300,7 +26212,6 @@
       {
         "nameform": "Normal",
         "protoform": "1895",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -31311,7 +26222,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1896",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -31322,7 +26232,6 @@
       {
         "nameform": "Purified",
         "protoform": "1897",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -31335,9 +26244,6 @@
   "498":{
     "name": "Tepig",
     "rarity":"",
-    "baseStamina": 163,
-    "baseAttack": 115,
-    "baseDefense": 85,
     "types": [
       {
         "type": "Fire",
@@ -31348,7 +26254,6 @@
       {
         "nameform": "Normal",
         "protoform": "1898",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -31359,7 +26264,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1899",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -31370,7 +26274,6 @@
       {
         "nameform": "Purified",
         "protoform": "1900",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -31383,9 +26286,6 @@
   "499":{
     "name": "Pignite",
     "rarity":"",
-    "baseStamina": 207,
-    "baseAttack": 173,
-    "baseDefense": 106,
     "types": [
       {
         "type": "Fire",
@@ -31400,7 +26300,6 @@
       {
         "nameform": "Normal",
         "protoform": "1901",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -31415,7 +26314,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1902",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -31430,7 +26328,6 @@
       {
         "nameform": "Purified",
         "protoform": "1903",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -31447,9 +26344,6 @@
   "500":{
     "name": "Emboar",
     "rarity":"",
-    "baseStamina": 242,
-    "baseAttack": 235,
-    "baseDefense": 127,
     "types": [
       {
         "type": "Fire",
@@ -31464,7 +26358,6 @@
       {
         "nameform": "Normal",
         "protoform": "1904",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -31479,7 +26372,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1905",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -31494,7 +26386,6 @@
       {
         "nameform": "Purified",
         "protoform": "1906",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -31511,9 +26402,6 @@
   "501":{
     "name": "Oshawott",
     "rarity":"",
-    "baseStamina": 146,
-    "baseAttack": 117,
-    "baseDefense": 85,
     "types": [
       {
         "type": "Water",
@@ -31524,7 +26412,6 @@
       {
         "nameform": "Normal",
         "protoform": "1907",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -31535,7 +26422,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1908",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -31546,7 +26432,6 @@
       {
         "nameform": "Purified",
         "protoform": "1909",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -31559,9 +26444,6 @@
   "502":{
     "name": "Dewott",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 159,
-    "baseDefense": 116,
     "types": [
       {
         "type": "Water",
@@ -31572,7 +26454,6 @@
       {
         "nameform": "Normal",
         "protoform": "1910",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -31583,7 +26464,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1911",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -31594,7 +26474,6 @@
       {
         "nameform": "Purified",
         "protoform": "1912",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -31607,9 +26486,6 @@
   "503":{
     "name": "Samurott",
     "rarity":"",
-    "baseStamina": 216,
-    "baseAttack": 212,
-    "baseDefense": 157,
     "types": [
       {
         "type": "Water",
@@ -31620,7 +26496,6 @@
       {
         "nameform": "Normal",
         "protoform": "1913",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -31631,7 +26506,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1914",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -31642,7 +26516,6 @@
       {
         "nameform": "Purified",
         "protoform": "1915",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -31655,9 +26528,6 @@
   "504":{
     "name": "Patrat",
     "rarity":"",
-    "baseStamina": 128,
-    "baseAttack": 98,
-    "baseDefense": 73,
     "types": [
       {
         "type": "Normal",
@@ -31668,7 +26538,6 @@
       {
         "nameform": "Normal",
         "protoform": "1916",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -31679,7 +26548,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1917",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -31690,7 +26558,6 @@
       {
         "nameform": "Purified",
         "protoform": "1918",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -31703,9 +26570,6 @@
   "505":{
     "name": "Watchog",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 165,
-    "baseDefense": 139,
     "types": [
       {
         "type": "Normal",
@@ -31716,7 +26580,6 @@
       {
         "nameform": "Normal",
         "protoform": "1919",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -31727,7 +26590,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1920",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -31738,7 +26600,6 @@
       {
         "nameform": "Purified",
         "protoform": "1921",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -31751,9 +26612,6 @@
   "506":{
     "name": "Lillipup",
     "rarity":"",
-    "baseStamina": 128,
-    "baseAttack": 107,
-    "baseDefense": 86,
     "types": [
       {
         "type": "Normal",
@@ -31764,7 +26622,6 @@
       {
         "nameform": "Normal",
         "protoform": "1922",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -31775,7 +26632,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1923",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -31786,7 +26642,6 @@
       {
         "nameform": "Purified",
         "protoform": "1924",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -31799,9 +26654,6 @@
   "507":{
     "name": "Herdier",
     "rarity":"",
-    "baseStamina": 163,
-    "baseAttack": 145,
-    "baseDefense": 126,
     "types": [
       {
         "type": "Normal",
@@ -31812,7 +26664,6 @@
       {
         "nameform": "Normal",
         "protoform": "1925",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -31823,7 +26674,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1926",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -31834,7 +26684,6 @@
       {
         "nameform": "Purified",
         "protoform": "1927",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -31847,9 +26696,6 @@
   "508":{
     "name": "Stoutland",
     "rarity":"",
-    "baseStamina": 198,
-    "baseAttack": 206,
-    "baseDefense": 182,
     "types": [
       {
         "type": "Normal",
@@ -31860,7 +26706,6 @@
       {
         "nameform": "Normal",
         "protoform": "1928",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -31871,7 +26716,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1929",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -31882,7 +26726,6 @@
       {
         "nameform": "Purified",
         "protoform": "1930",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -31895,9 +26738,6 @@
   "509":{
     "name": "Purrloin",
     "rarity":"",
-    "baseStamina": 121,
-    "baseAttack": 98,
-    "baseDefense": 73,
     "types": [
       {
         "type": "Dark",
@@ -31908,7 +26748,6 @@
       {
         "nameform": "Normal",
         "protoform": "1931",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -31919,7 +26758,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1932",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -31930,7 +26768,6 @@
       {
         "nameform": "Purified",
         "protoform": "1933",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -31943,9 +26780,6 @@
   "510":{
     "name": "Liepard",
     "rarity":"",
-    "baseStamina": 162,
-    "baseAttack": 187,
-    "baseDefense": 106,
     "types": [
       {
         "type": "Dark",
@@ -31956,7 +26790,6 @@
       {
         "nameform": "Normal",
         "protoform": "1934",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -31967,7 +26800,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1935",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -31978,7 +26810,6 @@
       {
         "nameform": "Purified",
         "protoform": "1936",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -31991,9 +26822,6 @@
   "511":{
     "name": "Pansage",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 104,
-    "baseDefense": 94,
     "types": [
       {
         "type": "Grass",
@@ -32004,7 +26832,6 @@
       {
         "nameform": "Normal",
         "protoform": "1937",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -32015,7 +26842,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1938",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -32026,7 +26852,6 @@
       {
         "nameform": "Purified",
         "protoform": "1939",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -32039,9 +26864,6 @@
   "512":{
     "name": "Simisage",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 206,
-    "baseDefense": 133,
     "types": [
       {
         "type": "Grass",
@@ -32052,7 +26874,6 @@
       {
         "nameform": "Normal",
         "protoform": "1940",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -32063,7 +26884,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1941",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -32074,7 +26894,6 @@
       {
         "nameform": "Purified",
         "protoform": "1942",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -32087,9 +26906,6 @@
   "513":{
     "name": "Pansear",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 104,
-    "baseDefense": 94,
     "types": [
       {
         "type": "Fire",
@@ -32100,7 +26916,6 @@
       {
         "nameform": "Normal",
         "protoform": "1943",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -32111,7 +26926,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1944",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -32122,7 +26936,6 @@
       {
         "nameform": "Purified",
         "protoform": "1945",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -32135,9 +26948,6 @@
   "514":{
     "name": "Simisear",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 206,
-    "baseDefense": 133,
     "types": [
       {
         "type": "Fire",
@@ -32148,7 +26958,6 @@
       {
         "nameform": "Normal",
         "protoform": "1946",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -32159,7 +26968,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1947",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -32170,7 +26978,6 @@
       {
         "nameform": "Purified",
         "protoform": "1948",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -32183,9 +26990,6 @@
   "515":{
     "name": "Panpour",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 104,
-    "baseDefense": 94,
     "types": [
       {
         "type": "Water",
@@ -32196,7 +27000,6 @@
       {
         "nameform": "Normal",
         "protoform": "1949",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -32207,7 +27010,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1950",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -32218,7 +27020,6 @@
       {
         "nameform": "Purified",
         "protoform": "1951",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -32231,9 +27032,6 @@
   "516":{
     "name": "Simipour",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 206,
-    "baseDefense": 133,
     "types": [
       {
         "type": "Water",
@@ -32244,7 +27042,6 @@
       {
         "nameform": "Normal",
         "protoform": "1952",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -32255,7 +27052,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1953",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -32266,7 +27062,6 @@
       {
         "nameform": "Purified",
         "protoform": "1954",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -32279,9 +27074,6 @@
   "517":{
     "name": "Munna",
     "rarity":"",
-    "baseStamina": 183,
-    "baseAttack": 111,
-    "baseDefense": 92,
     "types": [
       {
         "type": "Psychic",
@@ -32292,7 +27084,6 @@
       {
         "nameform": "Normal",
         "protoform": "1955",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -32303,7 +27094,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1956",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -32314,7 +27104,6 @@
       {
         "nameform": "Purified",
         "protoform": "1957",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -32327,9 +27116,6 @@
   "518":{
     "name": "Musharna",
     "rarity":"",
-    "baseStamina": 253,
-    "baseAttack": 183,
-    "baseDefense": 166,
     "types": [
       {
         "type": "Psychic",
@@ -32340,7 +27126,6 @@
       {
         "nameform": "Normal",
         "protoform": "1958",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -32351,7 +27136,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1959",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -32362,7 +27146,6 @@
       {
         "nameform": "Purified",
         "protoform": "1960",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -32375,9 +27158,6 @@
   "519":{
     "name": "Pidove",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 98,
-    "baseDefense": 80,
     "types": [
       {
         "type": "Normal",
@@ -32392,7 +27172,6 @@
       {
         "nameform": "Normal",
         "protoform": "1961",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -32407,7 +27186,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1962",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -32422,7 +27200,6 @@
       {
         "nameform": "Purified",
         "protoform": "1963",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -32439,9 +27216,6 @@
   "520":{
     "name": "Tranquill",
     "rarity":"",
-    "baseStamina": 158,
-    "baseAttack": 144,
-    "baseDefense": 107,
     "types": [
       {
         "type": "Normal",
@@ -32456,7 +27230,6 @@
       {
         "nameform": "Normal",
         "protoform": "1964",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -32471,7 +27244,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1965",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -32486,7 +27258,6 @@
       {
         "nameform": "Purified",
         "protoform": "1966",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -32503,9 +27274,6 @@
   "521":{
     "name": "Unfezant",
     "rarity":"",
-    "baseStamina": 190,
-    "baseAttack": 226,
-    "baseDefense": 146,
     "types": [
       {
         "type": "Normal",
@@ -32520,7 +27288,6 @@
       {
         "nameform": "Normal",
         "protoform": "1967",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -32535,7 +27302,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1968",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -32550,7 +27316,6 @@
       {
         "nameform": "Purified",
         "protoform": "1969",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -32567,9 +27332,6 @@
   "522":{
     "name": "Blitzle",
     "rarity":"",
-    "baseStamina": 128,
-    "baseAttack": 118,
-    "baseDefense": 64,
     "types": [
       {
         "type": "Electric",
@@ -32580,7 +27342,6 @@
       {
         "nameform": "Normal",
         "protoform": "1970",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -32591,7 +27352,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1971",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -32602,7 +27362,6 @@
       {
         "nameform": "Purified",
         "protoform": "1972",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -32615,9 +27374,6 @@
   "523":{
     "name": "Zebstrika",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 211,
-    "baseDefense": 136,
     "types": [
       {
         "type": "Electric",
@@ -32628,7 +27384,6 @@
       {
         "nameform": "Normal",
         "protoform": "1973",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -32639,7 +27394,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1974",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -32650,7 +27404,6 @@
       {
         "nameform": "Purified",
         "protoform": "1975",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -32663,9 +27416,6 @@
   "524":{
     "name": "Roggenrola",
     "rarity":"",
-    "baseStamina": 146,
-    "baseAttack": 121,
-    "baseDefense": 110,
     "types": [
       {
         "type": "Rock",
@@ -32676,7 +27426,6 @@
       {
         "nameform": "Normal",
         "protoform": "1976",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -32687,7 +27436,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1977",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -32698,7 +27446,6 @@
       {
         "nameform": "Purified",
         "protoform": "1978",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -32711,9 +27458,6 @@
   "525":{
     "name": "Boldore",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 174,
-    "baseDefense": 143,
     "types": [
       {
         "type": "Rock",
@@ -32724,7 +27468,6 @@
       {
         "nameform": "Normal",
         "protoform": "1979",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -32735,7 +27478,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1980",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -32746,7 +27488,6 @@
       {
         "nameform": "Purified",
         "protoform": "1981",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -32759,9 +27500,6 @@
   "526":{
     "name": "Gigalith",
     "rarity":"",
-    "baseStamina": 198,
-    "baseAttack": 226,
-    "baseDefense": 201,
     "types": [
       {
         "type": "Rock",
@@ -32772,7 +27510,6 @@
       {
         "nameform": "Normal",
         "protoform": "1982",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -32783,7 +27520,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1983",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -32794,7 +27530,6 @@
       {
         "nameform": "Purified",
         "protoform": "1984",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -32807,9 +27542,6 @@
   "527":{
     "name": "Woobat",
     "rarity":"",
-    "baseStamina": 163,
-    "baseAttack": 107,
-    "baseDefense": 85,
     "types": [
       {
         "type": "Psychic",
@@ -32824,7 +27556,6 @@
       {
         "nameform": "Normal",
         "protoform": "1985",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -32839,7 +27570,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1986",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -32854,7 +27584,6 @@
       {
         "nameform": "Purified",
         "protoform": "1987",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -32871,9 +27600,6 @@
   "528":{
     "name": "Swoobat",
     "rarity":"",
-    "baseStamina": 167,
-    "baseAttack": 161,
-    "baseDefense": 119,
     "types": [
       {
         "type": "Psychic",
@@ -32888,7 +27614,6 @@
       {
         "nameform": "Normal",
         "protoform": "1988",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -32903,7 +27628,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1989",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -32918,7 +27642,6 @@
       {
         "nameform": "Purified",
         "protoform": "1990",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -32935,9 +27658,6 @@
   "529":{
     "name": "Drilbur",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 154,
-    "baseDefense": 85,
     "types": [
       {
         "type": "Ground",
@@ -32948,7 +27668,6 @@
       {
         "nameform": "Normal",
         "protoform": "1991",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -32959,7 +27678,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1992",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -32970,7 +27688,6 @@
       {
         "nameform": "Purified",
         "protoform": "1993",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -32983,9 +27700,6 @@
   "530":{
     "name": "Excadrill",
     "rarity":"",
-    "baseStamina": 242,
-    "baseAttack": 255,
-    "baseDefense": 129,
     "types": [
       {
         "type": "Ground",
@@ -33000,7 +27714,6 @@
       {
         "nameform": "Normal",
         "protoform": "1994",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -33015,7 +27728,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1995",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -33030,7 +27742,6 @@
       {
         "nameform": "Purified",
         "protoform": "1996",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -33047,9 +27758,6 @@
   "531":{
     "name": "Audino",
     "rarity":"",
-    "baseStamina": 230,
-    "baseAttack": 114,
-    "baseDefense": 163,
     "types": [
       {
         "type": "Normal",
@@ -33060,7 +27768,6 @@
       {
         "nameform": "Normal",
         "protoform": "1997",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -33071,7 +27778,6 @@
       {
         "nameform": "Shadow",
         "protoform": "1998",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -33082,7 +27788,6 @@
       {
         "nameform": "Purified",
         "protoform": "1999",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -33095,9 +27800,6 @@
   "532":{
     "name": "Timburr",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 134,
-    "baseDefense": 87,
     "types": [
       {
         "type": "Fighting",
@@ -33108,7 +27810,6 @@
       {
         "nameform": "Normal",
         "protoform": "2000",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -33119,7 +27820,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2001",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -33130,7 +27830,6 @@
       {
         "nameform": "Purified",
         "protoform": "2002",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -33143,9 +27842,6 @@
   "533":{
     "name": "Gurdurr",
     "rarity":"",
-    "baseStamina": 198,
-    "baseAttack": 180,
-    "baseDefense": 134,
     "types": [
       {
         "type": "Fighting",
@@ -33156,7 +27852,6 @@
       {
         "nameform": "Normal",
         "protoform": "2003",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -33167,7 +27862,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2004",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -33178,7 +27872,6 @@
       {
         "nameform": "Purified",
         "protoform": "2005",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -33191,9 +27884,6 @@
   "534":{
     "name": "Conkeldurr",
     "rarity":"",
-    "baseStamina": 233,
-    "baseAttack": 243,
-    "baseDefense": 158,
     "types": [
       {
         "type": "Fighting",
@@ -33204,7 +27894,6 @@
       {
         "nameform": "Normal",
         "protoform": "2006",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -33215,7 +27904,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2007",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -33226,7 +27914,6 @@
       {
         "nameform": "Purified",
         "protoform": "2008",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -33239,9 +27926,6 @@
   "535":{
     "name": "Tympole",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 98,
-    "baseDefense": 78,
     "types": [
       {
         "type": "Water",
@@ -33252,7 +27936,6 @@
       {
         "nameform": "Normal",
         "protoform": "2009",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -33263,7 +27946,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2010",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -33274,7 +27956,6 @@
       {
         "nameform": "Purified",
         "protoform": "2011",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -33287,9 +27968,6 @@
   "536":{
     "name": "Palpitoad",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 128,
-    "baseDefense": 109,
     "types": [
       {
         "type": "Water",
@@ -33304,7 +27982,6 @@
       {
         "nameform": "Normal",
         "protoform": "2012",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -33319,7 +27996,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2013",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -33334,7 +28010,6 @@
       {
         "nameform": "Purified",
         "protoform": "2014",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -33351,9 +28026,6 @@
   "537":{
     "name": "Seismitoad",
     "rarity":"",
-    "baseStamina": 233,
-    "baseAttack": 188,
-    "baseDefense": 150,
     "types": [
       {
         "type": "Water",
@@ -33368,7 +28040,6 @@
       {
         "nameform": "Normal",
         "protoform": "2015",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -33383,7 +28054,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2016",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -33398,7 +28068,6 @@
       {
         "nameform": "Purified",
         "protoform": "2017",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -33415,9 +28084,6 @@
   "538":{
     "name": "Throh",
     "rarity":"",
-    "baseStamina": 260,
-    "baseAttack": 172,
-    "baseDefense": 160,
     "types": [
       {
         "type": "Fighting",
@@ -33428,7 +28094,6 @@
       {
         "nameform": "Normal",
         "protoform": "2018",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -33439,7 +28104,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2019",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -33450,7 +28114,6 @@
       {
         "nameform": "Purified",
         "protoform": "2020",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -33463,9 +28126,6 @@
   "539":{
     "name": "Sawk",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 231,
-    "baseDefense": 153,
     "types": [
       {
         "type": "Fighting",
@@ -33476,7 +28136,6 @@
       {
         "nameform": "Normal",
         "protoform": "2021",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -33487,7 +28146,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2022",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -33498,7 +28156,6 @@
       {
         "nameform": "Purified",
         "protoform": "2023",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -33511,9 +28168,6 @@
   "540":{
     "name": "Sewaddle",
     "rarity":"",
-    "baseStamina": 128,
-    "baseAttack": 96,
-    "baseDefense": 124,
     "types": [
       {
         "type": "Bug",
@@ -33528,7 +28182,6 @@
       {
         "nameform": "Normal",
         "protoform": "2024",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -33543,7 +28196,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2025",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -33558,7 +28210,6 @@
       {
         "nameform": "Purified",
         "protoform": "2026",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -33575,9 +28226,6 @@
   "541":{
     "name": "Swadloon",
     "rarity":"",
-    "baseStamina": 146,
-    "baseAttack": 115,
-    "baseDefense": 162,
     "types": [
       {
         "type": "Bug",
@@ -33592,7 +28240,6 @@
       {
         "nameform": "Normal",
         "protoform": "2027",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -33607,7 +28254,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2028",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -33622,7 +28268,6 @@
       {
         "nameform": "Purified",
         "protoform": "2029",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -33639,9 +28284,6 @@
   "542":{
     "name": "Leavanny",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 205,
-    "baseDefense": 165,
     "types": [
       {
         "type": "Bug",
@@ -33656,7 +28298,6 @@
       {
         "nameform": "Normal",
         "protoform": "2030",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -33671,7 +28312,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2031",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -33686,7 +28326,6 @@
       {
         "nameform": "Purified",
         "protoform": "2032",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -33703,9 +28342,6 @@
   "543":{
     "name": "Venipede",
     "rarity":"",
-    "baseStamina": 102,
-    "baseAttack": 83,
-    "baseDefense": 99,
     "types": [
       {
         "type": "Bug",
@@ -33720,7 +28356,6 @@
       {
         "nameform": "Normal",
         "protoform": "2033",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -33735,7 +28370,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2034",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -33750,7 +28384,6 @@
       {
         "nameform": "Purified",
         "protoform": "2035",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -33767,9 +28400,6 @@
   "544":{
     "name": "Whirlipede",
     "rarity":"",
-    "baseStamina": 120,
-    "baseAttack": 100,
-    "baseDefense": 173,
     "types": [
       {
         "type": "Bug",
@@ -33784,7 +28414,6 @@
       {
         "nameform": "Normal",
         "protoform": "2036",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -33799,7 +28428,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2037",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -33814,7 +28442,6 @@
       {
         "nameform": "Purified",
         "protoform": "2038",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -33831,9 +28458,6 @@
   "545":{
     "name": "Scolipede",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 203,
-    "baseDefense": 175,
     "types": [
       {
         "type": "Bug",
@@ -33848,7 +28472,6 @@
       {
         "nameform": "Normal",
         "protoform": "2039",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -33863,7 +28486,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2040",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -33878,7 +28500,6 @@
       {
         "nameform": "Purified",
         "protoform": "2041",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -33895,9 +28516,6 @@
   "546":{
     "name": "Cottonee",
     "rarity":"",
-    "baseStamina": 120,
-    "baseAttack": 71,
-    "baseDefense": 111,
     "types": [
       {
         "type": "Grass",
@@ -33912,7 +28530,6 @@
       {
         "nameform": "Normal",
         "protoform": "2042",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -33927,7 +28544,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2043",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -33942,7 +28558,6 @@
       {
         "nameform": "Purified",
         "protoform": "2044",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -33959,9 +28574,6 @@
   "547":{
     "name": "Whimsicott",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 164,
-    "baseDefense": 176,
     "types": [
       {
         "type": "Grass",
@@ -33976,7 +28588,6 @@
       {
         "nameform": "Normal",
         "protoform": "2045",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -33991,7 +28602,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2046",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -34006,7 +28616,6 @@
       {
         "nameform": "Purified",
         "protoform": "2047",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -34023,9 +28632,6 @@
   "548":{
     "name": "Petilil",
     "rarity":"",
-    "baseStamina": 128,
-    "baseAttack": 119,
-    "baseDefense": 91,
     "types": [
       {
         "type": "Grass",
@@ -34036,7 +28642,6 @@
       {
         "nameform": "Normal",
         "protoform": "2048",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -34047,7 +28652,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2049",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -34058,7 +28662,6 @@
       {
         "nameform": "Purified",
         "protoform": "2050",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -34071,9 +28674,6 @@
   "549":{
     "name": "Lilligant",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 214,
-    "baseDefense": 155,
     "types": [
       {
         "type": "Grass",
@@ -34084,7 +28684,6 @@
       {
         "nameform": "Normal",
         "protoform": "2051",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -34095,7 +28694,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2052",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -34106,7 +28704,6 @@
       {
         "nameform": "Purified",
         "protoform": "2053",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -34119,9 +28716,6 @@
   "550":{
     "name": "Basculin",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 189,
-    "baseDefense": 129,
     "types": [
       {
         "type": "Water",
@@ -34132,7 +28726,6 @@
       {
         "nameform": "Red Striped",
         "protoform": "136",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -34143,7 +28736,6 @@
       {
         "nameform": "Blue Striped",
         "protoform": "137",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -34156,9 +28748,6 @@
   "551":{
     "name": "Sandile",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 132,
-    "baseDefense": 69,
     "types": [
       {
         "type": "Ground",
@@ -34173,7 +28762,6 @@
       {
         "nameform": "Normal",
         "protoform": "2054",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -34188,7 +28776,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2055",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -34203,7 +28790,6 @@
       {
         "nameform": "Purified",
         "protoform": "2056",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -34220,9 +28806,6 @@
   "552":{
     "name": "Krokorok",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 155,
-    "baseDefense": 90,
     "types": [
       {
         "type": "Ground",
@@ -34237,7 +28820,6 @@
       {
         "nameform": "Normal",
         "protoform": "2057",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -34252,7 +28834,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2058",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -34267,7 +28848,6 @@
       {
         "nameform": "Purified",
         "protoform": "2059",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -34284,9 +28864,6 @@
   "553":{
     "name": "Krookodile",
     "rarity":"",
-    "baseStamina": 216,
-    "baseAttack": 229,
-    "baseDefense": 158,
     "types": [
       {
         "type": "Ground",
@@ -34301,7 +28878,6 @@
       {
         "nameform": "Normal",
         "protoform": "2060",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -34316,7 +28892,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2061",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -34331,7 +28906,6 @@
       {
         "nameform": "Purified",
         "protoform": "2062",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -34348,9 +28922,6 @@
   "554":{
     "name": "Darumaka",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 153,
-    "baseDefense": 86,
     "types": [
       {
         "type": "Fire",
@@ -34361,7 +28932,6 @@
       {
         "nameform": "Normal",
         "protoform": "2063",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -34372,7 +28942,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2064",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -34383,7 +28952,6 @@
       {
         "nameform": "Purified",
         "protoform": "2065",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -34394,7 +28962,6 @@
       {
         "nameform": "Galarian",
         "protoform": "2341",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -34407,9 +28974,6 @@
   "555":{
     "name": "Darmanitan",
     "rarity":"",
-    "baseStamina": 233,
-    "baseAttack": 243,
-    "baseDefense": 202,
     "types": [
       {
         "type": "Fire",
@@ -34420,10 +28984,6 @@
       {
         "nameform": "Standard",
         "protoform": "138",
-        "assetsform": "00",
-        "baseStamina": 233,
-        "baseAttack": 243,
-        "baseDefense": 202,
         "formtypes": [
           {
             "type": "Fire",
@@ -34434,7 +28994,6 @@
       {
         "nameform": "Zen",
         "protoform": "139",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -34449,10 +29008,6 @@
       {
         "nameform": "Galarian Standard",
         "protoform": "2342",
-        "assetsform": "00",
-        "baseStamina": 233,
-        "baseAttack": 243,
-        "baseDefense": 202,
         "formtypes": [
           {
             "type": "Fire",
@@ -34463,7 +29018,6 @@
       {
         "nameform": "Galarian Zen",
         "protoform": "2343",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -34480,9 +29034,6 @@
   "556":{
     "name": "Maractus",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 201,
-    "baseDefense": 130,
     "types": [
       {
         "type": "Grass",
@@ -34493,7 +29044,6 @@
       {
         "nameform": "Normal",
         "protoform": "2066",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -34504,7 +29054,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2067",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -34515,7 +29064,6 @@
       {
         "nameform": "Purified",
         "protoform": "2068",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -34528,9 +29076,6 @@
   "557":{
     "name": "Dwebble",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 118,
-    "baseDefense": 128,
     "types": [
       {
         "type": "Bug",
@@ -34545,7 +29090,6 @@
       {
         "nameform": "Normal",
         "protoform": "2069",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -34560,7 +29104,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2070",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -34575,7 +29118,6 @@
       {
         "nameform": "Purified",
         "protoform": "2071",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -34592,9 +29134,6 @@
   "558":{
     "name": "Crustle",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 188,
-    "baseDefense": 200,
     "types": [
       {
         "type": "Bug",
@@ -34609,7 +29148,6 @@
       {
         "nameform": "Normal",
         "protoform": "2072",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -34624,7 +29162,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2073",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -34639,7 +29176,6 @@
       {
         "nameform": "Purified",
         "protoform": "2074",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -34656,9 +29192,6 @@
   "559":{
     "name": "Scraggy",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 132,
-    "baseDefense": 132,
     "types": [
       {
         "type": "Dark",
@@ -34673,7 +29206,6 @@
       {
         "nameform": "Normal",
         "protoform": "2075",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -34688,7 +29220,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2076",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -34703,7 +29234,6 @@
       {
         "nameform": "Purified",
         "protoform": "2077",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -34720,9 +29250,6 @@
   "560":{
     "name": "Scrafty",
     "rarity":"",
-    "baseStamina": 163,
-    "baseAttack": 163,
-    "baseDefense": 222,
     "types": [
       {
         "type": "Dark",
@@ -34737,7 +29264,6 @@
       {
         "nameform": "Normal",
         "protoform": "2078",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -34752,7 +29278,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2079",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -34767,7 +29292,6 @@
       {
         "nameform": "Purified",
         "protoform": "2080",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -34784,9 +29308,6 @@
   "561":{
     "name": "Sigilyph",
     "rarity":"",
-    "baseStamina": 176,
-    "baseAttack": 204,
-    "baseDefense": 167,
     "types": [
       {
         "type": "Psychic",
@@ -34801,7 +29322,6 @@
       {
         "nameform": "Normal",
         "protoform": "2081",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -34816,7 +29336,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2082",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -34831,7 +29350,6 @@
       {
         "nameform": "Purified",
         "protoform": "2083",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -34848,9 +29366,6 @@
   "562":{
     "name": "Yamask",
     "rarity":"",
-    "baseStamina": 116,
-    "baseAttack": 95,
-    "baseDefense": 141,
     "types": [
       {
         "type": "Ghost",
@@ -34861,7 +29376,6 @@
       {
         "nameform": "Normal",
         "protoform": "2084",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -34872,7 +29386,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2085",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -34883,7 +29396,6 @@
       {
         "nameform": "Purified",
         "protoform": "2086",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -34894,7 +29406,6 @@
       {
         "nameform": "Galarian",
         "protoform": "2344",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -34911,9 +29422,6 @@
   "563":{
     "name": "Cofagrigus",
     "rarity":"",
-    "baseStamina": 151,
-    "baseAttack": 163,
-    "baseDefense": 237,
     "types": [
       {
         "type": "Ghost",
@@ -34924,7 +29432,6 @@
       {
         "nameform": "Normal",
         "protoform": "2087",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -34935,7 +29442,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2088",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -34946,7 +29452,6 @@
       {
         "nameform": "Purified",
         "protoform": "2089",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -34959,9 +29464,6 @@
   "564":{
     "name": "Tirtouga",
     "rarity":"",
-    "baseStamina": 144,
-    "baseAttack": 134,
-    "baseDefense": 146,
     "types": [
       {
         "type": "Water",
@@ -34976,7 +29478,6 @@
       {
         "nameform": "Normal",
         "protoform": "2090",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -34991,7 +29492,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2091",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -35006,7 +29506,6 @@
       {
         "nameform": "Purified",
         "protoform": "2092",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -35023,9 +29522,6 @@
   "565":{
     "name": "Carracosta",
     "rarity":"",
-    "baseStamina": 179,
-    "baseAttack": 192,
-    "baseDefense": 197,
     "types": [
       {
         "type": "Water",
@@ -35040,7 +29536,6 @@
       {
         "nameform": "Normal",
         "protoform": "2093",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -35055,7 +29550,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2094",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -35070,7 +29564,6 @@
       {
         "nameform": "Purified",
         "protoform": "2095",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -35087,9 +29580,6 @@
   "566":{
     "name": "Archen",
     "rarity":"",
-    "baseStamina": 146,
-    "baseAttack": 213,
-    "baseDefense": 89,
     "types": [
       {
         "type": "Rock",
@@ -35104,7 +29594,6 @@
       {
         "nameform": "Normal",
         "protoform": "2096",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -35119,7 +29608,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2097",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -35134,7 +29622,6 @@
       {
         "nameform": "Purified",
         "protoform": "2098",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -35151,9 +29638,6 @@
   "567":{
     "name": "Archeops",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 292,
-    "baseDefense": 139,
     "types": [
       {
         "type": "Rock",
@@ -35168,7 +29652,6 @@
       {
         "nameform": "Normal",
         "protoform": "2099",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -35183,7 +29666,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2100",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -35198,7 +29680,6 @@
       {
         "nameform": "Purified",
         "protoform": "2101",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -35215,9 +29696,6 @@
   "568":{
     "name": "Trubbish",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 96,
-    "baseDefense": 122,
     "types": [
       {
         "type": "Poison",
@@ -35228,7 +29706,6 @@
       {
         "nameform": "Normal",
         "protoform": "2102",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Poison",
@@ -35239,7 +29716,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2103",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Poison",
@@ -35250,7 +29726,6 @@
       {
         "nameform": "Purified",
         "protoform": "2104",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Poison",
@@ -35263,9 +29738,6 @@
   "569":{
     "name": "Garbodor",
     "rarity":"",
-    "baseStamina": 190,
-    "baseAttack": 181,
-    "baseDefense": 164,
     "types": [
       {
         "type": "Poison",
@@ -35276,7 +29748,6 @@
       {
         "nameform": "Normal",
         "protoform": "2105",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Poison",
@@ -35287,7 +29758,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2106",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Poison",
@@ -35298,7 +29768,6 @@
       {
         "nameform": "Purified",
         "protoform": "2107",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Poison",
@@ -35311,9 +29780,6 @@
   "570":{
     "name": "Zorua",
     "rarity":"",
-    "baseStamina": 120,
-    "baseAttack": 153,
-    "baseDefense": 78,
     "types": [
       {
         "type": "Dark",
@@ -35324,7 +29790,6 @@
       {
         "nameform": "Normal",
         "protoform": "2108",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -35335,7 +29800,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2109",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -35346,7 +29810,6 @@
       {
         "nameform": "Purified",
         "protoform": "2110",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -35359,9 +29822,6 @@
   "571":{
     "name": "Zoroark",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 250,
-    "baseDefense": 127,
     "types": [
       {
         "type": "Dark",
@@ -35372,7 +29832,6 @@
       {
         "nameform": "Normal",
         "protoform": "2111",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -35383,7 +29842,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2112",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -35394,7 +29852,6 @@
       {
         "nameform": "Purified",
         "protoform": "2113",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -35407,9 +29864,6 @@
   "572":{
     "name": "Minccino",
     "rarity":"",
-    "baseStamina": 146,
-    "baseAttack": 98,
-    "baseDefense": 80,
     "types": [
       {
         "type": "Normal",
@@ -35420,7 +29874,6 @@
       {
         "nameform": "Normal",
         "protoform": "2114",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -35431,7 +29884,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2115",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -35442,7 +29894,6 @@
       {
         "nameform": "Purified",
         "protoform": "2116",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -35455,9 +29906,6 @@
   "573":{
     "name": "Cinccino",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 198,
-    "baseDefense": 130,
     "types": [
       {
         "type": "Normal",
@@ -35468,7 +29916,6 @@
       {
         "nameform": "Normal",
         "protoform": "2117",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -35479,7 +29926,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2118",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -35490,7 +29936,6 @@
       {
         "nameform": "Purified",
         "protoform": "2119",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -35503,9 +29948,6 @@
   "574":{
     "name": "Gothita",
     "rarity":"",
-    "baseStamina": 128,
-    "baseAttack": 98,
-    "baseDefense": 112,
     "types": [
       {
         "type": "Psychic",
@@ -35516,7 +29958,6 @@
       {
         "nameform": "Normal",
         "protoform": "2120",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -35527,7 +29968,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2121",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -35538,7 +29978,6 @@
       {
         "nameform": "Purified",
         "protoform": "2122",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -35551,9 +29990,6 @@
   "575":{
     "name": "Gothorita",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 137,
-    "baseDefense": 153,
     "types": [
       {
         "type": "Psychic",
@@ -35564,7 +30000,6 @@
       {
         "nameform": "Normal",
         "protoform": "2123",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -35575,7 +30010,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2124",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -35586,7 +30020,6 @@
       {
         "nameform": "Purified",
         "protoform": "2125",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -35599,9 +30032,6 @@
   "576":{
     "name": "Gothitelle",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 176,
-    "baseDefense": 205,
     "types": [
       {
         "type": "Psychic",
@@ -35612,7 +30042,6 @@
       {
         "nameform": "Normal",
         "protoform": "2126",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -35623,7 +30052,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2127",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -35634,7 +30062,6 @@
       {
         "nameform": "Purified",
         "protoform": "2128",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -35647,9 +30074,6 @@
   "577":{
     "name": "Solosis",
     "rarity":"",
-    "baseStamina": 128,
-    "baseAttack": 170,
-    "baseDefense": 83,
     "types": [
       {
         "type": "Psychic",
@@ -35660,7 +30084,6 @@
       {
         "nameform": "Normal",
         "protoform": "2129",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -35671,7 +30094,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2130",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -35682,7 +30104,6 @@
       {
         "nameform": "Purified",
         "protoform": "2131",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -35695,9 +30116,6 @@
   "578":{
     "name": "Duosion",
     "rarity":"",
-    "baseStamina": 163,
-    "baseAttack": 208,
-    "baseDefense": 103,
     "types": [
       {
         "type": "Psychic",
@@ -35708,7 +30126,6 @@
       {
         "nameform": "Normal",
         "protoform": "2132",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -35719,7 +30136,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2133",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -35730,7 +30146,6 @@
       {
         "nameform": "Purified",
         "protoform": "2134",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -35743,9 +30158,6 @@
   "579":{
     "name": "Reuniclus",
     "rarity":"",
-    "baseStamina": 242,
-    "baseAttack": 214,
-    "baseDefense": 148,
     "types": [
       {
         "type": "Psychic",
@@ -35756,7 +30168,6 @@
       {
         "nameform": "Normal",
         "protoform": "2135",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -35767,7 +30178,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2136",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -35778,7 +30188,6 @@
       {
         "nameform": "Purified",
         "protoform": "2137",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -35791,9 +30200,6 @@
   "580":{
     "name": "Ducklett",
     "rarity":"",
-    "baseStamina": 158,
-    "baseAttack": 84,
-    "baseDefense": 96,
     "types": [
       {
         "type": "Water",
@@ -35808,7 +30214,6 @@
       {
         "nameform": "Normal",
         "protoform": "2138",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -35823,7 +30228,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2139",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -35838,7 +30242,6 @@
       {
         "nameform": "Purified",
         "protoform": "2140",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -35855,9 +30258,6 @@
   "581":{
     "name": "Swanna",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 182,
-    "baseDefense": 132,
     "types": [
       {
         "type": "Water",
@@ -35872,7 +30272,6 @@
       {
         "nameform": "Normal",
         "protoform": "2141",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -35887,7 +30286,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2142",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -35902,7 +30300,6 @@
       {
         "nameform": "Purified",
         "protoform": "2143",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -35919,9 +30316,6 @@
   "582":{
     "name": "Vanillite",
     "rarity":"",
-    "baseStamina": 113,
-    "baseAttack": 118,
-    "baseDefense": 106,
     "types": [
       {
         "type": "Ice",
@@ -35932,7 +30326,6 @@
       {
         "nameform": "Normal",
         "protoform": "2144",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -35943,7 +30336,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2145",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -35954,7 +30346,6 @@
       {
         "nameform": "Purified",
         "protoform": "2146",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -35967,9 +30358,6 @@
   "583":{
     "name": "Vanillish",
     "rarity":"",
-    "baseStamina": 139,
-    "baseAttack": 151,
-    "baseDefense": 138,
     "types": [
       {
         "type": "Ice",
@@ -35980,7 +30368,6 @@
       {
         "nameform": "Normal",
         "protoform": "2147",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -35991,7 +30378,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2148",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -36002,7 +30388,6 @@
       {
         "nameform": "Purified",
         "protoform": "2149",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -36015,9 +30400,6 @@
   "584":{
     "name": "Vanilluxe",
     "rarity":"",
-    "baseStamina": 174,
-    "baseAttack": 218,
-    "baseDefense": 184,
     "types": [
       {
         "type": "Ice",
@@ -36028,7 +30410,6 @@
       {
         "nameform": "Normal",
         "protoform": "2150",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -36039,7 +30420,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2151",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -36050,7 +30430,6 @@
       {
         "nameform": "Purified",
         "protoform": "2152",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -36063,9 +30442,6 @@
   "585":{
     "name": "Deerling",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 115,
-    "baseDefense": 100,
     "types": [
       {
         "type": "Normal",
@@ -36080,7 +30456,6 @@
       {
         "nameform": "Spring",
         "protoform": "585",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -36095,7 +30470,6 @@
       {
         "nameform": "Summer",
         "protoform": "586",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -36110,7 +30484,6 @@
       {
         "nameform": "Autumn",
         "protoform": "587",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -36125,7 +30498,6 @@
       {
         "nameform": "Winter",
         "protoform": "588",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -36142,9 +30514,6 @@
   "586":{
     "name": "Sawsbuck",
     "rarity":"",
-    "baseStamina": 190,
-    "baseAttack": 198,
-    "baseDefense": 146,
     "types": [
       {
         "type": "Normal",
@@ -36159,7 +30528,6 @@
       {
         "nameform": "Spring",
         "protoform": "589",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -36174,7 +30542,6 @@
       {
         "nameform": "Summer",
         "protoform": "590",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -36189,7 +30556,6 @@
       {
         "nameform": "Autumn",
         "protoform": "591",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -36204,7 +30570,6 @@
       {
         "nameform": "Winter",
         "protoform": "592",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -36221,9 +30586,6 @@
   "587":{
     "name": "Emolga",
     "rarity":"",
-    "baseStamina": 146,
-    "baseAttack": 158,
-    "baseDefense": 127,
     "types": [
       {
         "type": "Electric",
@@ -36238,7 +30600,6 @@
       {
         "nameform": "Normal",
         "protoform": "2153",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -36253,7 +30614,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2154",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -36268,7 +30628,6 @@
       {
         "nameform": "Purified",
         "protoform": "2155",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -36285,9 +30644,6 @@
   "588":{
     "name": "Karrablast",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 137,
-    "baseDefense": 87,
     "types": [
       {
         "type": "Bug",
@@ -36298,7 +30654,6 @@
       {
         "nameform": "Normal",
         "protoform": "2156",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -36309,7 +30664,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2157",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -36320,7 +30674,6 @@
       {
         "nameform": "Purified",
         "protoform": "2158",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -36333,9 +30686,6 @@
   "589":{
     "name": "Escavalier",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 223,
-    "baseDefense": 187,
     "types": [
       {
         "type": "Bug",
@@ -36350,7 +30700,6 @@
       {
         "nameform": "Normal",
         "protoform": "2159",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -36365,7 +30714,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2160",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -36380,7 +30728,6 @@
       {
         "nameform": "Purified",
         "protoform": "2161",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -36397,9 +30744,6 @@
   "590":{
     "name": "Foongus",
     "rarity":"",
-    "baseStamina": 170,
-    "baseAttack": 97,
-    "baseDefense": 91,
     "types": [
       {
         "type": "Grass",
@@ -36414,7 +30758,6 @@
       {
         "nameform": "Normal",
         "protoform": "2162",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -36429,7 +30772,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2163",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -36444,7 +30786,6 @@
       {
         "nameform": "Purified",
         "protoform": "2164",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -36461,9 +30802,6 @@
   "591":{
     "name": "Amoonguss",
     "rarity":"",
-    "baseStamina": 249,
-    "baseAttack": 155,
-    "baseDefense": 139,
     "types": [
       {
         "type": "Grass",
@@ -36478,7 +30816,6 @@
       {
         "nameform": "Normal",
         "protoform": "2165",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -36493,7 +30830,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2166",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -36508,7 +30844,6 @@
       {
         "nameform": "Purified",
         "protoform": "2167",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -36525,9 +30860,6 @@
   "592":{
     "name": "Frillish",
     "rarity":"",
-    "baseStamina": 146,
-    "baseAttack": 115,
-    "baseDefense": 134,
     "types": [
       {
         "type": "Water",
@@ -36542,7 +30874,6 @@
       {
         "nameform": "Normal",
         "protoform": "2168",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -36557,7 +30888,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2169",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -36572,7 +30902,6 @@
       {
         "nameform": "Purified",
         "protoform": "2170",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -36587,7 +30916,6 @@
       {
         "nameform": "Female",
         "protoform": "2330",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -36604,9 +30932,6 @@
   "593":{
     "name": "Jellicent",
     "rarity":"",
-    "baseStamina": 225,
-    "baseAttack": 159,
-    "baseDefense": 178,
     "types": [
       {
         "type": "Water",
@@ -36621,7 +30946,6 @@
       {
         "nameform": "Normal",
         "protoform": "2171",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -36636,7 +30960,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2172",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -36651,7 +30974,6 @@
       {
         "nameform": "Purified",
         "protoform": "2173",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -36666,7 +30988,6 @@
       {
         "nameform": "Female",
         "protoform": "2331",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -36683,9 +31004,6 @@
   "594":{
     "name": "Alomomola",
     "rarity":"",
-    "baseStamina": 338,
-    "baseAttack": 138,
-    "baseDefense": 131,
     "types": [
       {
         "type": "Water",
@@ -36696,7 +31014,6 @@
       {
         "nameform": "Normal",
         "protoform": "2174",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -36707,7 +31024,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2175",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -36718,7 +31034,6 @@
       {
         "nameform": "Purified",
         "protoform": "2176",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -36731,9 +31046,6 @@
   "595":{
     "name": "Joltik",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 110,
-    "baseDefense": 98,
     "types": [
       {
         "type": "Bug",
@@ -36748,7 +31060,6 @@
       {
         "nameform": "Normal",
         "protoform": "2177",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -36763,7 +31074,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2178",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -36778,7 +31088,6 @@
       {
         "nameform": "Purified",
         "protoform": "2179",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -36795,9 +31104,6 @@
   "596":{
     "name": "Galvantula",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 201,
-    "baseDefense": 128,
     "types": [
       {
         "type": "Bug",
@@ -36812,7 +31118,6 @@
       {
         "nameform": "Normal",
         "protoform": "2180",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -36827,7 +31132,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2181",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -36842,7 +31146,6 @@
       {
         "nameform": "Purified",
         "protoform": "2182",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -36859,9 +31162,6 @@
   "597":{
     "name": "Ferroseed",
     "rarity":"",
-    "baseStamina": 127,
-    "baseAttack": 82,
-    "baseDefense": 155,
     "types": [
       {
         "type": "Grass",
@@ -36876,7 +31176,6 @@
       {
         "nameform": "Normal",
         "protoform": "2183",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -36891,7 +31190,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2184",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -36906,7 +31204,6 @@
       {
         "nameform": "Purified",
         "protoform": "2185",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -36923,9 +31220,6 @@
   "598":{
     "name": "Ferrothorn",
     "rarity":"",
-    "baseStamina": 179,
-    "baseAttack": 158,
-    "baseDefense": 223,
     "types": [
       {
         "type": "Grass",
@@ -36940,7 +31234,6 @@
       {
         "nameform": "Normal",
         "protoform": "2186",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -36955,7 +31248,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2187",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -36970,7 +31262,6 @@
       {
         "nameform": "Purified",
         "protoform": "2188",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -36987,9 +31278,6 @@
   "599":{
     "name": "Klink",
     "rarity":"",
-    "baseStamina": 120,
-    "baseAttack": 98,
-    "baseDefense": 121,
     "types": [
       {
         "type": "Steel",
@@ -37000,7 +31288,6 @@
       {
         "nameform": "Normal",
         "protoform": "2189",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -37011,7 +31298,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2190",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -37022,7 +31308,6 @@
       {
         "nameform": "Purified",
         "protoform": "2191",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -37035,9 +31320,6 @@
   "600":{
     "name": "Klang",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 150,
-    "baseDefense": 174,
     "types": [
       {
         "type": "Steel",
@@ -37048,7 +31330,6 @@
       {
         "nameform": "Normal",
         "protoform": "2192",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -37059,7 +31340,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2193",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -37070,7 +31350,6 @@
       {
         "nameform": "Purified",
         "protoform": "2194",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -37083,9 +31362,6 @@
   "601":{
     "name": "Klinklang",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 199,
-    "baseDefense": 214,
     "types": [
       {
         "type": "Steel",
@@ -37096,7 +31372,6 @@
       {
         "nameform": "Normal",
         "protoform": "2195",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -37107,7 +31382,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2196",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -37118,7 +31392,6 @@
       {
         "nameform": "Purified",
         "protoform": "2197",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -37131,9 +31404,6 @@
   "602":{
     "name": "Tynamo",
     "rarity":"",
-    "baseStamina": 111,
-    "baseAttack": 105,
-    "baseDefense": 78,
     "types": [
       {
         "type": "Electric",
@@ -37144,7 +31414,6 @@
       {
         "nameform": "Normal",
         "protoform": "2198",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -37155,7 +31424,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2199",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -37166,7 +31434,6 @@
       {
         "nameform": "Purified",
         "protoform": "2200",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -37179,9 +31446,6 @@
   "603":{
     "name": "Eelektrik",
     "rarity":"",
-    "baseStamina": 163,
-    "baseAttack": 156,
-    "baseDefense": 130,
     "types": [
       {
         "type": "Electric",
@@ -37192,7 +31456,6 @@
       {
         "nameform": "Normal",
         "protoform": "2201",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -37203,7 +31466,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2202",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -37214,7 +31476,6 @@
       {
         "nameform": "Purified",
         "protoform": "2203",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -37227,9 +31488,6 @@
   "604":{
     "name": "Eelektross",
     "rarity":"",
-    "baseStamina": 198,
-    "baseAttack": 217,
-    "baseDefense": 152,
     "types": [
       {
         "type": "Electric",
@@ -37240,7 +31498,6 @@
       {
         "nameform": "Normal",
         "protoform": "2204",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -37251,7 +31508,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2205",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -37262,7 +31518,6 @@
       {
         "nameform": "Purified",
         "protoform": "2206",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -37275,9 +31530,6 @@
   "605":{
     "name": "Elgyem",
     "rarity":"",
-    "baseStamina": 146,
-    "baseAttack": 148,
-    "baseDefense": 100,
     "types": [
       {
         "type": "Psychic",
@@ -37288,7 +31540,6 @@
       {
         "nameform": "Normal",
         "protoform": "2207",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -37299,7 +31550,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2208",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -37310,7 +31560,6 @@
       {
         "nameform": "Purified",
         "protoform": "2209",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -37323,9 +31572,6 @@
   "606":{
     "name": "Beheeyem",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 221,
-    "baseDefense": 163,
     "types": [
       {
         "type": "Psychic",
@@ -37336,7 +31582,6 @@
       {
         "nameform": "Normal",
         "protoform": "2210",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -37347,7 +31592,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2211",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -37358,7 +31602,6 @@
       {
         "nameform": "Purified",
         "protoform": "2212",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Psychic",
@@ -37371,9 +31614,6 @@
   "607":{
     "name": "Litwick",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 108,
-    "baseDefense": 98,
     "types": [
       {
         "type": "Ghost",
@@ -37388,7 +31628,6 @@
       {
         "nameform": "Normal",
         "protoform": "2213",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -37403,7 +31642,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2214",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -37418,7 +31656,6 @@
       {
         "nameform": "Purified",
         "protoform": "2215",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -37435,9 +31672,6 @@
   "608":{
     "name": "Lampent",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 169,
-    "baseDefense": 115,
     "types": [
       {
         "type": "Ghost",
@@ -37452,7 +31686,6 @@
       {
         "nameform": "Normal",
         "protoform": "2216",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -37467,7 +31700,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2217",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -37482,7 +31714,6 @@
       {
         "nameform": "Purified",
         "protoform": "2218",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -37499,9 +31730,6 @@
   "609":{
     "name": "Chandelure",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 271,
-    "baseDefense": 182,
     "types": [
       {
         "type": "Ghost",
@@ -37516,7 +31744,6 @@
       {
         "nameform": "Normal",
         "protoform": "2219",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -37531,7 +31758,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2220",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -37546,7 +31772,6 @@
       {
         "nameform": "Purified",
         "protoform": "2221",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ghost",
@@ -37563,9 +31788,6 @@
   "610":{
     "name": "Axew",
     "rarity":"",
-    "baseStamina": 130,
-    "baseAttack": 154,
-    "baseDefense": 101,
     "types": [
       {
         "type": "Dragon",
@@ -37576,7 +31798,6 @@
       {
         "nameform": "Normal",
         "protoform": "2222",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -37587,7 +31808,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2223",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -37598,7 +31818,6 @@
       {
         "nameform": "Purified",
         "protoform": "2224",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -37611,9 +31830,6 @@
   "611":{
     "name": "Fraxure",
     "rarity":"",
-    "baseStamina": 165,
-    "baseAttack": 212,
-    "baseDefense": 123,
     "types": [
       {
         "type": "Dragon",
@@ -37624,7 +31840,6 @@
       {
         "nameform": "Normal",
         "protoform": "2225",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -37635,7 +31850,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2226",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -37646,7 +31860,6 @@
       {
         "nameform": "Purified",
         "protoform": "2227",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -37659,9 +31872,6 @@
   "612":{
     "name": "Haxorus",
     "rarity":"",
-    "baseStamina": 183,
-    "baseAttack": 284,
-    "baseDefense": 172,
     "types": [
       {
         "type": "Dragon",
@@ -37672,7 +31882,6 @@
       {
         "nameform": "Normal",
         "protoform": "2228",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -37683,7 +31892,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2229",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -37694,7 +31902,6 @@
       {
         "nameform": "Purified",
         "protoform": "2230",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -37707,9 +31914,6 @@
   "613":{
     "name": "Cubchoo",
     "rarity":"",
-    "baseStamina": 146,
-    "baseAttack": 128,
-    "baseDefense": 74,
     "types": [
       {
         "type": "Ice",
@@ -37720,7 +31924,6 @@
       {
         "nameform": "Normal",
         "protoform": "2231",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -37731,7 +31934,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2232",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -37742,7 +31944,6 @@
       {
         "nameform": "Purified",
         "protoform": "2233",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -37753,10 +31954,6 @@
       {
         "nameform": "Winter 2020",
         "protoform": "2672",
-        "assetsform": "00",
-        "baseStamina": 146,
-        "baseAttack": 128,
-        "baseDefense": 74,
         "formtypes": [
           {
             "type": "Ice",
@@ -37769,9 +31966,6 @@
   "614":{
     "name": "Beartic",
     "rarity":"",
-    "baseStamina": 216,
-    "baseAttack": 233,
-    "baseDefense": 152,
     "types": [
       {
         "type": "Ice",
@@ -37782,7 +31976,6 @@
       {
         "nameform": "Normal",
         "protoform": "2234",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -37793,7 +31986,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2235",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -37804,7 +31996,6 @@
       {
         "nameform": "Purified",
         "protoform": "2236",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -37817,9 +32008,6 @@
   "615":{
     "name": "Cryogonal",
     "rarity":"",
-    "baseStamina": 190,
-    "baseAttack": 190,
-    "baseDefense": 218,
     "types": [
       {
         "type": "Ice",
@@ -37830,7 +32018,6 @@
       {
         "nameform": "Normal",
         "protoform": "2237",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -37841,7 +32028,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2238",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -37852,7 +32038,6 @@
       {
         "nameform": "Purified",
         "protoform": "2239",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ice",
@@ -37865,9 +32050,6 @@
   "616":{
     "name": "Shelmet",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 72,
-    "baseDefense": 140,
     "types": [
       {
         "type": "Bug",
@@ -37878,7 +32060,6 @@
       {
         "nameform": "Normal",
         "protoform": "2240",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -37889,7 +32070,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2241",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -37900,7 +32080,6 @@
       {
         "nameform": "Purified",
         "protoform": "2242",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -37913,9 +32092,6 @@
   "617":{
     "name": "Accelgor",
     "rarity":"",
-    "baseStamina": 190,
-    "baseAttack": 220,
-    "baseDefense": 120,
     "types": [
       {
         "type": "Bug",
@@ -37926,7 +32102,6 @@
       {
         "nameform": "Normal",
         "protoform": "2243",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -37937,7 +32112,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2244",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -37948,7 +32122,6 @@
       {
         "nameform": "Purified",
         "protoform": "2245",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -37961,9 +32134,6 @@
   "618":{
     "name": "Stunfisk",
     "rarity":"",
-    "baseStamina": 240,
-    "baseAttack": 144,
-    "baseDefense": 171,
     "types": [
       {
         "type": "Ground",
@@ -37978,7 +32148,6 @@
       {
         "nameform": "Normal",
         "protoform": "2246",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -37993,7 +32162,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2247",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -38008,7 +32176,6 @@
       {
         "nameform": "Purified",
         "protoform": "2248",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -38023,7 +32190,6 @@
       {
         "nameform": "Galarian",
         "protoform": "2345",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -38040,9 +32206,6 @@
   "619":{
     "name": "Mienfoo",
     "rarity":"",
-    "baseStamina": 128,
-    "baseAttack": 160,
-    "baseDefense": 98,
     "types": [
       {
         "type": "Fighting",
@@ -38053,7 +32216,6 @@
       {
         "nameform": "Normal",
         "protoform": "2249",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -38064,7 +32226,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2250",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -38075,7 +32236,6 @@
       {
         "nameform": "Purified",
         "protoform": "2251",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -38088,9 +32248,6 @@
   "620":{
     "name": "Mienshao",
     "rarity":"",
-    "baseStamina": 163,
-    "baseAttack": 258,
-    "baseDefense": 127,
     "types": [
       {
         "type": "Fighting",
@@ -38101,7 +32258,6 @@
       {
         "nameform": "Normal",
         "protoform": "2252",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -38112,7 +32268,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2253",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -38123,7 +32278,6 @@
       {
         "nameform": "Purified",
         "protoform": "2254",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fighting",
@@ -38136,9 +32290,6 @@
   "621":{
     "name": "Druddigon",
     "rarity":"",
-    "baseStamina": 184,
-    "baseAttack": 213,
-    "baseDefense": 170,
     "types": [
       {
         "type": "Dragon",
@@ -38149,7 +32300,6 @@
       {
         "nameform": "Normal",
         "protoform": "2255",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -38160,7 +32310,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2256",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -38171,7 +32320,6 @@
       {
         "nameform": "Purified",
         "protoform": "2257",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -38184,9 +32332,6 @@
   "622":{
     "name": "Golett",
     "rarity":"",
-    "baseStamina": 153,
-    "baseAttack": 127,
-    "baseDefense": 92,
     "types": [
       {
         "type": "Ground",
@@ -38201,7 +32346,6 @@
       {
         "nameform": "Normal",
         "protoform": "2258",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -38216,7 +32360,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2259",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -38231,7 +32374,6 @@
       {
         "nameform": "Purified",
         "protoform": "2260",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -38248,9 +32390,6 @@
   "623":{
     "name": "Golurk",
     "rarity":"",
-    "baseStamina": 205,
-    "baseAttack": 222,
-    "baseDefense": 154,
     "types": [
       {
         "type": "Ground",
@@ -38265,7 +32404,6 @@
       {
         "nameform": "Normal",
         "protoform": "2261",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -38280,7 +32418,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2262",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -38295,7 +32432,6 @@
       {
         "nameform": "Purified",
         "protoform": "2263",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -38312,9 +32448,6 @@
   "624":{
     "name": "Pawniard",
     "rarity":"",
-    "baseStamina": 128,
-    "baseAttack": 154,
-    "baseDefense": 114,
     "types": [
       {
         "type": "Dark",
@@ -38329,7 +32462,6 @@
       {
         "nameform": "Normal",
         "protoform": "2264",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -38344,7 +32476,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2265",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -38359,7 +32490,6 @@
       {
         "nameform": "Purified",
         "protoform": "2266",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -38376,9 +32506,6 @@
   "625":{
     "name": "Bisharp",
     "rarity":"",
-    "baseStamina": 163,
-    "baseAttack": 232,
-    "baseDefense": 176,
     "types": [
       {
         "type": "Dark",
@@ -38393,7 +32520,6 @@
       {
         "nameform": "Normal",
         "protoform": "2267",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -38408,7 +32534,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2268",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -38423,7 +32548,6 @@
       {
         "nameform": "Purified",
         "protoform": "2269",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -38440,9 +32564,6 @@
   "626":{
     "name": "Bouffalant",
     "rarity":"",
-    "baseStamina": 216,
-    "baseAttack": 195,
-    "baseDefense": 182,
     "types": [
       {
         "type": "Normal",
@@ -38453,7 +32574,6 @@
       {
         "nameform": "Normal",
         "protoform": "2270",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -38464,7 +32584,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2271",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -38475,7 +32594,6 @@
       {
         "nameform": "Purified",
         "protoform": "2272",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -38488,9 +32606,6 @@
   "627":{
     "name": "Rufflet",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 150,
-    "baseDefense": 97,
     "types": [
       {
         "type": "Normal",
@@ -38505,7 +32620,6 @@
       {
         "nameform": "Normal",
         "protoform": "2273",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -38520,7 +32634,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2274",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -38535,7 +32648,6 @@
       {
         "nameform": "Purified",
         "protoform": "2275",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -38552,9 +32664,6 @@
   "628":{
     "name": "Braviary",
     "rarity":"",
-    "baseStamina": 225,
-    "baseAttack": 232,
-    "baseDefense": 152,
     "types": [
       {
         "type": "Normal",
@@ -38569,7 +32678,6 @@
       {
         "nameform": "Normal",
         "protoform": "2276",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -38584,7 +32692,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2277",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -38599,7 +32706,6 @@
       {
         "nameform": "Purified",
         "protoform": "2278",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -38616,9 +32722,6 @@
   "629":{
     "name": "Vullaby",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 105,
-    "baseDefense": 139,
     "types": [
       {
         "type": "Dark",
@@ -38633,7 +32736,6 @@
       {
         "nameform": "Normal",
         "protoform": "2279",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -38648,7 +32750,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2280",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -38663,7 +32764,6 @@
       {
         "nameform": "Purified",
         "protoform": "2281",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -38680,9 +32780,6 @@
   "630":{
     "name": "Mandibuzz",
     "rarity":"",
-    "baseStamina": 242,
-    "baseAttack": 129,
-    "baseDefense": 205,
     "types": [
       {
         "type": "Dark",
@@ -38697,7 +32794,6 @@
       {
         "nameform": "Normal",
         "protoform": "2282",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -38712,7 +32808,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2283",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -38727,7 +32822,6 @@
       {
         "nameform": "Purified",
         "protoform": "2284",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -38744,9 +32838,6 @@
   "631":{
     "name": "Heatmor",
     "rarity":"",
-    "baseStamina": 198,
-    "baseAttack": 204,
-    "baseDefense": 129,
     "types": [
       {
         "type": "Fire",
@@ -38757,7 +32848,6 @@
       {
         "nameform": "Normal",
         "protoform": "2285",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -38768,7 +32858,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2286",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -38779,7 +32868,6 @@
       {
         "nameform": "Purified",
         "protoform": "2287",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Fire",
@@ -38792,9 +32880,6 @@
   "632":{
     "name": "Durant",
     "rarity":"",
-    "baseStamina": 151,
-    "baseAttack": 217,
-    "baseDefense": 188,
     "types": [
       {
         "type": "Bug",
@@ -38809,7 +32894,6 @@
       {
         "nameform": "Normal",
         "protoform": "2288",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -38824,7 +32908,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2289",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -38839,7 +32922,6 @@
       {
         "nameform": "Purified",
         "protoform": "2290",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -38856,9 +32938,6 @@
   "633":{
     "name": "Deino",
     "rarity":"",
-    "baseStamina": 141,
-    "baseAttack": 116,
-    "baseDefense": 93,
     "types": [
       {
         "type": "Dark",
@@ -38873,7 +32952,6 @@
       {
         "nameform": "Normal",
         "protoform": "2291",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -38888,7 +32966,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2292",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -38903,7 +32980,6 @@
       {
         "nameform": "Purified",
         "protoform": "2293",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -38920,9 +32996,6 @@
   "634":{
     "name": "Zweilous",
     "rarity":"",
-    "baseStamina": 176,
-    "baseAttack": 159,
-    "baseDefense": 135,
     "types": [
       {
         "type": "Dark",
@@ -38937,7 +33010,6 @@
       {
         "nameform": "Normal",
         "protoform": "2294",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -38952,7 +33024,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2295",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -38967,7 +33038,6 @@
       {
         "nameform": "Purified",
         "protoform": "2296",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -38984,9 +33054,6 @@
   "635":{
     "name": "Hydreigon",
     "rarity":"",
-    "baseStamina": 211,
-    "baseAttack": 256,
-    "baseDefense": 188,
     "types": [
       {
         "type": "Dark",
@@ -39001,7 +33068,6 @@
       {
         "nameform": "Normal",
         "protoform": "2297",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -39016,7 +33082,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2298",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -39031,7 +33096,6 @@
       {
         "nameform": "Purified",
         "protoform": "2299",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dark",
@@ -39048,9 +33112,6 @@
   "636":{
     "name": "Larvesta",
     "rarity":"",
-    "baseStamina": 146,
-    "baseAttack": 156,
-    "baseDefense": 107,
     "types": [
       {
         "type": "Bug",
@@ -39065,7 +33126,6 @@
       {
         "nameform": "Normal",
         "protoform": "2300",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -39080,7 +33140,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2301",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -39095,7 +33154,6 @@
       {
         "nameform": "Purified",
         "protoform": "2302",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -39112,9 +33170,6 @@
   "637":{
     "name": "Volcarona",
     "rarity":"",
-    "baseStamina": 198,
-    "baseAttack": 264,
-    "baseDefense": 189,
     "types": [
       {
         "type": "Bug",
@@ -39129,7 +33184,6 @@
       {
         "nameform": "Normal",
         "protoform": "2303",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -39144,7 +33198,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2304",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -39159,7 +33212,6 @@
       {
         "nameform": "Purified",
         "protoform": "2305",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -39176,9 +33228,6 @@
   "638":{
     "name": "Cobalion",
     "rarity":"",
-    "baseStamina": 209,
-    "baseAttack": 192,
-    "baseDefense": 229,
     "types": [
       {
         "type": "Steel",
@@ -39193,7 +33242,6 @@
       {
         "nameform": "Normal",
         "protoform": "2306",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -39208,7 +33256,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2307",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -39223,7 +33270,6 @@
       {
         "nameform": "Purified",
         "protoform": "2308",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -39240,9 +33286,6 @@
   "639":{
     "name": "Terrakion",
     "rarity":"",
-    "baseStamina": 209,
-    "baseAttack": 260,
-    "baseDefense": 192,
     "types": [
       {
         "type": "Rock",
@@ -39257,7 +33300,6 @@
       {
         "nameform": "Normal",
         "protoform": "2309",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -39272,7 +33314,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2310",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -39287,7 +33328,6 @@
       {
         "nameform": "Purified",
         "protoform": "2311",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Rock",
@@ -39304,9 +33344,6 @@
   "640":{
     "name": "Virizion",
     "rarity":"",
-    "baseStamina": 209,
-    "baseAttack": 192,
-    "baseDefense": 229,
     "types": [
       {
         "type": "Grass",
@@ -39321,7 +33358,6 @@
       {
         "nameform": "Normal",
         "protoform": "2312",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -39336,7 +33372,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2313",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -39351,7 +33386,6 @@
       {
         "nameform": "Purified",
         "protoform": "2314",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Grass",
@@ -39368,9 +33402,6 @@
   "641": {
     "name": "Tornadus",
     "rarity": "",
-    "baseStamina": 188,
-    "baseAttack": 238,
-    "baseDefense": 189,
     "types": [
       {
         "type": "Flying",
@@ -39381,7 +33412,6 @@
       {
         "nameform": "Incarnate",
         "protoform": "140",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Flying",
@@ -39392,7 +33422,6 @@
       {
         "nameform": "Therian",
         "protoform": "141",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Flying",
@@ -39404,9 +33433,6 @@
   },
   "642": {
     "name": "Thundurus",
-    "baseStamina": 188,
-    "baseAttack": 295,
-    "baseDefense": 161,
     "rarity": "",
     "types": [
       {
@@ -39422,7 +33448,6 @@
       {
         "nameform": "Incarnate",
         "protoform": "142",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -39437,7 +33462,6 @@
       {
         "nameform": "Therian",
         "protoform": "143",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Electric",
@@ -39453,9 +33477,6 @@
   },
   "643":{
     "name": "Reshiram",
-    "baseStamina": 225,
-    "baseAttack": 302,
-    "baseDefense": 232,
     "rarity":"",
     "types": [
       {
@@ -39471,7 +33492,6 @@
       {
         "nameform": "Normal",
         "protoform": "2315",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -39486,7 +33506,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2316",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -39501,7 +33520,6 @@
       {
         "nameform": "Purified",
         "protoform": "2317",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -39518,9 +33536,6 @@
   "644":{
     "name": "Zekrom",
     "rarity":"",
-    "baseStamina": 225,
-    "baseAttack": 302,
-    "baseDefense": 232,
     "types": [
       {
         "type": "Dragon",
@@ -39535,7 +33550,6 @@
       {
         "nameform": "Normal",
         "protoform": "2318",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -39550,7 +33564,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2319",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -39565,7 +33578,6 @@
       {
         "nameform": "Purified",
         "protoform": "2320",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -39582,9 +33594,6 @@
   "645": {
     "name": "Landorus",
     "rarity": "",
-    "baseStamina": 205,
-    "baseAttack": 289,
-    "baseDefense": 179,
     "types": [
       {
         "type": "Ground",
@@ -39599,7 +33608,6 @@
       {
         "nameform": "Incarnate",
         "protoform": "144",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -39614,7 +33622,6 @@
       {
         "nameform": "Therian",
         "protoform": "145",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Ground",
@@ -39631,9 +33638,6 @@
   "646":{
     "name": "Kyurem",
     "rarity":"",
-    "baseStamina": 268,
-    "baseAttack": 341,
-    "baseDefense": 201,
     "types": [
       {
         "type": "Dragon",
@@ -39648,7 +33652,6 @@
       {
         "nameform": "Normal",
         "protoform": "146",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -39663,7 +33666,6 @@
       {
         "nameform": "Black",
         "protoform": "147",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -39678,7 +33680,6 @@
       {
         "nameform": "White",
         "protoform": "148",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Dragon",
@@ -39695,9 +33696,6 @@
   "647":{
     "name": "Keldeo",
     "rarity":"",
-    "baseStamina": 209,
-    "baseAttack": 260,
-    "baseDefense": 192,
     "types": [
       {
         "type": "Water",
@@ -39712,7 +33710,6 @@
       {
         "nameform": "Ordinary",
         "protoform": "149",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -39727,7 +33724,6 @@
       {
         "nameform": "Resolute",
         "protoform": "150",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Water",
@@ -39744,9 +33740,6 @@
   "648": {
     "name": "Meloetta",
     "rarity": "",
-    "baseStamina": 225,
-    "baseAttack": 269,
-    "baseDefense": 188,
     "types": [
       {
         "type": "Normal",
@@ -39761,7 +33754,6 @@
       {
         "nameform": "Aria",
         "protoform": "151",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -39776,7 +33768,6 @@
       {
         "nameform": "Pirouette",
         "protoform": "152",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Normal",
@@ -39793,9 +33784,6 @@
   "649":{
     "name": "Genesect",
     "rarity":"",
-    "baseStamina": 174,
-    "baseAttack": 252,
-    "baseDefense": 199,
     "types": [
       {
         "type": "Bug",
@@ -39810,7 +33798,6 @@
       {
         "nameform": "Normal",
         "protoform": "593",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -39825,7 +33812,6 @@
       {
         "nameform": "Shock",
         "protoform": "594",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -39840,7 +33826,6 @@
       {
         "nameform": "Burn",
         "protoform": "595",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -39855,7 +33840,6 @@
       {
         "nameform": "Chill",
         "protoform": "596",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -39870,7 +33854,6 @@
       {
         "nameform": "Douse",
         "protoform": "597",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Bug",
@@ -39887,9 +33870,6 @@
   "650":{
     "name": "Chespin",
     "rarity":"",
-    "baseStamina": 148,
-    "baseAttack": 110,
-    "baseDefense": 106,
     "types": [
       {
         "type": "Grass",
@@ -39900,9 +33880,6 @@
   "651":{
     "name": "Quilladin",
     "rarity":"",
-    "baseStamina": 156,
-    "baseAttack": 146,
-    "baseDefense": 156,
     "types": [
       {
         "type": "Grass",
@@ -39913,9 +33890,6 @@
   "652":{
     "name": "Chesnaught",
     "rarity":"",
-    "baseStamina": 204,
-    "baseAttack": 201,
-    "baseDefense": 204,
     "types": [
       {
         "type": "Grass",
@@ -39930,9 +33904,6 @@
   "653":{
     "name": "Fennekin",
     "rarity":"",
-    "baseStamina": 120,
-    "baseAttack": 116,
-    "baseDefense": 102,
     "types": [
       {
         "type": "Fire",
@@ -39943,9 +33914,6 @@
   "654":{
     "name": "Braixen",
     "rarity":"",
-    "baseStamina": 153,
-    "baseAttack": 171,
-    "baseDefense": 130,
     "types": [
       {
         "type": "Fire",
@@ -39956,9 +33924,6 @@
   "655":{
     "name": "Delphox",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 230,
-    "baseDefense": 189,
     "types": [
       {
         "type": "Fire",
@@ -39973,9 +33938,6 @@
   "656":{
     "name": "Froakie",
     "rarity":"",
-    "baseStamina": 121,
-    "baseAttack": 122,
-    "baseDefense": 84,
     "types": [
       {
         "type": "Water",
@@ -39986,9 +33948,6 @@
   "657":{
     "name": "Frogadier",
     "rarity":"",
-    "baseStamina": 144,
-    "baseAttack": 168,
-    "baseDefense": 114,
     "types": [
       {
         "type": "Water",
@@ -39999,9 +33958,6 @@
   "658":{
     "name": "Greninja",
     "rarity":"",
-    "baseStamina": 176,
-    "baseAttack": 339,
-    "baseDefense": 155,
     "types": [
       {
         "type": "Water",
@@ -40016,9 +33972,6 @@
   "659":{
     "name": "Bunnelby",
     "rarity":"",
-    "baseStamina": 116,
-    "baseAttack": 68,
-    "baseDefense": 72,
     "types": [
       {
         "type": "Normal",
@@ -40029,9 +33982,6 @@
   "660":{
     "name": "Diggersby",
     "rarity":"",
-    "baseStamina": 198,
-    "baseAttack": 112,
-    "baseDefense": 155,
     "types": [
       {
         "type": "Normal",
@@ -40046,9 +33996,6 @@
   "661":{
     "name": "Fletchling",
     "rarity":"",
-    "baseStamina": 128,
-    "baseAttack": 95,
-    "baseDefense": 80,
     "types": [
       {
         "type": "Normal",
@@ -40063,9 +34010,6 @@
   "662":{
     "name": "Fletchinder",
     "rarity":"",
-    "baseStamina": 158,
-    "baseAttack": 145,
-    "baseDefense": 110,
     "types": [
       {
         "type": "Fire",
@@ -40080,9 +34024,6 @@
   "663":{
     "name": "Talonflame",
     "rarity":"",
-    "baseStamina": 186,
-    "baseAttack": 176,
-    "baseDefense": 155,
     "types": [
       {
         "type": "Fire",
@@ -40097,9 +34038,6 @@
   "664":{
     "name": "Scatterbug",
     "rarity":"",
-    "baseStamina": 116,
-    "baseAttack": 63,
-    "baseDefense": 63,
     "types": [
       {
         "type": "Bug",
@@ -40110,9 +34048,6 @@
   "665":{
     "name": "Spewpa",
     "rarity":"",
-    "baseStamina": 128,
-    "baseAttack": 48,
-    "baseDefense": 89,
     "types": [
       {
         "type": "Bug",
@@ -40123,9 +34058,6 @@
   "666":{
     "name": "Vivillon",
     "rarity":"",
-    "baseStamina": 190,
-    "baseAttack": 176,
-    "baseDefense": 103,
     "types": [
       {
         "type": "Bug",
@@ -40135,14 +34067,293 @@
         "type": "Flying",
         "color": "#a890f0"
       }
+    ],
+    "forms": [
+      {
+        "nameform": "Archipelago",
+        "protoform": "2594",
+        "formtypes": [
+          {
+            "type": "Bug",
+            "color": "#a8b820"
+          },
+          {
+            "type": "Flying",
+            "color": "#a890f0"
+          }
+        ]
+      },
+      {
+        "nameform": "Continental",
+        "protoform": "2595",
+        "formtypes": [
+          {
+            "type": "Bug",
+            "color": "#a8b820"
+          },
+          {
+            "type": "Flying",
+            "color": "#a890f0"
+          }
+        ]
+      },
+      {
+        "nameform": "Elegant",
+        "protoform": "2596",
+        "formtypes": [
+          {
+            "type": "Bug",
+            "color": "#a8b820"
+          },
+          {
+            "type": "Flying",
+            "color": "#a890f0"
+          }
+        ]
+      },
+      {
+        "nameform": "Fancy",
+        "protoform": "2597",
+        "formtypes": [
+          {
+            "type": "Bug",
+            "color": "#a8b820"
+          },
+          {
+            "type": "Flying",
+            "color": "#a890f0"
+          }
+        ]
+      },
+      {
+        "nameform": "Garden",
+        "protoform": "2598",
+        "formtypes": [
+          {
+            "type": "Bug",
+            "color": "#a8b820"
+          },
+          {
+            "type": "Flying",
+            "color": "#a890f0"
+          }
+        ]
+      },
+      {
+        "nameform": "High Plains",
+        "protoform": "2599",
+        "formtypes": [
+          {
+            "type": "Bug",
+            "color": "#a8b820"
+          },
+          {
+            "type": "Flying",
+            "color": "#a890f0"
+          }
+        ]
+      },
+      {
+        "nameform": "Icy Snow",
+        "protoform": "2600",
+        "formtypes": [
+          {
+            "type": "Bug",
+            "color": "#a8b820"
+          },
+          {
+            "type": "Flying",
+            "color": "#a890f0"
+          }
+        ]
+      },
+      {
+        "nameform": "Jungle",
+        "protoform": "2601",
+        "formtypes": [
+          {
+            "type": "Bug",
+            "color": "#a8b820"
+          },
+          {
+            "type": "Flying",
+            "color": "#a890f0"
+          }
+        ]
+      },
+      {
+        "nameform": "Marine",
+        "protoform": "2602",
+        "formtypes": [
+          {
+            "type": "Bug",
+            "color": "#a8b820"
+          },
+          {
+            "type": "Flying",
+            "color": "#a890f0"
+          }
+        ]
+      },
+      {
+        "nameform": "Meadow",
+        "protoform": "2603",
+        "formtypes": [
+          {
+            "type": "Bug",
+            "color": "#a8b820"
+          },
+          {
+            "type": "Flying",
+            "color": "#a890f0"
+          }
+        ]
+      },
+      {
+        "nameform": "Modern",
+        "protoform": "2604",
+        "formtypes": [
+          {
+            "type": "Bug",
+            "color": "#a8b820"
+          },
+          {
+            "type": "Flying",
+            "color": "#a890f0"
+          }
+        ]
+      },
+      {
+        "nameform": "Monsoon",
+        "protoform": "2605",
+        "formtypes": [
+          {
+            "type": "Bug",
+            "color": "#a8b820"
+          },
+          {
+            "type": "Flying",
+            "color": "#a890f0"
+          }
+        ]
+      },
+      {
+        "nameform": "Ocean",
+        "protoform": "2606",
+        "formtypes": [
+          {
+            "type": "Bug",
+            "color": "#a8b820"
+          },
+          {
+            "type": "Flying",
+            "color": "#a890f0"
+          }
+        ]
+      },
+      {
+        "nameform": "Pokeball",
+        "protoform": "2607",
+        "formtypes": [
+          {
+            "type": "Bug",
+            "color": "#a8b820"
+          },
+          {
+            "type": "Flying",
+            "color": "#a890f0"
+          }
+        ]
+      },
+      {
+        "nameform": "Polar",
+        "protoform": "2608",
+        "formtypes": [
+          {
+            "type": "Bug",
+            "color": "#a8b820"
+          },
+          {
+            "type": "Flying",
+            "color": "#a890f0"
+          }
+        ]
+      },
+      {
+        "nameform": "River",
+        "protoform": "2609",
+        "formtypes": [
+          {
+            "type": "Bug",
+            "color": "#a8b820"
+          },
+          {
+            "type": "Flying",
+            "color": "#a890f0"
+          }
+        ]
+      },
+      {
+        "nameform": "Sandstorm",
+        "protoform": "2610",
+        "formtypes": [
+          {
+            "type": "Bug",
+            "color": "#a8b820"
+          },
+          {
+            "type": "Flying",
+            "color": "#a890f0"
+          }
+        ]
+      },
+      {
+        "nameform": "Savanna",
+        "protoform": "2611",
+        "formtypes": [
+          {
+            "type": "Bug",
+            "color": "#a8b820"
+          },
+          {
+            "type": "Flying",
+            "color": "#a890f0"
+          }
+        ]
+      },
+      {
+        "nameform": "Sun",
+        "protoform": "2612",
+        "formtypes": [
+          {
+            "type": "Bug",
+            "color": "#a8b820"
+          },
+          {
+            "type": "Flying",
+            "color": "#a890f0"
+          }
+        ]
+      },
+      {
+        "nameform": "Tundra",
+        "protoform": "2613",
+        "formtypes": [
+          {
+            "type": "Bug",
+            "color": "#a8b820"
+          },
+          {
+            "type": "Flying",
+            "color": "#a890f0"
+          }
+        ]
+      }
     ]
   },
   "667":{
     "name": "Litleo",
     "rarity":"",
-    "baseStamina": 158,
-    "baseAttack": 139,
-    "baseDefense": 112,
     "types": [
       {
         "type": "Fire",
@@ -40157,9 +34368,6 @@
   "668":{
     "name": "Pyroar",
     "rarity":"",
-    "baseStamina": 200,
-    "baseAttack": 221,
-    "baseDefense": 149,
     "types": [
       {
         "type": "Fire",
@@ -40169,53 +34377,227 @@
         "type": "Normal",
         "color": "#8a8a59"
       }
+    ],
+    "forms": [
+      {
+        "nameform": "Normal",
+        "protoform": "2587",
+        "formtypes": [
+          {
+            "type": "Fire",
+            "color": "#f08030"
+          },
+          {
+            "type": "Normal",
+            "color": "#8a8a59"
+          }
+        ]
+      },
+      {
+        "nameform": "Female",
+        "protoform": "2588",
+        "formtypes": [
+          {
+            "type": "Fire",
+            "color": "#f08030"
+          },
+          {
+            "type": "Normal",
+            "color": "#8a8a59"
+          }
+        ]
+      }
     ]
   },
   "669":{
     "name": "Flabébé",
     "rarity":"",
-    "baseStamina": 127,
-    "baseAttack": 108,
-    "baseDefense": 120,
     "types": [
       {
         "type": "Fairy",
         "color": "#e898e8"
+      }
+    ],
+    "forms": [
+      {
+        "nameform": "Red",
+        "protoform": "2614",
+        "formtypes": [
+          {
+            "type": "Fairy",
+            "color": "#e898e8"
+          }
+        ]
+      },
+      {
+        "nameform": "Yellow",
+        "protoform": "2615",
+        "formtypes": [
+          {
+            "type": "Fairy",
+            "color": "#e898e8"
+          }
+        ]
+      },
+      {
+        "nameform": "Orange",
+        "protoform": "2616",
+        "formtypes": [
+          {
+            "type": "Fairy",
+            "color": "#e898e8"
+          }
+        ]
+      },
+      {
+        "nameform": "Blue",
+        "protoform": "2617",
+        "formtypes": [
+          {
+            "type": "Fairy",
+            "color": "#e898e8"
+          }
+        ]
+      },
+      {
+        "nameform": "White",
+        "protoform": "2618",
+        "formtypes": [
+          {
+            "type": "Fairy",
+            "color": "#e898e8"
+          }
+        ]
       }
     ]
   },
   "670":{
     "name": "Floette",
     "rarity":"",
-    "baseStamina": 144,
-    "baseAttack": 136,
-    "baseDefense": 151,
     "types": [
       {
         "type": "Fairy",
         "color": "#e898e8"
+      }
+    ],
+    "forms": [
+      {
+        "nameform": "Red",
+        "protoform": "2619",
+        "formtypes": [
+          {
+            "type": "Fairy",
+            "color": "#e898e8"
+          }
+        ]
+      },
+      {
+        "nameform": "Yellow",
+        "protoform": "2620",
+        "formtypes": [
+          {
+            "type": "Fairy",
+            "color": "#e898e8"
+          }
+        ]
+      },
+      {
+        "nameform": "Orange",
+        "protoform": "2621",
+        "formtypes": [
+          {
+            "type": "Fairy",
+            "color": "#e898e8"
+          }
+        ]
+      },
+      {
+        "nameform": "Blue",
+        "protoform": "2622",
+        "formtypes": [
+          {
+            "type": "Fairy",
+            "color": "#e898e8"
+          }
+        ]
+      },
+      {
+        "nameform": "White",
+        "protoform": "2623",
+        "formtypes": [
+          {
+            "type": "Fairy",
+            "color": "#e898e8"
+          }
+        ]
       }
     ]
   },
   "671":{
     "name": "Florges",
     "rarity":"",
-    "baseStamina": 186,
-    "baseAttack": 212,
-    "baseDefense": 244,
     "types": [
       {
         "type": "Fairy",
         "color": "#e898e8"
+      }
+    ],
+    "forms": [
+      {
+        "nameform": "Red",
+        "protoform": "2624",
+        "formtypes": [
+          {
+            "type": "Fairy",
+            "color": "#e898e8"
+          }
+        ]
+      },
+      {
+        "nameform": "Yellow",
+        "protoform": "2625",
+        "formtypes": [
+          {
+            "type": "Fairy",
+            "color": "#e898e8"
+          }
+        ]
+      },
+      {
+        "nameform": "Orange",
+        "protoform": "2626",
+        "formtypes": [
+          {
+            "type": "Fairy",
+            "color": "#e898e8"
+          }
+        ]
+      },
+      {
+        "nameform": "Blue",
+        "protoform": "2627",
+        "formtypes": [
+          {
+            "type": "Fairy",
+            "color": "#e898e8"
+          }
+        ]
+      },
+      {
+        "nameform": "White",
+        "protoform": "2628",
+        "formtypes": [
+          {
+            "type": "Fairy",
+            "color": "#e898e8"
+          }
+        ]
       }
     ]
   },
   "672":{
     "name": "Skiddo",
     "rarity":"",
-    "baseStamina": 165,
-    "baseAttack": 123,
-    "baseDefense": 102,
     "types": [
       {
         "type": "Grass",
@@ -40226,9 +34608,6 @@
   "673":{
     "name": "Gogoat",
     "rarity":"",
-    "baseStamina": 265,
-    "baseAttack": 196,
-    "baseDefense": 146,
     "types": [
       {
         "type": "Grass",
@@ -40239,9 +34618,6 @@
   "674":{
     "name": "Pancham",
     "rarity":"",
-    "baseStamina": 167,
-    "baseAttack": 145,
-    "baseDefense": 107,
     "types": [
       {
         "type": "Fighting",
@@ -40252,9 +34628,6 @@
   "675":{
     "name": "Pangoro",
     "rarity":"",
-    "baseStamina": 216,
-    "baseAttack": 226,
-    "baseDefense": 146,
     "types": [
       {
         "type": "Fighting",
@@ -40269,22 +34642,118 @@
   "676":{
     "name": "Furfrou",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 164,
-    "baseDefense": 167,
     "types": [
       {
         "type": "Normal",
         "color": "#8a8a59"
+      }
+    ],
+    "forms": [
+      {
+        "nameform": "Natural",
+        "protoform": "2629",
+        "formtypes": [
+          {
+            "type": "Normal",
+            "color": "#8a8a59"
+          }
+        ]
+      },
+      {
+        "nameform": "Heart",
+        "protoform": "2630",
+        "formtypes": [
+          {
+            "type": "Normal",
+            "color": "#8a8a59"
+          }
+        ]
+      },
+      {
+        "nameform": "Star",
+        "protoform": "2631",
+        "formtypes": [
+          {
+            "type": "Normal",
+            "color": "#8a8a59"
+          }
+        ]
+      },
+      {
+        "nameform": "Diamond",
+        "protoform": "2632",
+        "formtypes": [
+          {
+            "type": "Normal",
+            "color": "#8a8a59"
+          }
+        ]
+      },
+      {
+        "nameform": "Debutante",
+        "protoform": "2633",
+        "formtypes": [
+          {
+            "type": "Normal",
+            "color": "#8a8a59"
+          }
+        ]
+      },
+      {
+        "nameform": "Matron",
+        "protoform": "2634",
+        "formtypes": [
+          {
+            "type": "Normal",
+            "color": "#8a8a59"
+          }
+        ]
+      },
+      {
+        "nameform": "Dandy",
+        "protoform": "2635",
+        "formtypes": [
+          {
+            "type": "Normal",
+            "color": "#8a8a59"
+          }
+        ]
+      },
+      {
+        "nameform": "La Reine",
+        "protoform": "2636",
+        "formtypes": [
+          {
+            "type": "Normal",
+            "color": "#8a8a59"
+          }
+        ]
+      },
+      {
+        "nameform": "Kabuki",
+        "protoform": "2637",
+        "formtypes": [
+          {
+            "type": "Normal",
+            "color": "#8a8a59"
+          }
+        ]
+      },
+      {
+        "nameform": "Pharaoh",
+        "protoform": "2638",
+        "formtypes": [
+          {
+            "type": "Normal",
+            "color": "#8a8a59"
+          }
+        ]
       }
     ]
   },
   "677":{
     "name": "Espurr",
     "rarity":"",
-    "baseStamina": 158,
-    "baseAttack": 120,
-    "baseDefense": 114,
     "types": [
       {
         "type": "Psychic",
@@ -40295,22 +34764,38 @@
   "678":{
     "name": "Meowstic",
     "rarity":"",
-    "baseStamina": 179,
-    "baseAttack": 166,
-    "baseDefense": 167,
     "types": [
       {
         "type": "Psychic",
         "color": "#f85888"
+      }
+    ],
+    "forms": [
+      {
+        "nameform": "Normal",
+        "protoform": "2589",
+        "formtypes": [
+          {
+            "type": "Psychic",
+            "color": "#f85888"
+          }
+        ]
+      },
+      {
+        "nameform": "Female",
+        "protoform": "2590",
+        "formtypes": [
+          {
+            "type": "Psychic",
+            "color": "#f85888"
+          }
+        ]
       }
     ]
   },
   "679":{
     "name": "Honedge",
     "rarity":"",
-    "baseStamina": 128,
-    "baseAttack": 135,
-    "baseDefense": 139,
     "types": [
       {
         "type": "Steel",
@@ -40325,9 +34810,6 @@
   "680":{
     "name": "Doublade",
     "rarity":"",
-    "baseStamina": 153,
-    "baseAttack": 188,
-    "baseDefense": 206,
     "types": [
       {
         "type": "Steel",
@@ -40342,9 +34824,6 @@
   "681":{
     "name": "Aegislash",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 97,
-    "baseDefense": 291,
     "types": [
       {
         "type": "Steel",
@@ -40354,14 +34833,41 @@
         "type": "Ghost",
         "color": "#705898"
       }
+    ],
+    "forms": [
+      {
+        "nameform": "Shield",
+        "protoform": "2639",
+        "formtypes": [
+          {
+            "type": "Steel",
+            "color": "#b8b8d0"
+          },
+          {
+            "type": "Ghost",
+            "color": "#705898"
+          }
+        ]
+      },
+      {
+        "nameform": "Blade",
+        "protoform": "2640",
+        "formtypes": [
+          {
+            "type": "Steel",
+            "color": "#b8b8d0"
+          },
+          {
+            "type": "Ghost",
+            "color": "#705898"
+          }
+        ]
+      }
     ]
   },
   "682":{
     "name": "Spritzee",
     "rarity":"",
-    "baseStamina": 186,
-    "baseAttack": 110,
-    "baseDefense": 113,
     "types": [
       {
         "type": "Fairy",
@@ -40372,9 +34878,6 @@
   "683":{
     "name": "Aromatisse",
     "rarity":"",
-    "baseStamina": 226,
-    "baseAttack": 173,
-    "baseDefense": 150,
     "types": [
       {
         "type": "Fairy",
@@ -40385,9 +34888,6 @@
   "684":{
     "name": "Swirlix",
     "rarity":"",
-    "baseStamina": 158,
-    "baseAttack": 109,
-    "baseDefense": 119,
     "types": [
       {
         "type": "Fairy",
@@ -40398,9 +34898,6 @@
   "685":{
     "name": "Slurpuff",
     "rarity":"",
-    "baseStamina": 193,
-    "baseAttack": 168,
-    "baseDefense": 163,
     "types": [
       {
         "type": "Fairy",
@@ -40411,9 +34908,6 @@
   "686":{
     "name": "Inkay",
     "rarity":"",
-    "baseStamina": 142,
-    "baseAttack": 98,
-    "baseDefense": 95,
     "types": [
       {
         "type": "Dark",
@@ -40428,9 +34922,6 @@
   "687":{
     "name": "Malamar",
     "rarity":"",
-    "baseStamina": 200,
-    "baseAttack": 177,
-    "baseDefense": 165,
     "types": [
       {
         "type": "Dark",
@@ -40445,9 +34936,6 @@
   "688":{
     "name": "Binacle",
     "rarity":"",
-    "baseStamina": 123,
-    "baseAttack": 96,
-    "baseDefense": 120,
     "types": [
       {
         "type": "Rock",
@@ -40462,9 +34950,6 @@
   "689":{
     "name": "Barbaracle",
     "rarity":"",
-    "baseStamina": 176,
-    "baseAttack": 194,
-    "baseDefense": 205,
     "types": [
       {
         "type": "Rock",
@@ -40479,9 +34964,6 @@
   "690":{
     "name": "Skrelp",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 109,
-    "baseDefense": 109,
     "types": [
       {
         "type": "Poison",
@@ -40496,9 +34978,6 @@
   "691":{
     "name": "Dragalge",
     "rarity":"",
-    "baseStamina": 163,
-    "baseAttack": 177,
-    "baseDefense": 207,
     "types": [
       {
         "type": "Poison",
@@ -40513,9 +34992,6 @@
   "692":{
     "name": "Clauncher",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 108,
-    "baseDefense": 117,
     "types": [
       {
         "type": "Water",
@@ -40526,9 +35002,6 @@
   "693":{
     "name": "Clawitzer",
     "rarity":"",
-    "baseStamina": 174,
-    "baseAttack": 221,
-    "baseDefense": 171,
     "types": [
       {
         "type": "Water",
@@ -40539,9 +35012,6 @@
   "694":{
     "name": "Helioptile",
     "rarity":"",
-    "baseStamina": 127,
-    "baseAttack": 115,
-    "baseDefense": 78,
     "types": [
       {
         "type": "Electric",
@@ -40556,9 +35026,6 @@
   "695":{
     "name": "Heliolisk",
     "rarity":"",
-    "baseStamina": 158,
-    "baseAttack": 219,
-    "baseDefense": 168,
     "types": [
       {
         "type": "Electric",
@@ -40573,9 +35040,6 @@
   "696":{
     "name": "Tyrunt",
     "rarity":"",
-    "baseStamina": 151,
-    "baseAttack": 158,
-    "baseDefense": 123,
     "types": [
       {
         "type": "Rock",
@@ -40590,9 +35054,6 @@
   "697":{
     "name": "Tyrantrum",
     "rarity":"",
-    "baseStamina": 193,
-    "baseAttack": 227,
-    "baseDefense": 191,
     "types": [
       {
         "type": "Rock",
@@ -40607,9 +35068,6 @@
   "698":{
     "name": "Amaura",
     "rarity":"",
-    "baseStamina": 184,
-    "baseAttack": 124,
-    "baseDefense": 109,
     "types": [
       {
         "type": "Rock",
@@ -40624,9 +35082,6 @@
   "699":{
     "name": "Aurorus",
     "rarity":"",
-    "baseStamina": 265,
-    "baseAttack": 186,
-    "baseDefense": 163,
     "types": [
       {
         "type": "Rock",
@@ -40641,9 +35096,6 @@
   "700":{
     "name": "Sylveon",
     "rarity":"",
-    "baseStamina": 216,
-    "baseAttack": 203,
-    "baseDefense": 205,
     "types": [
       {
         "type": "Fairy",
@@ -40654,9 +35106,6 @@
   "701":{
     "name": "Hawlucha",
     "rarity":"",
-    "baseStamina": 186,
-    "baseAttack": 195,
-    "baseDefense": 153,
     "types": [
       {
         "type": "Fighting",
@@ -40671,9 +35120,6 @@
   "702":{
     "name": "Dedenne",
     "rarity":"",
-    "baseStamina": 167,
-    "baseAttack": 164,
-    "baseDefense": 134,
     "types": [
       {
         "type": "Electric",
@@ -40688,9 +35134,6 @@
   "703":{
     "name": "Carbink",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 95,
-    "baseDefense": 285,
     "types": [
       {
         "type": "Rock",
@@ -40705,9 +35148,6 @@
   "704":{
     "name": "Goomy",
     "rarity":"",
-    "baseStamina": 128,
-    "baseAttack": 101,
-    "baseDefense": 112,
     "types": [
       {
         "type": "Dragon",
@@ -40718,9 +35158,6 @@
   "705":{
     "name": "Sliggoo",
     "rarity":"",
-    "baseStamina": 169,
-    "baseAttack": 159,
-    "baseDefense": 176,
     "types": [
       {
         "type": "Dragon",
@@ -40731,9 +35168,6 @@
   "706":{
     "name": "Goodra",
     "rarity":"",
-    "baseStamina": 207,
-    "baseAttack": 220,
-    "baseDefense": 242,
     "types": [
       {
         "type": "Dragon",
@@ -40744,9 +35178,6 @@
   "707":{
     "name": "Klefki",
     "rarity":"",
-    "baseStamina": 149,
-    "baseAttack": 160,
-    "baseDefense": 179,
     "types": [
       {
         "type": "Steel",
@@ -40761,9 +35192,6 @@
   "708":{
     "name": "Phantump",
     "rarity":"",
-    "baseStamina": 125,
-    "baseAttack": 125,
-    "baseDefense": 103,
     "types": [
       {
         "type": "Ghost",
@@ -40778,9 +35206,6 @@
   "709":{
     "name": "Trevenant",
     "rarity":"",
-    "baseStamina": 198,
-    "baseAttack": 201,
-    "baseDefense": 154,
     "types": [
       {
         "type": "Ghost",
@@ -40795,9 +35220,6 @@
   "710":{
     "name": "Pumpkaboo",
     "rarity":"",
-    "baseStamina": 153,
-    "baseAttack": 118,
-    "baseDefense": 120,
     "types": [
       {
         "type": "Ghost",
@@ -40806,15 +35228,70 @@
       {
         "type": "Grass",
         "color": "#78c850"
+      }
+    ],
+    "forms": [
+      {
+        "nameform": "Small",
+        "protoform": "2641",
+        "formtypes": [
+          {
+            "type": "Ghost",
+            "color": "#705898"
+          },
+          {
+            "type": "Grass",
+            "color": "#78c850"
+          }
+        ]
+      },
+      {
+        "nameform": "Average",
+        "protoform": "2642",
+        "formtypes": [
+          {
+            "type": "Ghost",
+            "color": "#705898"
+          },
+          {
+            "type": "Grass",
+            "color": "#78c850"
+          }
+        ]
+      },
+      {
+        "nameform": "Large",
+        "protoform": "2643",
+        "formtypes": [
+          {
+            "type": "Ghost",
+            "color": "#705898"
+          },
+          {
+            "type": "Grass",
+            "color": "#78c850"
+          }
+        ]
+      },
+      {
+        "nameform": "Super",
+        "protoform": "2644",
+        "formtypes": [
+          {
+            "type": "Ghost",
+            "color": "#705898"
+          },
+          {
+            "type": "Grass",
+            "color": "#78c850"
+          }
+        ]
       }
     ]
   },
   "711":{
     "name": "Gourgeist",
     "rarity":"",
-    "baseStamina": 198,
-    "baseAttack": 182,
-    "baseDefense": 200,
     "types": [
       {
         "type": "Ghost",
@@ -40824,14 +35301,69 @@
         "type": "Grass",
         "color": "#78c850"
       }
+    ],
+    "forms": [
+      {
+        "nameform": "Small",
+        "protoform": "2645",
+        "formtypes": [
+          {
+            "type": "Ghost",
+            "color": "#705898"
+          },
+          {
+            "type": "Grass",
+            "color": "#78c850"
+          }
+        ]
+      },
+      {
+        "nameform": "Average",
+        "protoform": "2646",
+        "formtypes": [
+          {
+            "type": "Ghost",
+            "color": "#705898"
+          },
+          {
+            "type": "Grass",
+            "color": "#78c850"
+          }
+        ]
+      },
+      {
+        "nameform": "Large",
+        "protoform": "2647",
+        "formtypes": [
+          {
+            "type": "Ghost",
+            "color": "#705898"
+          },
+          {
+            "type": "Grass",
+            "color": "#78c850"
+          }
+        ]
+      },
+      {
+        "nameform": "Super",
+        "protoform": "2648",
+        "formtypes": [
+          {
+            "type": "Ghost",
+            "color": "#705898"
+          },
+          {
+            "type": "Grass",
+            "color": "#78c850"
+          }
+        ]
+      }
     ]
   },
   "712":{
     "name": "Bergmite",
     "rarity":"",
-    "baseStamina": 146,
-    "baseAttack": 117,
-    "baseDefense": 120,
     "types": [
       {
         "type": "Ice",
@@ -40842,9 +35374,6 @@
   "713":{
     "name": "Avalugg",
     "rarity":"",
-    "baseStamina": 216,
-    "baseAttack": 196,
-    "baseDefense": 240,
     "types": [
       {
         "type": "Ice",
@@ -40855,9 +35384,6 @@
   "714":{
     "name": "Noibat",
     "rarity":"",
-    "baseStamina": 120,
-    "baseAttack": 83,
-    "baseDefense": 73,
     "types": [
       {
         "type": "Flying",
@@ -40872,9 +35398,6 @@
   "715":{
     "name": "Noivern",
     "rarity":"",
-    "baseStamina": 198,
-    "baseAttack": 205,
-    "baseDefense": 175,
     "types": [
       {
         "type": "Flying",
@@ -40889,22 +35412,38 @@
   "716":{
     "name": "Xerneas",
     "rarity":"",
-    "baseStamina": 270,
-    "baseAttack": 275,
-    "baseDefense": 203,
     "types": [
       {
         "type": "Fairy",
         "color": "#e898e8"
+      }
+    ],
+    "forms": [
+      {
+        "nameform": "Neutral",
+        "protoform": "2649",
+        "formtypes": [
+          {
+            "type": "Fairy",
+            "color": "#e898e8"
+          }
+        ]
+      },
+      {
+        "nameform": "Active",
+        "protoform": "2650",
+        "formtypes": [
+          {
+            "type": "Fairy",
+            "color": "#e898e8"
+          }
+        ]
       }
     ]
   },
   "717":{
     "name": "Yveltal",
     "rarity":"",
-    "baseStamina": 270,
-    "baseAttack": 275,
-    "baseDefense": 203,
     "types": [
       {
         "type": "Dark",
@@ -40919,9 +35458,6 @@
   "718":{
     "name": "Zygarde",
     "rarity":"",
-    "baseStamina": 428,
-    "baseAttack": 202,
-    "baseDefense": 227,
     "types": [
       {
         "type": "Dragon",
@@ -40931,14 +35467,55 @@
         "type": "Ground",
         "color": "#e0c068"
       }
+    ],
+    "forms": [
+      {
+        "nameform": "Ten Percent",
+        "protoform": "2591",
+        "formtypes": [
+          {
+            "type": "Dragon",
+            "color": "#7038f8"
+          },
+          {
+            "type": "Ground",
+            "color": "#e0c068"
+          }
+        ]
+      },
+      {
+        "nameform": "Fifty Percent",
+        "protoform": "2592",
+        "formtypes": [
+          {
+            "type": "Dragon",
+            "color": "#7038f8"
+          },
+          {
+            "type": "Ground",
+            "color": "#e0c068"
+          }
+        ]
+      },
+      {
+        "nameform": "Complete",
+        "protoform": "2593",
+        "formtypes": [
+          {
+            "type": "Dragon",
+            "color": "#7038f8"
+          },
+          {
+            "type": "Ground",
+            "color": "#e0c068"
+          }
+        ]
+      }
     ]
   },
   "719":{
     "name": "Diancie",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 190,
-    "baseDefense": 285,
     "types": [
       {
         "type": "Rock",
@@ -40953,9 +35530,6 @@
   "720":{
     "name": "Hoopa",
     "rarity":"",
-    "baseStamina": 190,
-    "baseAttack": 341,
-    "baseDefense": 210,
     "types": [
       {
         "type": "Psychic",
@@ -40965,14 +35539,41 @@
         "type": "Ghost",
         "color": "#705898"
       }
+    ],
+    "forms": [
+      {
+        "nameform": "Confined",
+        "protoform": "2650",
+        "formtypes": [
+          {
+            "type": "Psychic",
+            "color": "#f85888"
+          },
+          {
+            "type": "Ghost",
+            "color": "#705898"
+          }
+        ]
+      },
+      {
+        "nameform": "Unbound",
+        "protoform": "2652",
+        "formtypes": [
+          {
+            "type": "Psychic",
+            "color": "#f85888"
+          },
+          {
+            "type": "Ghost",
+            "color": "#705898"
+          }
+        ]
+      }
     ]
   },
   "721":{
     "name": "Volcanion",
     "rarity":"",
-    "baseStamina": 190,
-    "baseAttack": 252,
-    "baseDefense": 216,
     "types": [
       {
         "type": "Fire",
@@ -40987,9 +35588,6 @@
   "722":{
     "name": "Rowlet",
     "rarity":"",
-    "baseStamina": 169,
-    "baseAttack": 102,
-    "baseDefense": 99,
     "types": [
       {
         "type": "Grass",
@@ -41004,9 +35602,6 @@
   "723":{
     "name": "Dartrix",
     "rarity":"",
-    "baseStamina": 186,
-    "baseAttack": 142,
-    "baseDefense": 139,
     "types": [
       {
         "type": "Grass",
@@ -41021,9 +35616,6 @@
   "724":{
     "name": "Decidueye",
     "rarity":"",
-    "baseStamina": 186,
-    "baseAttack": 210,
-    "baseDefense": 179,
     "types": [
       {
         "type": "Grass",
@@ -41038,9 +35630,6 @@
   "725":{
     "name": "Litten",
     "rarity":"",
-    "baseStamina": 128,
-    "baseAttack": 128,
-    "baseDefense": 79,
     "types": [
       {
         "type": "Fire",
@@ -41051,9 +35640,6 @@
   "726":{
     "name": "Torracat",
     "rarity":"",
-    "baseStamina": 163,
-    "baseAttack": 174,
-    "baseDefense": 103,
     "types": [
       {
         "type": "Fire",
@@ -41064,9 +35650,6 @@
   "727":{
     "name": "Incineroar",
     "rarity":"",
-    "baseStamina": 216,
-    "baseAttack": 214,
-    "baseDefense": 175,
     "types": [
       {
         "type": "Fire",
@@ -41081,9 +35664,6 @@
   "728":{
     "name": "Popplio",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 120,
-    "baseDefense": 103,
     "types": [
       {
         "type": "Water",
@@ -41094,9 +35674,6 @@
   "729":{
     "name": "Brionne",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 168,
-    "baseDefense": 145,
     "types": [
       {
         "type": "Water",
@@ -41107,9 +35684,6 @@
   "730":{
     "name": "Primarina",
     "rarity":"",
-    "baseStamina": 190,
-    "baseAttack": 232,
-    "baseDefense": 195,
     "types": [
       {
         "type": "Water",
@@ -41124,9 +35698,6 @@
   "731":{
     "name": "Pikipek",
     "rarity":"",
-    "baseStamina": 111,
-    "baseAttack": 136,
-    "baseDefense": 59,
     "types": [
       {
         "type": "Normal",
@@ -41141,9 +35712,6 @@
   "732":{
     "name": "Trumbeak",
     "rarity":"",
-    "baseStamina": 146,
-    "baseAttack": 159,
-    "baseDefense": 100,
     "types": [
       {
         "type": "Normal",
@@ -41158,9 +35726,6 @@
   "733":{
     "name": "Toucannon",
     "rarity":"",
-    "baseStamina": 190,
-    "baseAttack": 222,
-    "baseDefense": 146,
     "types": [
       {
         "type": "Normal",
@@ -41175,9 +35740,6 @@
   "734":{
     "name": "Yungoos",
     "rarity":"",
-    "baseStamina": 134,
-    "baseAttack": 122,
-    "baseDefense": 56,
     "types": [
       {
         "type": "Normal",
@@ -41188,9 +35750,6 @@
   "735":{
     "name": "Gumshoos",
     "rarity":"",
-    "baseStamina": 204,
-    "baseAttack": 194,
-    "baseDefense": 113,
     "types": [
       {
         "type": "Normal",
@@ -41201,9 +35760,6 @@
   "736":{
     "name": "Grubbin",
     "rarity":"",
-    "baseStamina": 132,
-    "baseAttack": 115,
-    "baseDefense": 85,
     "types": [
       {
         "type": "Bug",
@@ -41214,9 +35770,6 @@
   "737":{
     "name": "Charjabug",
     "rarity":"",
-    "baseStamina": 149,
-    "baseAttack": 145,
-    "baseDefense": 161,
     "types": [
       {
         "type": "Bug",
@@ -41231,9 +35784,6 @@
   "738":{
     "name": "Vikavolt",
     "rarity":"",
-    "baseStamina": 184,
-    "baseAttack": 254,
-    "baseDefense": 158,
     "types": [
       {
         "type": "Bug",
@@ -41248,9 +35798,6 @@
   "739":{
     "name": "Crabrawler",
     "rarity":"",
-    "baseStamina": 132,
-    "baseAttack": 150,
-    "baseDefense": 104,
     "types": [
       {
         "type": "Fighting",
@@ -41261,9 +35808,6 @@
   "740":{
     "name": "Crabominable",
     "rarity":"",
-    "baseStamina": 219,
-    "baseAttack": 231,
-    "baseDefense": 138,
     "types": [
       {
         "type": "Fighting",
@@ -41278,9 +35822,6 @@
   "741":{
     "name": "Oricorio",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 196,
-    "baseDefense": 145,
     "types": [
       {
         "type": "Fire",
@@ -41295,9 +35836,6 @@
   "742":{
     "name": "Cutiefly",
     "rarity":"",
-    "baseStamina": 120,
-    "baseAttack": 110,
-    "baseDefense": 81,
     "types": [
       {
         "type": "Bug",
@@ -41312,9 +35850,6 @@
   "743":{
     "name": "Ribombee",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 198,
-    "baseDefense": 146,
     "types": [
       {
         "type": "Bug",
@@ -41329,9 +35864,6 @@
   "744":{
     "name": "Rockruff",
     "rarity":"",
-    "baseStamina": 128,
-    "baseAttack": 117,
-    "baseDefense": 78,
     "types": [
       {
         "type": "Rock",
@@ -41342,9 +35874,6 @@
   "745":{
     "name": "Lycanroc",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 234,
-    "baseDefense": 139,
     "types": [
       {
         "type": "Rock",
@@ -41355,9 +35884,6 @@
   "746":{
     "name": "Wishiwashi",
     "rarity":"",
-    "baseStamina": 128,
-    "baseAttack": 255,
-    "baseDefense": 242,
     "types": [
       {
         "type": "Water",
@@ -41368,9 +35894,6 @@
   "747":{
     "name": "Mareanie",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 98,
-    "baseDefense": 110,
     "types": [
       {
         "type": "Poison",
@@ -41385,9 +35908,6 @@
   "748":{
     "name": "Toxapex",
     "rarity":"",
-    "baseStamina": 137,
-    "baseAttack": 114,
-    "baseDefense": 273,
     "types": [
       {
         "type": "Poison",
@@ -41402,9 +35922,6 @@
   "749":{
     "name": "Mudbray",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 175,
-    "baseDefense": 121,
     "types": [
       {
         "type": "Ground",
@@ -41415,9 +35932,6 @@
   "750":{
     "name": "Mudsdale",
     "rarity":"",
-    "baseStamina": 225,
-    "baseAttack": 214,
-    "baseDefense": 174,
     "types": [
       {
         "type": "Ground",
@@ -41428,9 +35942,6 @@
   "751":{
     "name": "Dewpider",
     "rarity":"",
-    "baseStamina": 116,
-    "baseAttack": 72,
-    "baseDefense": 117,
     "types": [
       {
         "type": "Water",
@@ -41445,9 +35956,6 @@
   "752":{
     "name": "Araquanid",
     "rarity":"",
-    "baseStamina": 169,
-    "baseAttack": 126,
-    "baseDefense": 219,
     "types": [
       {
         "type": "Water",
@@ -41462,9 +35970,6 @@
   "753":{
     "name": "Fomantis",
     "rarity":"",
-    "baseStamina": 120,
-    "baseAttack": 100,
-    "baseDefense": 64,
     "types": [
       {
         "type": "Grass",
@@ -41475,9 +35980,6 @@
   "754":{
     "name": "Lurantis",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 192,
-    "baseDefense": 169,
     "types": [
       {
         "type": "Grass",
@@ -41488,9 +35990,6 @@
   "755":{
     "name": "Morelull",
     "rarity":"",
-    "baseStamina": 120,
-    "baseAttack": 108,
-    "baseDefense": 119,
     "types": [
       {
         "type": "Grass",
@@ -41505,9 +36004,6 @@
   "756":{
     "name": "Shiinotic",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 154,
-    "baseDefense": 168,
     "types": [
       {
         "type": "Grass",
@@ -41522,9 +36018,6 @@
   "757":{
     "name": "Salandit",
     "rarity":"",
-    "baseStamina": 134,
-    "baseAttack": 136,
-    "baseDefense": 80,
     "types": [
       {
         "type": "Poison",
@@ -41539,9 +36032,6 @@
   "758":{
     "name": "Salazzle",
     "rarity":"",
-    "baseStamina": 169,
-    "baseAttack": 228,
-    "baseDefense": 130,
     "types": [
       {
         "type": "Poison",
@@ -41556,9 +36046,6 @@
   "759":{
     "name": "Stufful",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 136,
-    "baseDefense": 95,
     "types": [
       {
         "type": "Normal",
@@ -41573,9 +36060,6 @@
   "760":{
     "name": "Bewear",
     "rarity":"",
-    "baseStamina": 260,
-    "baseAttack": 226,
-    "baseDefense": 141,
     "types": [
       {
         "type": "Normal",
@@ -41590,9 +36074,6 @@
   "761":{
     "name": "Bounsweet",
     "rarity":"",
-    "baseStamina": 123,
-    "baseAttack": 55,
-    "baseDefense": 69,
     "types": [
       {
         "type": "Grass",
@@ -41603,9 +36084,6 @@
   "762":{
     "name": "Steenee",
     "rarity":"",
-    "baseStamina": 141,
-    "baseAttack": 78,
-    "baseDefense": 94,
     "types": [
       {
         "type": "Grass",
@@ -41616,9 +36094,6 @@
   "763":{
     "name": "Tsareena",
     "rarity":"",
-    "baseStamina": 176,
-    "baseAttack": 222,
-    "baseDefense": 195,
     "types": [
       {
         "type": "Grass",
@@ -41629,9 +36104,6 @@
   "764":{
     "name": "Comfey",
     "rarity":"",
-    "baseStamina": 139,
-    "baseAttack": 165,
-    "baseDefense": 215,
     "types": [
       {
         "type": "Fairy",
@@ -41642,9 +36114,6 @@
   "765":{
     "name": "Oranguru",
     "rarity":"",
-    "baseStamina": 207,
-    "baseAttack": 168,
-    "baseDefense": 192,
     "types": [
       {
         "type": "Normal",
@@ -41659,9 +36128,6 @@
   "766":{
     "name": "Passimian",
     "rarity":"",
-    "baseStamina": 225,
-    "baseAttack": 222,
-    "baseDefense": 160,
     "types": [
       {
         "type": "Fighting",
@@ -41672,9 +36138,6 @@
   "767":{
     "name": "Wimpod",
     "rarity":"",
-    "baseStamina": 93,
-    "baseAttack": 67,
-    "baseDefense": 74,
     "types": [
       {
         "type": "Bug",
@@ -41689,9 +36152,6 @@
   "768":{
     "name": "Golisopod",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 218,
-    "baseDefense": 226,
     "types": [
       {
         "type": "Bug",
@@ -41706,9 +36166,6 @@
   "769":{
     "name": "Sandygast",
     "rarity":"",
-    "baseStamina": 146,
-    "baseAttack": 120,
-    "baseDefense": 118,
     "types": [
       {
         "type": "Ghost",
@@ -41723,9 +36180,6 @@
   "770":{
     "name": "Palossand",
     "rarity":"",
-    "baseStamina": 198,
-    "baseAttack": 178,
-    "baseDefense": 178,
     "types": [
       {
         "type": "Ghost",
@@ -41740,9 +36194,6 @@
   "771":{
     "name": "Pyukumuku",
     "rarity":"",
-    "baseStamina": 146,
-    "baseAttack": 97,
-    "baseDefense": 224,
     "types": [
       {
         "type": "Water",
@@ -41753,9 +36204,6 @@
   "772":{
     "name": "Type: Null",
     "rarity":"",
-    "baseStamina": 216,
-    "baseAttack": 184,
-    "baseDefense": 184,
     "types": [
       {
         "type": "Normal",
@@ -41766,9 +36214,6 @@
   "773":{
     "name": "Silvally",
     "rarity":"",
-    "baseStamina": 216,
-    "baseAttack": 198,
-    "baseDefense": 198,
     "types": [
       {
         "type": "Normal",
@@ -41779,9 +36224,6 @@
   "774":{
     "name": "Minior (Core)",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 218,
-    "baseDefense": 131,
     "types": [
       {
         "type": "Rock",
@@ -41796,9 +36238,6 @@
   "775":{
     "name": "Komala",
     "rarity":"",
-    "baseStamina": 163,
-    "baseAttack": 216,
-    "baseDefense": 165,
     "types": [
       {
         "type": "Normal",
@@ -41809,9 +36248,6 @@
   "776":{
     "name": "Turtonator",
     "rarity":"",
-    "baseStamina": 155,
-    "baseAttack": 165,
-    "baseDefense": 215,
     "types": [
       {
         "type": "Fire",
@@ -41826,9 +36262,6 @@
   "777":{
     "name": "Togedemaru",
     "rarity":"",
-    "baseStamina": 163,
-    "baseAttack": 190,
-    "baseDefense": 145,
     "types": [
       {
         "type": "Electric",
@@ -41843,9 +36276,6 @@
   "778":{
     "name": "Mimikyu",
     "rarity":"",
-    "baseStamina": 146,
-    "baseAttack": 177,
-    "baseDefense": 199,
     "types": [
       {
         "type": "Ghost",
@@ -41860,9 +36290,6 @@
   "779":{
     "name": "Bruxish",
     "rarity":"",
-    "baseStamina": 169,
-    "baseAttack": 208,
-    "baseDefense": 145,
     "types": [
       {
         "type": "Water",
@@ -41877,9 +36304,6 @@
   "780":{
     "name": "Drampa",
     "rarity":"",
-    "baseStamina": 186,
-    "baseAttack": 231,
-    "baseDefense": 164,
     "types": [
       {
         "type": "Normal",
@@ -41894,9 +36318,6 @@
   "781":{
     "name": "Dhelmise",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 233,
-    "baseDefense": 179,
     "types": [
       {
         "type": "Ghost",
@@ -41911,9 +36332,6 @@
   "782":{
     "name": "Jangmo-o",
     "rarity":"",
-    "baseStamina": 128,
-    "baseAttack": 102,
-    "baseDefense": 108,
     "types": [
       {
         "type": "Dragon",
@@ -41924,9 +36342,6 @@
   "783":{
     "name": "Hakamo-o",
     "rarity":"",
-    "baseStamina": 146,
-    "baseAttack": 145,
-    "baseDefense": 162,
     "types": [
       {
         "type": "Dragon",
@@ -41941,9 +36356,6 @@
   "784":{
     "name": "Kommo-o",
     "rarity":"",
-    "baseStamina": 181,
-    "baseAttack": 222,
-    "baseDefense": 240,
     "types": [
       {
         "type": "Dragon",
@@ -41958,9 +36370,6 @@
   "785":{
     "name": "Tapu Koko",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 250,
-    "baseDefense": 181,
     "types": [
       {
         "type": "Electric",
@@ -41975,9 +36384,6 @@
   "786":{
     "name": "Tapu Lele",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 259,
-    "baseDefense": 208,
     "types": [
       {
         "type": "Psychic",
@@ -41992,9 +36398,6 @@
   "787":{
     "name": "Tapu Bulu",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 249,
-    "baseDefense": 215,
     "types": [
       {
         "type": "Grass",
@@ -42009,9 +36412,6 @@
   "788":{
     "name": "Tapu Fini",
     "rarity":"",
-    "baseStamina": 172,
-    "baseAttack": 189,
-    "baseDefense": 254,
     "types": [
       {
         "type": "Water",
@@ -42026,9 +36426,6 @@
   "789":{
     "name": "Cosmog",
     "rarity":"",
-    "baseStamina": 125,
-    "baseAttack": 54,
-    "baseDefense": 57,
     "types": [
       {
         "type": "Psychic",
@@ -42039,9 +36436,6 @@
   "790":{
     "name": "Cosmoem",
     "rarity":"",
-    "baseStamina": 125,
-    "baseAttack": 54,
-    "baseDefense": 242,
     "types": [
       {
         "type": "Psychic",
@@ -42052,9 +36446,6 @@
   "791":{
     "name": "Solgaleo",
     "rarity":"",
-    "baseStamina": 289,
-    "baseAttack": 280,
-    "baseDefense": 210,
     "types": [
       {
         "type": "Psychic",
@@ -42069,9 +36460,6 @@
   "792":{
     "name": "Lunala",
     "rarity":"",
-    "baseStamina": 289,
-    "baseAttack": 280,
-    "baseDefense": 210,
     "types": [
       {
         "type": "Psychic",
@@ -42086,9 +36474,6 @@
   "793":{
     "name": "Nihilego",
     "rarity":"",
-    "baseStamina": 240,
-    "baseAttack": 249,
-    "baseDefense": 210,
     "types": [
       {
         "type": "Rock",
@@ -42103,9 +36488,6 @@
   "794":{
     "name": "Buzzwole",
     "rarity":"",
-    "baseStamina": 237,
-    "baseAttack": 259,
-    "baseDefense": 216,
     "types": [
       {
         "type": "Bug",
@@ -42120,9 +36502,6 @@
   "795":{
     "name": "Pheromosa",
     "rarity":"",
-    "baseStamina": 174,
-    "baseAttack": 316,
-    "baseDefense": 85,
     "types": [
       {
         "type": "Bug",
@@ -42137,9 +36516,6 @@
   "796":{
     "name": "Xurkitree",
     "rarity":"",
-    "baseStamina": 195,
-    "baseAttack": 330,
-    "baseDefense": 144,
     "types": [
       {
         "type": "Electric",
@@ -42150,9 +36526,6 @@
   "797":{
     "name": "Celesteela",
     "rarity":"",
-    "baseStamina": 219,
-    "baseAttack": 207,
-    "baseDefense": 199,
     "types": [
       {
         "type": "Steel",
@@ -42167,9 +36540,6 @@
   "798":{
     "name": "Kartana",
     "rarity":"",
-    "baseStamina": 153,
-    "baseAttack": 355,
-    "baseDefense": 200,
     "types": [
       {
         "type": "Grass",
@@ -42184,9 +36554,6 @@
   "799":{
     "name": "Guzzlord",
     "rarity":"",
-    "baseStamina": 440,
-    "baseAttack": 188,
-    "baseDefense": 99,
     "types": [
       {
         "type": "Dark",
@@ -42201,9 +36568,6 @@
   "800":{
     "name": "Necrozma",
     "rarity":"",
-    "baseStamina": 219,
-    "baseAttack": 370,
-    "baseDefense": 215,
     "types": [
       {
         "type": "Psychic",
@@ -42214,9 +36578,6 @@
   "801":{
     "name": "Magearna",
     "rarity":"",
-    "baseStamina": 190,
-    "baseAttack": 246,
-    "baseDefense": 225,
     "types": [
       {
         "type": "Steel",
@@ -42231,9 +36592,6 @@
   "802": {
     "name": "Marshadow",
     "rarity": "",
-    "baseStamina": 207,
-    "baseAttack": 265,
-    "baseDefense": 190,
     "types": [
       {
         "type": "Fighting",
@@ -42248,9 +36606,6 @@
   "803": {
     "name": "Poipole",
     "rarity": "",
-    "baseStamina": 167,
-    "baseAttack": 145,
-    "baseDefense": 133,
     "types": [
       {
         "type": "Poison",
@@ -42261,9 +36616,6 @@
   "804": {
     "name": "Naganadel",
     "rarity": "",
-    "baseStamina": 177,
-    "baseAttack": 263,
-    "baseDefense": 159,
     "types": [
       {
         "type": "Poison",
@@ -42278,9 +36630,6 @@
   "805": {
     "name": "Stakataka",
     "rarity": "",
-    "baseStamina": 156,
-    "baseAttack": 213,
-    "baseDefense": 298,
     "types": [
       {
         "type": "Rock",
@@ -42295,9 +36644,6 @@
   "806": {
     "name": "Blacephalon",
     "rarity": "",
-    "baseStamina": 142,
-    "baseAttack": 315,
-    "baseDefense": 148,
     "types": [
       {
         "type": "Fire",
@@ -42312,9 +36658,6 @@
   "807": {
     "name": "Zeraora",
     "rarity": "",
-    "baseStamina": 204,
-    "baseAttack": 252,
-    "baseDefense": 177,
     "types": [
       {
         "type": "Electric",
@@ -42325,9 +36668,6 @@
   "808": {
     "name": "Meltan",
     "rarity": "",
-    "baseStamina": 130,
-    "baseAttack": 118,
-    "baseDefense": 99,
     "types": [
       {
         "type": "Steel",
@@ -42338,7 +36678,6 @@
       {
         "nameform": "Normal",
         "protoform": "2321",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -42349,7 +36688,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2322",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -42360,7 +36698,6 @@
       {
         "nameform": "Purified",
         "protoform": "2323",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -42373,9 +36710,6 @@
   "809": {
     "name": "Melmetal",
     "rarity": "",
-    "baseStamina": 264,
-    "baseAttack": 226,
-    "baseDefense": 190,
     "types": [
       {
         "type": "Steel",
@@ -42386,7 +36720,6 @@
       {
         "nameform": "Normal",
         "protoform": "2324",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -42397,7 +36730,6 @@
       {
         "nameform": "Shadow",
         "protoform": "2325",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
@@ -42408,13 +36740,552 @@
       {
         "nameform": "Purified",
         "protoform": "2326",
-        "assetsform": "00",
         "formtypes": [
           {
             "type": "Steel",
             "color": "#b8b8d0"
           }
         ]
+      }
+    ]
+  },
+  "810":{
+    "name":"Grookey",
+    "types":[
+      {
+        "type": "Grass",
+        "color": "#78c850"
+      }
+    ]
+  },
+  "811":{
+    "name":"Thwackey",
+    "types":[
+      {
+        "type": "Grass",
+        "color": "#78c850"
+      }
+    ]
+  },
+  "812":{
+    "name":"Rillaboom",
+    "types":[
+      {
+        "type": "Grass",
+        "color": "#78c850"
+      }
+    ]
+  },
+  "813":{
+    "name":"Scorbunny",
+    "types":[
+      {
+        "type": "Fire",
+        "color": "#f08030"
+      }
+    ]
+  },
+  "814":{
+    "name":"Raboot",
+    "types":[
+      {
+        "type": "Fire",
+        "color": "#f08030"
+      }
+    ]
+  },
+  "815":{
+    "name":"Cinderace",
+    "types":[
+      {
+        "type": "Fire",
+        "color": "#f08030"
+      }
+    ]
+  },
+  "816":{
+    "name":"Sobble",
+    "types":[
+      {
+        "type": "Water",
+        "color": "#6890f0"
+      }
+    ]
+  },
+  "817":{
+    "name":"Drizzile",
+    "types":[
+      {
+        "type": "Water",
+        "color": "#6890f0"
+      }
+    ]
+  },
+  "818":{
+    "name":"Inteleon",
+    "types":[
+      {
+        "type": "Water",
+        "color": "#6890f0"
+      }
+    ]
+  },
+  "819":{
+    "name":"Skwovet",
+    "types":[
+      {
+        "type": "Normal",
+        "color": "#8a8a59"
+      }
+    ]
+  },
+  "820":{
+    "name":"Greedent",
+    "types":[
+      {
+        "type": "Normal",
+        "color": "#8a8a59"
+      }
+    ]
+  },
+  "821":{
+    "name":"Rookidee",
+    "types":[
+      {
+        "type": "Flying",
+        "color": "#a890f0"
+      }
+    ]
+  },
+  "822":{
+    "name":"Corvisquire",
+    "types":[
+      {
+        "type": "Flying",
+        "color": "#a890f0"
+      }
+    ]
+  },
+  "823":{
+    "name":"Corviknight",
+    "types":[
+      {
+        "type": "Flying",
+        "color": "#a890f0"
+      },
+      {
+        "type": "Steel",
+        "color": "#b8b8d0"
+      }
+    ]
+  },
+  "824":{
+    "name":"Blipbug",
+    "types":[
+      {
+        "type": "Bug",
+        "color": "#a8b820"
+      }
+    ]
+  },
+  "825":{
+    "name":"Dottler",
+    "types":[
+      {
+        "type": "Bug",
+        "color": "#a8b820"
+      },
+      {
+        "type": "Psychic",
+        "color": "#f85888"
+      }
+    ]
+  },
+  "826":{
+    "name":"Orbeetle",
+    "types":[
+      {
+        "type": "Bug",
+        "color": "#a8b820"
+      },
+      {
+        "type": "Psychic",
+        "color": "#f85888"
+      }
+    ]
+  },
+  "827":{
+    "name":"Nickit",
+    "types":[
+          {
+            "type": "Dark",
+            "color": "#b8b8d0"
+          }
+    ]
+  },
+  "828":{
+    "name":"Thievul",
+    "types":[
+          {
+            "type": "Dark",
+            "color": "#b8b8d0"
+          }
+    ]
+  },
+  "829":{
+    "name":"Gossifleur",
+    "types":[
+      {
+        "type": "Grass",
+        "color": "#78c850"
+      }
+    ]
+  },
+  "830":{
+    "name":"Eldegoss",
+    "types":[
+      {
+        "type": "Grass",
+        "color": "#78c850"
+      }
+    ]
+  },
+  "831":{
+    "name":"Wooloo",
+    "types":[
+      {
+        "type": "Normal",
+        "color": "#8a8a59"
+      }
+    ]
+  },
+  "832":{
+    "name":"Dubwool",
+    "types":[
+      {
+        "type": "Normal",
+        "color": "#8a8a59"
+      }
+    ]
+  },
+  "833":{
+    "name":"Chewtle",
+    "types":[
+      {
+        "type": "Water",
+        "color": "#6890f0"
+      }
+    ]
+  },
+  "834":{
+    "name":"Drednaw",
+    "types":[
+      {
+        "type": "Water",
+        "color": "#6890f0"
+      },
+      {
+        "type": "Rock",
+        "color": "#b8a038"
+      }
+    ]
+  },
+  "835":{
+    "name":"Yamper",
+    "types":[
+      {
+        "type": "Electric",
+        "color": "#f8d030"
+      }
+    ]
+  },
+  "836":{
+    "name":"Boltund",
+    "types":[
+      {
+        "type": "Electric",
+        "color": "#f8d030"
+      }
+    ]
+  },
+  "837":{
+    "name":"Rolycoly",
+    "types":[
+      {
+        "type": "Rock",
+        "color": "#b8a038"
+      }
+    ]
+  },
+  "838":{
+    "name":"Carkol",
+    "types":[
+      {
+        "type": "Rock",
+        "color": "#b8a038"
+      },
+      {
+        "type": "Fire",
+        "color": "#f08030"
+      }
+    ]
+  },
+  "839":{
+    "name":"Coalossal",
+    "types":[
+      {
+        "type": "Rock",
+        "color": "#b8a038"
+      },
+      {
+        "type": "Fire",
+        "color": "#f08030"
+      }
+    ]
+  },
+  "840":{
+    "name":"Applin",
+    "types":[
+      {
+        "type": "Grass",
+        "color": "#78c850"
+      },
+      {
+        "type": "Dragon",
+        "color": "#7038f8"
+      }
+    ]
+  },
+  "841":{
+    "name":"Flapple",
+    "types":[
+      {
+        "type": "Grass",
+        "color": "#78c850"
+      },
+      {
+        "type": "Dragon",
+        "color": "#7038f8"
+      }
+    ]
+  },
+  "842":{
+    "name":"Appletun",
+    "types":[
+      {
+        "type": "Grass",
+        "color": "#78c850"
+      },
+      {
+        "type": "Dragon",
+        "color": "#7038f8"
+      }
+    ]
+  },
+  "843":{
+    "name":"Silicobra",
+    "types":[
+      {
+        "type": "Ground",
+        "color": "#e0c068"
+      }
+    ]
+  },
+  "844":{
+    "name":"Sandaconda",
+    "types":[
+      {
+        "type": "Ground",
+        "color": "#e0c068"
+      }
+    ]
+  },
+  "845":{
+    "name":"Cramorant",
+    "types":[
+      {
+        "type": "Flying",
+        "color": "#a890f0"
+      },
+      {
+        "type": "Water",
+        "color": "#6890f0"
+      }
+    ]
+  },
+  "846":{
+    "name":"Arrokuda",
+    "types":[
+      {
+        "type": "Water",
+        "color": "#6890f0"
+      }
+    ]
+  },
+  "847":{
+    "name":"Barraskewda",
+    "types":[
+      {
+        "type": "Water",
+        "color": "#6890f0"
+      }
+    ]
+  },
+  "848":{
+    "name":"Toxel",
+    "types":[
+      {
+        "type": "Electric",
+        "color": "#f8d030"
+      },
+      {
+        "type": "Poison",
+        "color": "#a040a0"
+      }
+    ]
+  },
+  "849":{
+    "name":"Toxtricity",
+    "types":[
+      {
+        "type": "Electric",
+        "color": "#f8d030"
+      },
+      {
+        "type": "Poison",
+        "color": "#a040a0"
+      }
+    ]
+  },
+  "850":{
+    "name":"Sizzlipede",
+    "types":[
+      {
+        "type": "Fire",
+        "color": "#f08030"
+      },
+      {
+        "type": "Bug",
+        "color": "#a8b820"
+      }
+    ]
+  },
+  "851":{
+    "name":"Centiskorch",
+    "types":[
+      {
+        "type": "Fire",
+        "color": "#f08030"
+      },
+      {
+        "type": "Bug",
+        "color": "#a8b820"
+      }
+    ]
+  },
+  "852":{
+    "name":"Clobbopus",
+    "types":[
+      {
+        "type": "Fighting",
+        "color": "#b8b8d0"
+      }
+    ]
+  },
+  "853":{
+    "name":"Grapploct",
+    "types":[
+      {
+        "type": "Fighting",
+        "color": "#b8b8d0"
+      }
+    ]
+  },
+  "854":{
+    "name":"Sinistea",
+    "types":[
+      {
+        "type": "Ghost",
+        "color": "#705898"
+      }
+    ]
+  },
+  "855":{
+    "name":"Polteageist",
+    "types":[
+      {
+        "type": "Ghost",
+        "color": "#705898"
+      }
+    ]
+  },
+  "856":{
+    "name":"Hatenna",
+    "types":[
+      {
+        "type": "Psychic",
+        "color": "#f85888"
+      }
+    ]
+  },
+  "857":{
+    "name":"Hattrem",
+    "types":[
+      {
+        "type": "Psychic",
+        "color": "#f85888"
+      }
+    ]
+  },
+  "858":{
+    "name":"Hatterene",
+    "types":[
+      {
+        "type": "Psychic",
+        "color": "#f85888"
+      },
+      {
+        "type": "Fairy",
+        "color": "#e898e8"
+      }
+    ]
+  },
+  "859":{
+    "name":"Impidimp",
+    "types":[
+      {
+        "type": "Dark",
+        "color": "#b8b8d0"
+      },
+      {
+        "type": "Fairy",
+        "color": "#e898e8"
+      }
+    ]
+  },
+  "860":{
+    "name":"Morgrem",
+    "types":[
+      {
+        "type": "Dark",
+        "color": "#b8b8d0"
+      },
+      {
+        "type": "Fairy",
+        "color": "#e898e8"
+      }
+    ]
+  },
+  "861":{
+    "name":"Grimmsnarl",
+    "types":[
+      {
+        "type": "Dark",
+        "color": "#b8b8d0"
+      },
+      {
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ]
   },
@@ -42475,7 +37346,7 @@
       }
     ]
   },
-  "862": {
+  "863": {
     "name": "Perrserker",
     "types": [
       {
@@ -42513,6 +37384,15 @@
             "color": "#b8b8d0"
           }
         ]
+      }
+    ]
+  },
+  "864":{
+    "name":"Cursola",
+    "types":[
+      {
+        "type": "Ghost",
+        "color": "#705898"
       }
     ]
   },
@@ -42554,6 +37434,335 @@
             "color": "#b8b8d0"
           }
         ]
+      }
+    ]
+  },
+  "866":{
+    "name":"Mr. Rime",
+    "types":[
+      {
+        "type": "Ice",
+        "color": "#98d8d8"
+      },
+      {
+        "type": "Psychic",
+        "color": "#f85888"
+      }
+    ]
+  },
+  "867":{
+    "name":"Runerigus",
+    "types":[
+      {
+        "type": "Ground",
+        "color": "#e0c068"
+      },
+      {
+        "type": "Ghost",
+        "color": "#705898"
+      }
+    ],
+    "forms": [
+      {
+        "nameform": "Normal",
+        "protoform": "2516",
+        "formtypes": [
+          {
+            "type": "Ground",
+            "color": "#e0c068"
+          },
+          {
+            "type": "Ghost",
+            "color": "#705898"
+          }
+        ]
+      },
+      {
+        "nameform": "Shadow",
+        "protoform": "2517",
+        "formtypes": [
+          {
+            "type": "Ground",
+            "color": "#e0c068"
+          },
+          {
+            "type": "Ghost",
+            "color": "#705898"
+          }
+        ]
+      },
+      {
+        "nameform": "Purified",
+        "protoform": "2518",
+        "formtypes": [
+          {
+            "type": "Ground",
+            "color": "#e0c068"
+          },
+          {
+            "type": "Ghost",
+            "color": "#705898"
+          }
+        ]
+      }
+    ]
+  },
+  "868":{
+    "name":"Milcery",
+    "types":[
+      {
+        "type": "Fairy",
+        "color": "#e898e8"
+      }
+    ]
+  },
+  "869":{
+    "name":"Alcremie",
+    "types":[
+      {
+        "type": "Fairy",
+        "color": "#e898e8"
+      }
+    ]
+  },
+  "870":{
+    "name":"Falinks",
+    "types":[
+      {
+        "type": "Fighting",
+        "color": "#b8b8d0"
+      }
+    ]
+  },
+  "871":{
+    "name":"Pincurchin",
+    "types":[
+      {
+        "type": "Electric",
+        "color": "#f8d030"
+      }
+    ]
+  },
+  "872":{
+    "name":"Snom",
+    "types":[
+      {
+        "type": "Ice",
+        "color": "#98d8d8"
+      },
+      {
+        "type": "Bug",
+        "color": "#a8b820"
+      }
+    ]
+  },
+  "873":{
+    "name":"Frosmoth",
+    "types":[
+      {
+        "type": "Ice",
+        "color": "#98d8d8"
+      },
+      {
+        "type": "Bug",
+        "color": "#a8b820"
+      }
+    ]
+  },
+  "874":{
+    "name":"Stonjourner",
+    "types":[
+      {
+        "type": "Rock",
+        "color": "#b8a038"
+      }
+    ]
+  },
+  "875":{
+    "name":"Eiscue",
+    "types":[
+      {
+        "type": "Ice",
+        "color": "#98d8d8"
+      }
+    ]
+  },
+  "876":{
+    "name":"Indeedee",
+    "types":[
+      {
+        "type": "Psychic",
+        "color": "#f85888"
+      },
+      {
+        "type": "Normal",
+        "color": "#8a8a59"
+      }
+    ]
+  },
+  "877":{
+    "name":"Morpeko",
+    "types":[
+      {
+        "type": "Electric",
+        "color": "#f8d030"
+      },
+      {
+        "type": "Dark",
+        "color": "#b8b8d0"
+      }
+    ]
+  },
+  "878":{
+    "name":"Cufant",
+    "types":[
+      {
+        "type": "Steel",
+        "color": "#b8b8d0"
+      }
+    ]
+  },
+  "879":{
+    "name":"Copperajah",
+    "types":[
+      {
+        "type": "Steel",
+        "color": "#b8b8d0"
+      }
+    ]
+  },
+  "880":{
+    "name":"Dracozolt",
+    "types":[
+      {
+        "type": "Electric",
+        "color": "#f8d030"
+      },
+      {
+        "type": "Dragon",
+        "color": "#7038f8"
+      }
+    ]
+  },
+  "881":{
+    "name":"Arctozolt",
+    "types":[
+      {
+        "type": "Electric",
+        "color": "#f8d030"
+      },
+      {
+        "type": "Ice",
+        "color": "#98d8d8"
+      }
+    ]
+  },
+  "882":{
+    "name":"Dracovish",
+    "types":[
+      {
+        "type": "Water",
+        "color": "#6890f0"
+      },
+      {
+        "type": "Dragon",
+        "color": "#7038f8"
+      }
+    ]
+  },
+  "883":{
+    "name":"Arctovish",
+    "types":[
+      {
+        "type": "Water",
+        "color": "#6890f0"
+      },
+      {
+        "type": "Ice",
+        "color": "#98d8d8"
+      }
+    ]
+  },
+  "884":{
+    "name":"Duraludon",
+    "types":[
+      {
+        "type": "Steel",
+        "color": "#b8b8d0"
+      },
+      {
+        "type": "Dragon",
+        "color": "#7038f8"
+      }
+    ]
+  },
+  "885":{
+    "name":"Dreepy",
+    "types":[
+      {
+        "type": "Dragon",
+        "color": "#7038f8"
+      },
+      {
+        "type": "Ghost",
+        "color": "#705898"
+      }
+    ]
+  },
+  "886":{
+    "name":"Drakloak",
+    "types":[
+      {
+        "type": "Dragon",
+        "color": "#7038f8"
+      },
+      {
+        "type": "Ghost",
+        "color": "#705898"
+      }
+    ]
+  },
+  "887":{
+    "name":"Dragapult",
+    "types":[
+      {
+        "type": "Dragon",
+        "color": "#7038f8"
+      },
+      {
+        "type": "Ghost",
+        "color": "#705898"
+      }
+    ]
+  },
+  "888":{
+    "name":"Zacian",
+    "types":[
+      {
+        "type": "Fairy",
+        "color": "#e898e8"
+      }
+    ]
+  },
+  "889":{
+    "name":"Zamazenta",
+    "types":[
+      {
+        "type": "Fighting",
+        "color": "#b8b8d0"
+      }
+    ]
+  },
+  "890":{
+    "name":"Eternatus",
+    "types":[
+      {
+        "type": "Poison",
+        "color": "#a040a0"
+      },
+      {
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ]
   }


### PR DESCRIPTION
When authenticating through FB for the first time Access level was being set to 'null' due to access_level being set twice in the insert statement.