### PR TITLE
add little league support (rdm only)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -84,6 +84,7 @@
     "directionProvider": true,
     "hidePokemon": true,
     "excludeMinIV": true,
+    "minLLRank": true,
     "minGLRank": true,
     "minULRank": true,
     "minIV": true,

--- a/config/default.php
+++ b/config/default.php
@@ -219,6 +219,7 @@ $adminUsers = [];                                                   // You can a
 //-----------------------------------------------------
 
 /* Marker Settings */
+$noMinLLRank = false;                                               // true/false
 $noMinGLRank = false;                                               // true/false
 $noMinULRank = false;                                               // true/false
 $noExcludeMinIV = true;                                             // true/false
@@ -260,6 +261,7 @@ $noPvp = false;                                                     // true/fals
 
 $excludeMinIV = '[]';                                               // [] for empty
 
+$minLLRank = '0';                                                   // "0" for empty or a number
 $minGLRank = '0';                                                   // "0" for empty or a number
 $minULRank = '0';                                                   // "0" for empty or a number
 

--- a/config/example.config.php
+++ b/config/example.config.php
@@ -219,6 +219,7 @@ $adminUsers = ['admin@example.com', 'Superadmin#13337'];            // You can a
 //-----------------------------------------------------
 
 /* Marker Settings */
+$noMinLLRank = false;                                               // true/false
 $noMinGLRank = false;                                               // true/false
 $noMinULRank = false;                                               // true/false
 $noExcludeMinIV = false;                                            // true/false
@@ -260,6 +261,7 @@ $noPvp = false;                                                     // true/fals
 
 $excludeMinIV = '[131, 143, 147, 148, 149, 248]';                   // [] for empty
 
+$minLLRank = '0';                                                   // "0" for empty or a number
 $minGLRank = '0';                                                   // "0" for empty or a number
 $minULRank = '0';                                                   // "0" for empty or a number
 

--- a/lib/RDM.php
+++ b/lib/RDM.php
@@ -27,6 +27,7 @@ class RDM extends Scanner
         if (!$noHighLevelData) {
             if ($this->columnExists("pokemon","pvp")) {
                 $rdmPvP = ",
+                json_extract(`pvp`,'$.little') AS pvp_rankings_little_league,
                 json_extract(`pvp`,'$.great') AS pvp_rankings_great_league,
                 json_extract(`pvp`,'$.ultra') AS pvp_rankings_ultra_league";
             } else {
@@ -150,6 +151,7 @@ class RDM extends Scanner
         if (!$noHighLevelData) {
             if ($this->columnExists("pokemon","pvp")) {
                 $rdmPvP = ",
+                json_extract(`pvp`,'$.little') AS pvp_rankings_little_league,
                 json_extract(`pvp`,'$.great') AS pvp_rankings_great_league,
                 json_extract(`pvp`,'$.ultra') AS pvp_rankings_ultra_league";
             } else {
@@ -285,6 +287,7 @@ class RDM extends Scanner
             $pokemon["individual_defense"] = isset($pokemon["individual_defense"]) ? intval($pokemon["individual_defense"]) : null;
             $pokemon["individual_stamina"] = isset($pokemon["individual_stamina"]) ? intval($pokemon["individual_stamina"]) : null;
 
+            $pokemon["pvp_rankings_little_league"] = isset($pokemon["pvp_rankings_little_league"]) ? $pokemon["pvp_rankings_little_league"] : null;
             $pokemon["pvp_rankings_great_league"] = isset($pokemon["pvp_rankings_great_league"]) ? $pokemon["pvp_rankings_great_league"] : null;
             $pokemon["pvp_rankings_ultra_league"] = isset($pokemon["pvp_rankings_ultra_league"]) ? $pokemon["pvp_rankings_ultra_league"] : null;
 

--- a/lib/RocketMap_MAD.php
+++ b/lib/RocketMap_MAD.php
@@ -273,6 +273,7 @@ class RocketMap_MAD extends RocketMap
             $pokemon["individual_defense"] = isset($pokemon["individual_defense"]) ? intval($pokemon["individual_defense"]) : null;
             $pokemon["individual_stamina"] = isset($pokemon["individual_stamina"]) ? intval($pokemon["individual_stamina"]) : null;
 
+            $pokemon["pvp_rankings_little_league"] = null;
             $pokemon["pvp_rankings_great_league"] = null;
             $pokemon["pvp_rankings_ultra_league"] = null;
 

--- a/pre-index.php
+++ b/pre-index.php
@@ -313,11 +313,20 @@ if (strtolower($map) === "rdm") {
                                             </div>
                                         <?php
                                         }
-                                        if (! $noMinGLRank || ! $noMinULRank) { ?>
+                                        if (! $noMinLLRank || $noMinGLRank || ! $noMinULRank) { ?>
                                             <div class="dropdown-divider"></div>
                                             <div class="overflow-hidden">
                                                 <div class="row gx-3">
                                                 <?php
+                                                if (! $noMinLLRank) { ?>
+                                                    <div class="col" >
+                                                        <div class="p-1 border bg-light">
+                                                            <input id="min-ll-rank" type="number" min="0" max="100" name="min-ll-rank"/>
+                                                            <label for="min-ll-rank"><?php echo i8ln('Min LLR') ?></label>
+                                                        </div>
+                                                    </div>
+                                                <?php
+                                                }
                                                 if (! $noMinGLRank) { ?>
                                                     <div class="col" >
                                                         <div class="p-1 border bg-light">
@@ -1531,8 +1540,12 @@ include('modals.php');
     var mapStyle = '<?php echo $mapStyle ?>';
     var mapStyleList = <?php echo json_encode($mapStyleList) ?>;
     var hidePokemon = <?php echo $noHidePokemon ? '[]' : $hidePokemon ?>;
+    var minLLRank = <?php echo $noMinLLRank ? '""' : $minLLRank ?>;
+    if (minLLRank === "") { localStorage.setItem('remember_text_min_ll_rank', 0) }
     var minGLRank = <?php echo $noMinGLRank ? '""' : $minGLRank ?>;
+    if (minGLRank === "") { localStorage.setItem('remember_text_min_gl_rank', 0) }
     var minULRank = <?php echo $noMinULRank ? '""' : $minULRank ?>;
+    if (minULRank === "") { localStorage.setItem('remember_text_min_ul_rank', 0) }
     var excludeMinIV = <?php echo $noExcludeMinIV ? '[]' : $excludeMinIV ?>;
     var minIV = <?php echo $noMinIV ? '""' : $minIV ?>;
     var minLevel = <?php echo $noMinLevel ? '""' : $minLevel ?>;

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -91,6 +91,11 @@ var StoreOptions = {
             default: notifyLevel,
             type: StoreTypes.Number
         },
+    'remember_text_min_ll_rank':
+        {
+            default: minLLRank,
+            type: StoreTypes.Number
+        },
     'remember_text_min_gl_rank':
         {
             default: minGLRank,


### PR DESCRIPTION
- display ranks in mons popup
- add LLR filter to menu (LittleLeagueRank)
- reset to no filtering when `$noMinXXRank` is true to prevent users from being stuck with invisible filtering when admin changes `$noMinXXRank` from false to true

new config variables
- `$noMinLLRank`. Default: `false` (enabled)
- `$minLLRank`. Default `0` (no filtering)