### PR TITLE
FullStats - Rewards: Misc Adds/Fixes.

### DIFF
--- a/lib/stats/Stats.rdm.php
+++ b/lib/stats/Stats.rdm.php
@@ -165,9 +165,9 @@ class RDM extends Stats
       $data = array();
       foreach ($mons as $mon) {
         $pokemon["name"] = i8ln($this->data[$mon['pokemon_id']]["name"]);
-        $pokemon["pokemon_id"] = $mon["pokemon_id"];
-        $pokemon["form"] = $mon["form"];
-        $pokemon["costume"] = $mon["costume"];
+        $pokemon["pokemon_id"] = intval($mon["pokemon_id"]);
+        $pokemon["form"] = intval($mon["form"]);
+        $pokemon["costume"] = intval($mon["costume"]);
         $pokemon["count"] = $mon["count"];
         $pokemon["percentage"] = round(100 / $total["total"] * $mon["count"], 3) . '%';
         if (isset($mon["form"]) && $mon["form"] > 0) {
@@ -220,12 +220,12 @@ class RDM extends Stats
 
       $data = array();
       foreach ($rewards as $reward) {
-        $questReward["quest_pokemon_id"] = $reward["quest_pokemon_id"];
-        $questReward["quest_energy_pokemon_id"] = $reward["quest_energy_pokemon_id"];
-        $questReward["quest_pokemon_form"] = $reward["quest_pokemon_form"];
-        $questReward["quest_pokemon_costume"] = $reward["quest_pokemon_costume"];
-        $questReward["quest_item_id"] = $reward["quest_item_id"];
-        $questReward["quest_reward_amount"] = $reward["quest_reward_amount"];
+        $questReward["quest_pokemon_id"] = intval($reward["quest_pokemon_id"]);
+        $questReward["quest_energy_pokemon_id"] = intval($reward["quest_energy_pokemon_id"]);
+        $questReward["quest_pokemon_form"] = intval($reward["quest_pokemon_form"]);
+        $questReward["quest_pokemon_costume"] = intval($reward["quest_pokemon_costume"]);
+        $questReward["quest_item_id"] = intval($reward["quest_item_id"]);
+        $questReward["quest_reward_amount"] = intval($reward["quest_reward_amount"]);
         $questReward["quest_reward_type"] = intval($reward["quest_reward_type"]);
         $questReward["count"] = $reward["count"];
         $questReward["percentage"] = round(100 / $total["total"] * $reward["count"], 3) . '%';
@@ -269,9 +269,9 @@ class RDM extends Stats
       foreach ($shinys as $shiny) {
         $pokemon["name"] = i8ln($this->data[$shiny['pokemon_id']]["name"]);
         $pokemon["shiny_count"] = $shiny["shiny_count"];
-        $pokemon["pokemon_id"] = $shiny["pokemon_id"];
-        $pokemon["form"] = $shiny["form"];
-        $pokemon["costume"] = $shiny["costume"];
+        $pokemon["pokemon_id"] = intval($shiny["pokemon_id"]);
+        $pokemon["form"] = intval($shiny["form"]);
+        $pokemon["costume"] = intval($shiny["costume"]);
         $pokemon["rate"] = '1/' . round($shiny["sample_size"] / $shiny['shiny_count']);
         $pokemon["percentage"] = round(100 / $shiny["sample_size"] * $shiny["shiny_count"], 3) . '%';
         $pokemon["sample_size"] = $shiny['sample_size'];

--- a/lib/stats/Stats.rdm.php
+++ b/lib/stats/Stats.rdm.php
@@ -209,11 +209,12 @@ class RDM extends Stats
           quest_pokemon_id,
           json_extract(json_extract(`quest_rewards`,'$[*].info.pokemon_id'),'$[0]') AS quest_energy_pokemon_id,
           json_extract(json_extract(`quest_rewards`,'$[*].info.form_id'),'$[0]') AS quest_pokemon_form,
+          json_extract(json_extract(`quest_rewards`,'$[*].info.costume_id'),'$[0]') AS quest_pokemon_costume,
           json_extract(json_extract(`quest_rewards`,'$[*].info.amount'),'$[0]') AS quest_reward_amount,
           quest_reward_type
         FROM pokestop
         WHERE quest_reward_type IS NOT NULL $geofenceSQL
-        GROUP BY quest_reward_type, quest_item_id, quest_reward_amount, quest_pokemon_id, quest_pokemon_form"
+        GROUP BY quest_reward_type, quest_item_id, quest_reward_amount, quest_pokemon_id, quest_pokemon_form, quest_pokemon_costume"
       );
       $total = $db->query("SELECT COUNT(*) AS total FROM pokestop WHERE quest_reward_type IS NOT NULL $geofenceSQL")->fetch();
 
@@ -222,6 +223,7 @@ class RDM extends Stats
         $questReward["quest_pokemon_id"] = $reward["quest_pokemon_id"];
         $questReward["quest_energy_pokemon_id"] = $reward["quest_energy_pokemon_id"];
         $questReward["quest_pokemon_form"] = $reward["quest_pokemon_form"];
+        $questReward["quest_pokemon_costume"] = $reward["quest_pokemon_costume"];
         $questReward["quest_item_id"] = $reward["quest_item_id"];
         $questReward["quest_reward_amount"] = $reward["quest_reward_amount"];
         $questReward["quest_reward_type"] = intval($reward["quest_reward_type"]);

--- a/lib/stats/Stats.rocketmap_mad.php
+++ b/lib/stats/Stats.rocketmap_mad.php
@@ -209,13 +209,14 @@ class RocketMap_MAD extends Stats
           tq.quest_pokemon_id, 
           tq.quest_pokemon_id AS quest_energy_pokemon_id,
           tq.quest_pokemon_form_id AS quest_pokemon_form,
+          tq.quest_pokemon_costume_id AS quest_pokemon_costume,
           tq.quest_item_amount AS quest_item_amount,
           tq.quest_stardust AS quest_dust_amount,
           tq.quest_reward_type AS quest_reward_type
         FROM trs_quest tq
         LEFT JOIN pokestop p ON p.pokestop_id = tq.GUID
         WHERE tq.quest_timestamp >= UNIX_TIMESTAMP(CURDATE()) $geofenceSQL
-        GROUP BY tq.quest_reward_type, tq.quest_item_id, tq.quest_stardust, tq.quest_item_amount, tq.quest_pokemon_id, tq.quest_pokemon_form_id"
+        GROUP BY tq.quest_reward_type, tq.quest_item_id, tq.quest_stardust, tq.quest_item_amount, tq.quest_pokemon_id, tq.quest_pokemon_form_id, tq.quest_pokemon_costume_id"
       );
 
       $total = $db->query("
@@ -229,7 +230,9 @@ class RocketMap_MAD extends Stats
       $data = array();
       foreach ($rewards as $reward) {
         $questReward["quest_pokemon_id"] = $reward["quest_pokemon_id"];
+        $questReward["quest_energy_pokemon_id"] = $reward["quest_energy_pokemon_id"];
         $questReward["quest_pokemon_form"] = $reward["quest_pokemon_form"];
+        $questReward["quest_pokemon_costume"] = $reward["quest_pokemon_costume"];
         $questReward["quest_item_id"] = $reward["quest_item_id"];
         $questReward["count"] = $reward["count"];
         $questReward["percentage"] = round(100 / $total["total"] * $reward["count"], 3) . '%';
@@ -237,7 +240,7 @@ class RocketMap_MAD extends Stats
         
         if ($reward["quest_reward_type"] == 12) {
           $questReward["name"] = i8ln($this->data[$reward['quest_energy_pokemon_id']]["name"]);
-          $questReward["quest_reward_amount"] = null;
+          $questReward["quest_reward_amount"] = $reward["quest_item_amount"];
         } elseif ($reward["quest_reward_type"] == 7) {
           $questReward["name"] = i8ln($this->data[$reward['quest_pokemon_id']]["name"]);
           $questReward["quest_reward_amount"] = null;

--- a/lib/stats/Stats.rocketmap_mad.php
+++ b/lib/stats/Stats.rocketmap_mad.php
@@ -165,9 +165,9 @@ class RocketMap_MAD extends Stats
       $data = array();
       foreach ($mons as $mon) {
         $pokemon["name"] = i8ln($this->data[$mon['pokemon_id']]["name"]);
-        $pokemon["pokemon_id"] = $mon["pokemon_id"];
-        $pokemon["form"] = $mon["form"];
-        $pokemon["costume"] = $mon["costume"];
+        $pokemon["pokemon_id"] = intval($mon["pokemon_id"]);
+        $pokemon["form"] = intval($mon["form"]);
+        $pokemon["costume"] = intval($mon["costume"]);
         $pokemon["count"] = $mon["count"];
         $pokemon["percentage"] = round(100 / $total["total"] * $mon["count"], 3) . '%';
         if (isset($mon["form"]) && $mon["form"] > 0) {
@@ -229,12 +229,12 @@ class RocketMap_MAD extends Stats
 
       $data = array();
       foreach ($rewards as $reward) {
-        $questReward["quest_pokemon_id"] = $reward["quest_pokemon_id"];
-        $questReward["quest_energy_pokemon_id"] = $reward["quest_energy_pokemon_id"];
-        $questReward["quest_pokemon_form"] = $reward["quest_pokemon_form"];
-        $questReward["quest_pokemon_costume"] = $reward["quest_pokemon_costume"];
-        $questReward["quest_item_id"] = $reward["quest_item_id"];
-        $questReward["count"] = $reward["count"];
+        $questReward["quest_pokemon_id"] = intval($reward["quest_pokemon_id"]);
+        $questReward["quest_energy_pokemon_id"] = intval($reward["quest_energy_pokemon_id"]);
+        $questReward["quest_pokemon_form"] = intval($reward["quest_pokemon_form"]);
+        $questReward["quest_pokemon_costume"] = intval($reward["quest_pokemon_costume"]);
+        $questReward["quest_item_id"] = intval($reward["quest_item_id"]);
+        $questReward["count"] = reward["count"];
         $questReward["percentage"] = round(100 / $total["total"] * $reward["count"], 3) . '%';
         $questReward["quest_reward_type"] = intval($reward["quest_reward_type"]);
         
@@ -287,9 +287,9 @@ class RocketMap_MAD extends Stats
       foreach ($shinys as $shiny) {
         $pokemon["name"] = i8ln($this->data[$shiny['pokemon_id']]["name"]);
         $pokemon["shiny_count"] = $shiny["shiny_count"];
-        $pokemon["pokemon_id"] = $shiny["pokemon_id"];
-        $pokemon["form"] = $shiny["form"];
-        $pokemon["costume"] = $shiny["costume"];
+        $pokemon["pokemon_id"] = intval($shiny["pokemon_id"]);
+        $pokemon["form"] = intval($shiny["form"]);
+        $pokemon["costume"] = intval($shiny["costume"]);
         $pokemon["rate"] = '1/' . round($shiny["sample_size"] / $shiny['shiny_count']);
         $pokemon["percentage"] = round(100 / $shiny["sample_size"] * $shiny["shiny_count"], 3) . '%';
         $pokemon["sample_size"] = $shiny['sample_size'];

--- a/lib/stats/Stats.rocketmap_mad.php
+++ b/lib/stats/Stats.rocketmap_mad.php
@@ -234,7 +234,7 @@ class RocketMap_MAD extends Stats
         $questReward["quest_pokemon_form"] = intval($reward["quest_pokemon_form"]);
         $questReward["quest_pokemon_costume"] = intval($reward["quest_pokemon_costume"]);
         $questReward["quest_item_id"] = intval($reward["quest_item_id"]);
-        $questReward["count"] = reward["count"];
+        $questReward["count"] = $reward["count"];
         $questReward["percentage"] = round(100 / $total["total"] * $reward["count"], 3) . '%';
         $questReward["quest_reward_type"] = intval($reward["quest_reward_type"]);
         

--- a/static/js/stats.js
+++ b/static/js/stats.js
@@ -380,7 +380,7 @@ function processRewardStats(i, item) { // eslint-disable-line no-unused-vars
             type = i8ln('Item')
             break
         case 3:
-            reward = '<img src="' + getIcon(iconpath.reward, 'reward/stardust', '.png', item['quest_dust_amount']) + '" style="width:40px;">' +
+            reward = '<img src="' + getIcon(iconpath.reward, 'reward/stardust', '.png', item['quest_reward_amount']) + '" style="width:40px;">' +
             hiddenName
             type = i8ln('Stardust')
             break
@@ -390,12 +390,12 @@ function processRewardStats(i, item) { // eslint-disable-line no-unused-vars
             type = i8ln('Candy')
             break
         case 7:
-            reward = '<img src="' + getIcon(iconpath.pokemon, 'pokemon', '.png', item['quest_pokemon_id'], 0, item['quest_pokemon_form']) + '" style="width:40px;">' +
+            reward = '<img src="' + getIcon(iconpath.pokemon, 'pokemon', '.png', item['quest_pokemon_id'], 0, item['quest_pokemon_form'], item['quest_pokemon_costume']) + '" style="width:40px;">' +
             hiddenName
             type = i8ln('Pokémon')
             break
         case 12:
-            reward = '<img src="' + getIcon(iconpath.reward, 'reward/mega_resource', '.png', item['quest_energy_pokemon_id']) + '" style="width:40px;">' +
+            reward = '<img src="' + getIcon(iconpath.reward, 'reward/mega_resource', '.png', item['quest_energy_pokemon_id'], item['quest_reward_amount']) + '" style="width:40px;">' +
             hiddenName
             type = i8ln('Mega Energy')
             break


### PR DESCRIPTION
MAD+RDM: Add costumes to images to be able to differentiate on days where you have both with and without a costume like current Squirtle or different costumes of the same mon. **RDM IS UNTESTED** but it’s a copy/paste from RDM's `query_stops()` to get the value so it should be fine.

MAD+RDM: fix `stardust icon: undefined.png` in console with enableJSDebug enabled. Both MAD and RDM are returning the value in the key `quest_reward_amount` while JavaScript was attempting to use the key `quest_dust_amount`. Both now should display the amounts correctly.

MAD: fix `mega_resource icon: undefined.png` in console with enableJSDebug enabled. MAD wasn't returning the value of `quest_energy_pokemon_id` downstream. Also return the amount to match RDM even through it’s currently unused by getIcon() nor am I aware of a repo with amount on the mega images.