### PR TITLE
fix: make spawnpoint despawn time of 0:00 and unknown(null) distinguishable

### DIFF
--- a/lib/RDM.php
+++ b/lib/RDM.php
@@ -847,7 +847,7 @@ class RDM extends Scanner
         foreach ($spawnpoints as $spawnpoint) {
             $spawnpoint["latitude"] = floatval($spawnpoint["latitude"]);
             $spawnpoint["longitude"] = floatval($spawnpoint["longitude"]);
-            $spawnpoint["time"] = intval($spawnpoint["despawn_sec"]);
+            $spawnpoint["time"] = is_null($spawnpoint["despawn_sec"]) ? null : intval($spawnpoint["despawn_sec"]);
             $data[] = $spawnpoint;
             unset($spawnpoints[$i]);
             $i++;

--- a/lib/RocketMap_MAD.php
+++ b/lib/RocketMap_MAD.php
@@ -559,6 +559,7 @@ class RocketMap_MAD extends RocketMap
         $query = "SELECT latitude,
         longitude,
         spawnpoint AS spawnpoint_id,
+        calc_endminsec AS calc_endminsec,
         (SUBSTRING_INDEX(SUBSTRING_INDEX(calc_endminsec, ':', 1), ' ', -1)*60) + (SUBSTRING_INDEX(SUBSTRING_INDEX(calc_endminsec, ':', -1), ' ', -1)) AS time
         FROM trs_spawn
         WHERE :conditions";
@@ -569,7 +570,7 @@ class RocketMap_MAD extends RocketMap
         foreach ($spawnpoints as $spawnpoint) {
             $spawnpoint["latitude"] = floatval($spawnpoint["latitude"]);
             $spawnpoint["longitude"] = floatval($spawnpoint["longitude"]);
-            $spawnpoint["time"] = intval($spawnpoint["time"]);
+            $spawnpoint["time"] = is_null($spawnpoint["calc_endminsec"]) ? null : intval($spawnpoint["time"]);
             $data[] = $spawnpoint;
             unset($spawnpoints[$i]);
             $i++;

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2011,7 +2011,7 @@ function formatSpawnTime(seconds) {
 
 function spawnpointLabel(item) {
     var str = ''
-    if (item.time > 0) {
+    if (item.time !== null) {
         str += '<div><b>' + i8ln('Spawn Point') + '</b></div>' +
         '<div>' + i8ln('Despawn time') + ': xx:' + formatSpawnTime(item.time) + '</div>'
     } else {
@@ -3061,7 +3061,7 @@ function deletePoi(event) { // eslint-disable-line no-unused-vars
 
 function setupSpawnpointMarker(item) {
     var color = ''
-    if (item['time'] > 0) {
+    if (item['time'] !== null) {
         color = 'green'
     } else {
         color = 'red'
@@ -5351,7 +5351,7 @@ function updateSpawnPoints() {
     $.each(mapData.spawnpoints, function (key, value) {
         if (map.getBounds().contains(value.marker.getLatLng())) {
             var color = ''
-            if (value['time'] > 0) {
+            if (value['time'] !== null) {
                 color = 'green'
             } else {
                 color = 'red'

--- a/static/js/stats.js
+++ b/static/js/stats.js
@@ -298,7 +298,7 @@ function countMarkers(map) { // eslint-disable-line no-unused-vars
             var thisSpawnpointLocation = {lat: mapData.spawnpoints[key]['latitude'], lng: mapData.spawnpoints[key]['longitude']}
             thisSpawnpointIsVisible = currentVisibleMap.contains(thisSpawnpointLocation)
             if (thisSpawnpointIsVisible) {
-                if (mapData.spawnpoints[key]['time'] === 0) {
+                if (mapData.spawnpoints[key]['time'] === null) {
                     if (spawnpointCount[2] === 0 || !spawnpointCount[2]) {
                         spawnpointCount[2] = 1
                     } else {


### PR DESCRIPTION
- despawn_sec(RDM) and calc_endminsec(MAD) both default to `null` when unknown.
- code used `intval(column) ` which resulted in 0 if `null` or despawn time was exactly `0:00` making them impossible to distinguish and displayed `Unknown spawnpoint info` for `0:00` known despawn time.
- code will now set it to `null` when unknown and intval(column) if not null.
