### PR TITLE
Main docker file linked to dev branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 
 FROM thecodingmachine/php:7.4-v3-apache-node10
 
-RUN git clone -b develop https://github.com/pmsf/PMSF.git .
+RUN git clone -b main https://github.com/pmsf/PMSF.git .
 RUN composer install
 RUN npm install
 RUN npm audit fix


### PR DESCRIPTION
When trying to make a container it's using node10 for the dev branch.
Now it will use node10 with the main branch.
When you download the docker file from de dev branch it will use node12.