### PR TITLE
add compatibility for rdm multiple invasions

### DIFF
--- a/lib/RDM.php
+++ b/lib/RDM.php
@@ -538,6 +538,11 @@ class RDM extends Scanner
     public function query_stops($conds, $params)
     {
         global $db;
+        $db_version = $db->get('metadata',['value'],['key'=>'DB_VERSION']);
+        $rdmgrunts = "";
+        if (intval($db_version['value']) >= 81) {
+            $rdmgrunts = " LEFT JOIN (SELECT * FROM (SELECT `pokestop_id` AS pokestop_id_incident, `character` AS grunt_type, `expiration` AS incident_expire_timestamp FROM incident WHERE `expiration` > UNIX_TIMESTAMP() ORDER BY `character`) AS i_sorted GROUP BY i_sorted.`pokestop_id_incident`) AS i ON i.`pokestop_id_incident` = p.`id` ";
+        }
 
         $query = "SELECT id AS pokestop_id,
         lat AS latitude,
@@ -564,7 +569,8 @@ class RDM extends Scanner
         json_extract(json_extract(`quest_rewards`,'$[*].info.costume_id'),'$[0]') AS reward_pokemon_costumeid,
         json_extract(json_extract(`quest_rewards`,'$[*].info.gender_id'),'$[0]') AS reward_pokemon_genderid,
         json_extract(json_extract(`quest_rewards`,'$[*].info.shiny'),'$[0]') AS reward_pokemon_shiny
-        FROM pokestop
+        FROM pokestop p
+        $rdmgrunts
         WHERE :conditions";
 
         $query = str_replace(":conditions", join(" AND ", $conds), $query);
@@ -970,7 +976,12 @@ class RDM extends Scanner
                 $data[] = $pokestop['reward_item_id'];
             }
         } elseif ($type === 'gruntlist') {
-            $pokestops = $db->query("SELECT distinct grunt_type FROM pokestop WHERE grunt_type > 0 AND incident_expire_timestamp > UNIX_TIMESTAMP() order by grunt_type;")->fetchAll(\PDO::FETCH_ASSOC);
+            $db_version = $db->get('metadata',['value'],['key'=>'DB_VERSION']);
+            if (intval($db_version['value']) >= 81) {
+                $pokestops = $db->query("SELECT distinct `character` AS grunt_type FROM incident WHERE `expiration` > UNIX_TIMESTAMP() ORDER BY `character`;")->fetchAll(\PDO::FETCH_ASSOC);
+            } else {
+                $pokestops = $db->query("SELECT distinct grunt_type FROM pokestop WHERE grunt_type > 0 AND incident_expire_timestamp > UNIX_TIMESTAMP() order by grunt_type;")->fetchAll(\PDO::FETCH_ASSOC);
+			}
             $data = array();
             foreach ($pokestops as $pokestop) {
                 $data[] = $pokestop['grunt_type'];


### PR DESCRIPTION
**INFO:**
A single Pokestop can have more than 1 invasion active at the same time (usually Giovanni and a Team Leader).

**ISSUE:**
development branch of rdm recently added multiple invasions support changing the database structure which broke PMSF's ability to query stops properly for anything.

Details: https://github.com/RealDeviceMap/RealDeviceMap/pull/326

**CHANGE:**
Query the RDM database first to get the `DB_VERSION` which allows the rest of the queries to use the correct tables and columns so that PMSF remains compatible with both master and development branch of rdm.

**NOTES:**
- PMSF cannot display both Invasions without a major PokestopMarker rework which is outside the scope of this PR. Instead, While imperfect, PMSF will display the LOWEST grunt_id to give priority to everything else before displaying Giovanni (ie, some Team Leader may be hiding a Giovanni if you have a completed Rocket Radar).
- MariaDB (and others) often ignore a direct ORDER BY in a FROM subquery and I don't want the query to randomly pick one of the multiple invasions when the map refreshed. `SELECT * FROM (SELECT .. ORDER BY) GROUP BY` is used to workaround that limitation.