### PR TITLE
rdm: switch from availble_slots to available_slots (gym table)

### DIFF
--- a/lib/RDM.php
+++ b/lib/RDM.php
@@ -711,7 +711,7 @@ class RDM extends Scanner
         raid_battle_timestamp AS raid_start,
         updated AS last_scanned,
         raid_pokemon_id,
-        availble_slots AS slots_available,
+        available_slots AS slots_available,
         team_id,
         raid_level,
         raid_pokemon_move_1,


### PR DESCRIPTION
- available_slots has been added to rdm master in December 2021.
- availble_slots is being removed from rdm-dev in June 2022.