### PR TITLE
better incident query, add columnExists and availble_slots compatibility

### DIFF
--- a/lib/Scanner.php
+++ b/lib/Scanner.php
@@ -20,6 +20,20 @@ class Scanner
     public $moves = [];
 
     /**
+     * columnExists()
+     * Used for backward compatibility (backend agnostic)
+     * Returns true if column exists in table
+     */
+    public function columnExists($table = '', $column = '')
+    {
+        global $db;
+        if (empty($table) || empty($column)) {
+            return false;
+        }
+        return (count($db->query("SHOW COLUMNS FROM `$table` WHERE LOWER(`Field`) = LOWER('$column');")->fetchAll(\PDO::FETCH_ASSOC)) > 0) ? true : false;
+    }
+
+    /**
      * Scanner constructor.
      * Loads in the JSON arrays for Pokemon and moves
      */

--- a/lib/stats/Stats.php
+++ b/lib/stats/Stats.php
@@ -19,6 +19,20 @@ class Stats
     public $moves = [];
 
     /**
+     * columnExists()
+     * Used for backward compatibility (backend agnostic)
+     * Returns true if column exists in table
+     */
+    public function columnExists($table = '', $column = '')
+    {
+        global $db;
+        if (empty($table) || empty($column)) {
+            return false;
+        }
+        return (count($db->query("SHOW COLUMNS FROM `$table` WHERE LOWER(`Field`) = LOWER('$column');")->fetchAll(\PDO::FETCH_ASSOC)) > 0) ? true : false;
+    }
+
+    /**
      * Scanner constructor.
      * Loads in the JSON arrays for Pokemon and moves
      */


### PR DESCRIPTION
- optimize the Multi-Incident query for better performance.
- add «columnExists» function to make backward compatibility easier to manage long term and provide better compatibility with forks that may have different `DB_VERSION`.
- add «availble_slots» backward compatibility instead of simply removing the misnamed column so that pmsf can merge to master/staging independently from rdm.