### PR TITLE
make `$pokemonToExclude` work with mad and rdm for mons

### DIFF
--- a/pre-index.php
+++ b/pre-index.php
@@ -392,7 +392,7 @@ if (strtolower($map) === "rdm") {
                                                 if (! $noHidePokemon) { ?>
                                                     <div class="tab-pane fade<?php echo (($firstTabContent == 1) ? " show active" : ""); ?>" id="exclude-pokemon" role="tabpanel" aria-labelledby="exclude-pokemon-tab">
                                                         <div class="scroll-container">
-                                                            <?php pokemonFilterImages($noPokemonNames, $noPokemonNumbers, '', [], 2); ?>
+                                                            <?php pokemonFilterImages($noPokemonNames, $noPokemonNumbers, '', $pokemonToExclude, 2); ?>
                                                         </div>
                                                         <div class="dropdown-divider"></div>
                                                         <a class="btn btn-secondary select-all" href="#"><?php echo i8ln('All') ?></a>
@@ -404,7 +404,7 @@ if (strtolower($map) === "rdm") {
                                                 if (! $noExcludeMinIV) { ?>
                                                     <div class="tab-pane fade<?php echo (($firstTabContent == 1) ? " show active" : ""); ?>" id="exclude-min-iv" role="tabpanel" aria-labelledby="exclude-min-iv-tab">
                                                         <div class="scroll-container">
-                                                            <?php pokemonFilterImages($noPokemonNames, $noPokemonNumbers, '', [], 3); ?>
+                                                            <?php pokemonFilterImages($noPokemonNames, $noPokemonNumbers, '', $pokemonToExclude, 3); ?>
                                                         </div>
                                                         <div class="dropdown-divider"></div>
                                                         <a class="btn btn-secondary select-all" href="#"><?php echo i8ln('All') ?></a>
@@ -1097,7 +1097,7 @@ if (strtolower($map) === "rdm") {
                                             <div class="tab-content" id="notifyPokemonContent">
                                                 <div class="tab-pane fade show active" id="notify-pokemon" role="tabpanel" aria-labelledby="notify-pokemon-tab">
                                                     <div class="scroll-container">
-                                                        <?php pokemonFilterImages($noPokemonNames, $noPokemonNumbers, '', [], 4); ?>
+                                                        <?php pokemonFilterImages($noPokemonNames, $noPokemonNumbers, '', $pokemonToExclude, 4); ?>
                                                     </div>
                                                     <div class="dropdown-divider"></div>
                                                     <a class="btn btn-secondary select-all notify-pokemon-button" href="#"><?php echo i8ln('All') ?></a>

--- a/raw_data.php
+++ b/raw_data.php
@@ -144,10 +144,13 @@ $rereids = array();
 
 $debug['1_before_functions'] = microtime(true) - $timing['start'];
 
-global $noPokemon;
+global $noPokemon, $pokemonToExclude;
 if (!$noPokemon) {
     if ($d["lastpokemon"] == "true") {
         $eids = !empty($_POST['eids']) ? explode(",", $_POST['eids']) : array();
+        if (count($pokemonToExclude)) {
+            $eids = array_unique(array_merge($eids, $pokemonToExclude));
+        }
         if ($lastpokemon != 'true') {
             $d["pokemons"] = $scanner->get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $despawnTimeType, $pokemonGender, $swLat, $swLng, $neLat, $neLng, 0, 0, 0, 0, 0, $enc_id);
         } else {


### PR DESCRIPTION
- previously only used for manual submissions.
- pokémon filter, notification filter and mons queries should now respect it.
- only added to `$eids` if actually populated to avoid affecting performance when unused.

No config change. Examples if you wish to use it in your config/access-config:
```
Don’t exclude anything (default):
$pokemonToExclude = [];

Exclude id 1, 2, 3 and 4:
$pokemonToExclude = [1, 2, 3, 4];

Exclude everything except id 1, 2, 3 and 4:
$pokemonToExclude = array_diff(range(1, $numberOfPokemon), [1, 2, 3, 4]);
```