### PR TITLE
fix: mad weather query was not selecting `last_updated`

### DIFF
--- a/lib/RocketMap_MAD.php
+++ b/lib/RocketMap_MAD.php
@@ -317,7 +317,7 @@ class RocketMap_MAD extends RocketMap
     public function get_weather_by_cell_id($cell_id)
     {
         global $db;
-        $query = "SELECT s2_cell_id, gameplay_weather FROM weather WHERE s2_cell_id = :cell_id";
+        $query = "SELECT s2_cell_id, gameplay_weather, UNIX_TIMESTAMP(CONVERT_TZ(last_updated, '+00:00', @@global.time_zone)) AS updated FROM weather WHERE s2_cell_id = :cell_id";
         $params = [':cell_id' => intval((float)$cell_id)]; // use float to intval because RM is signed int
         $weather_info = $db->query($query, $params)->fetchAll(\PDO::FETCH_ASSOC);
         if ($weather_info) {
@@ -333,7 +333,7 @@ class RocketMap_MAD extends RocketMap
     public function get_weather($updated = null)
     {
         global $db;
-        $query = "SELECT s2_cell_id, gameplay_weather FROM weather";
+        $query = "SELECT s2_cell_id, gameplay_weather, UNIX_TIMESTAMP(CONVERT_TZ(last_updated, '+00:00', @@global.time_zone)) AS updated FROM weather";
         $weathers = $db->query($query)->fetchAll(\PDO::FETCH_ASSOC);
         $data = array();
         foreach ($weathers as $weather) {


### PR DESCRIPTION
- without that field, the weather reported on the map was correct but it was always marked as «Out Of Date» with an invalid date