### PR TITLE
hide fullStats's section if `$noFullStats = true`

### DIFF
--- a/pre-index.php
+++ b/pre-index.php
@@ -1368,6 +1368,7 @@ if (strtolower($map) === "rdm") {
     </div>
     <div class="offcanvas offcanvas-end" data-bs-scroll="true" data-bs-backdrop="true" tabindex="-1" id="rightNav" aria-labelledby="rightNavLabel">
         <div class="offcanvas-body right">
+            <?php if (! $noFullStats ) { ?>
             <div class="card">
                 <div class="card-header">
                     <?php echo i8ln('Full Stats') ?>
@@ -1380,6 +1381,7 @@ if (strtolower($map) === "rdm") {
                     </div>
                 </div>
             </div>
+            <?php } ?>
             <div class="card" id="loadingSpinner">
                 <div class="card-header">
                     <?php echo i8ln('Loading...') ?>


### PR DESCRIPTION
no reason to display a section with a button that does nothing besides cause a console errors if pressed when the functionality is disabled.

that was the reason I was receiving the below error: it was displaying the functionality on the map while it was disabled in my access-config! (ie confusing for users)
![image](https://user-images.githubusercontent.com/46268060/143061130-606afacb-3fab-49c5-8e5a-d3621455dd1f.png)
