### PR TITLE
fix iconsArray’s keys not updating

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -255,7 +255,7 @@ if (copyrightSafe) {
     var setPokemon = Store.get('iconsArray')
     setPokemon.pokemon = 'static/sprites/'
     Store.set('iconsArray', setPokemon)
-} else if (Object.prototype.toString.call(Store.get('iconsArray')) === '[object String]' || Store.get('iconsArray') === '') {
+} else {
     for (const [key, value] of Object.entries(iconFolderArray)) {
         if (Object.prototype.toString.call(value) === '[object Object]') {
             iconFolderArray[key] = iconFolderArray[key][Object.keys(iconFolderArray[key])[0]]


### PR DESCRIPTION
**Issue?**
The background image of nests representing the nest type is broken despite having a valid `nest` key in `config.php` -> `$iconFolderArray`. It could also have other issues down the line.
![image](https://user-images.githubusercontent.com/46268060/142909590-ffb5c697-b244-4349-b7ce-059452623de3.png)


**Who is affected?**
Anyone running main, staging or develop will experience this issue once they move past #556 which adds the `nest` key to `$iconFolderArray` (config.php).

**Why?**
Only the values of existing keys of `iconsArray` are updating but not the keys themselves after you add, rename or delete a key in `$iconFolderArray` and reload the page.

**About the fix!**
In all current branches, `iconsArray` is an `Object Object`.

Logic wise, removing the `Object String` condition could cause an issue with older pmsf that haven’t upgraded in a while which means you’d need to have `Object String`, `Object Object` and Empty as the condition and those seem to be the _ONLY_ possible types/values of that variable. Performance wise, it only executes once when the page loads and it’s a fast in-memory process with just a few values. Considering this, dropping the else conditions entirely makes more sense and will cause the variable to always be fully refreshed when the map is loaded which should have negligible impact if any.

**Useful console commands to quickly debug:**
`Store.get('iconsArray')` to see its value.

Quick `nest` key removal:
```
myTempVar = Store.get('iconsArray')
delete myTempVar.nest
delete myTempVar.nestIndex
Store.set('iconsArray', myTempVar)
```