### PR TITLE
fix style selections not sticking after #573

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -255,6 +255,18 @@ if (copyrightSafe) {
     var setPokemon = Store.get('iconsArray')
     setPokemon.pokemon = 'static/sprites/'
     Store.set('iconsArray', setPokemon)
+} else if (localStorage.getItem('iconsArray') !== null) {
+    var oldIconsArray = Store.get('iconsArray')
+    for (const [key, value] of Object.entries(iconFolderArray)) {
+        if (key in oldIconsArray === false) {
+            if (Object.prototype.toString.call(value) === '[object Object]') {
+                oldIconsArray[key] = iconFolderArray[key][Object.keys(iconFolderArray[key])[0]]
+            } else {
+                oldIconsArray[key] = iconFolderArray[key]
+            }
+        }
+    }
+    Store.set('iconsArray', oldIconsArray)
 } else {
     for (const [key, value] of Object.entries(iconFolderArray)) {
         if (Object.prototype.toString.call(value) === '[object Object]') {


### PR DESCRIPTION
While #573 solved the issue of not adding new keys like `nest` that were causing errors, it also caused the styles to be reset to the default value every time the page was loaded.

A condition is added to check for the existence of `iconsArray` in LocalStorage. When it exists (returning user), we only add missing keys to it leaving the rest untouched otherwise we proceed like before fully refreshing `iconsArray`.