### PR TITLE
add 0%iv toggle to pokemon menu

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -91,6 +91,7 @@
     "minLevel": true,
     "showBigKarp": true,
     "showTinyRat": true,
+    "showZeroIv": true,
     "showDespawnTimeType": true,
     "showPokemonGender": true,
     "hidePokemonCoords": true,

--- a/config/default.php
+++ b/config/default.php
@@ -271,6 +271,7 @@ $minLevel = '0';                                                    // "0" for e
 $noMissingIVOnly = true;                                            // true/false
 $noBigKarp = false;                                                 // true/false
 $noTinyRat = false;                                                 // true/false
+$noZeroIvToggle = false;                                            // true/false
 $noDespawnTimeType = true;                                          // true/false
 $showDespawnTimeType = 0;                                           // 0 = All, 1 = Verified, 2 = Unverified, 3 = Unverified + Nearby (Nearby = no spawn point)
 $noPokemonGender = false;                                           // true/false

--- a/config/example.config.php
+++ b/config/example.config.php
@@ -271,6 +271,7 @@ $minLevel = '0';                                                    // "0" for e
 $noMissingIVOnly = true;                                            // true/false
 $noBigKarp = false;                                                 // true/false
 $noTinyRat = false;                                                 // true/false
+$noZeroIvToggle = false;                                            // true/false
 $noDespawnTimeType = true;                                          // true/false
 $showDespawnTimeType = 0;                                           // 0 = All, 1 = Verified, 2 = Unverified, 3 = Unverified + Nearby (Nearby = no spawn point)
 $noPokemonGender = false;                                           // true/false

--- a/lib/RocketMap.php
+++ b/lib/RocketMap.php
@@ -12,7 +12,7 @@ class RocketMap extends Scanner
         $this->setCpMultiplier();
     }
 
-    public function get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $despawnTimeType, $gender, $swLat, $swLng, $neLat, $neLng, $tstamp = 0, $oSwLat = 0, $oSwLng = 0, $oNeLat = 0, $oNeLng = 0, $encId = 0)
+    public function get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $zeroIv, $despawnTimeType, $gender, $swLat, $swLng, $neLat, $neLng, $tstamp = 0, $oSwLat = 0, $oSwLng = 0, $oNeLat = 0, $oNeLng = 0, $encId = 0)
     {
         global $db;
         $conds = array();
@@ -90,10 +90,14 @@ class RocketMap extends Scanner
         if ($encId != 0) {
             $encSql = " OR (encounter_id = " . $encId . " AND latitude > '" . $swLat . "' AND longitude > '" . $swLng . "' AND latitude < '" . $neLat . "' AND longitude < '" . $neLng . "' AND disappear_time > '" . $params[':time'] . "')";
         }
-        return $this->query_active($select, $conds, $params, $encSql);
+        $zeroSql = '';
+        if (!$noHighLevelData && !empty($zeroIv) && $zeroIv === 'true') {
+            $zeroSql = " OR (individual_attack = 0 AND individual_defense = 0 AND individual_stamina = 0 AND disappear_time > '" . $params[':time'] . "')";
+        }
+        return $this->query_active($select, $conds, $params, $encSql, $zeroSql);
     }
 
-    public function get_active_by_id($ids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $despawnTimeType, $gender, $swLat, $swLng, $neLat, $neLng)
+    public function get_active_by_id($ids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $zeroIv, $despawnTimeType, $gender, $swLat, $swLng, $neLat, $neLng)
     {
         global $db;
         $conds = array();
@@ -161,11 +165,14 @@ class RocketMap extends Scanner
                 $conds[] = '(cp_multiplier >= ' . $this->cpMultiplier[$minLevel] . ' OR pokemon_id IN(' . $exMinIv . ') )';
             }
         }
-
-        return $this->query_active($select, $conds, $params);
+        $zeroSql = '';
+        if (!$noHighLevelData && !empty($zeroIv) && $zeroIv === 'true') {
+            $zeroSql = " OR (individual_attack = 0 AND individual_defense = 0 AND individual_stamina = 0 AND disappear_time > '" . $params[':time'] . "')";
+        }
+        return $this->query_active($select, $conds, $params, '', $zeroSql);
     }
 
-    public function query_active($select, $conds, $params, $encSql = '')
+    public function query_active($select, $conds, $params, $encSql = '', $zeroSql = '')
     {
         global $db;
 
@@ -174,7 +181,7 @@ class RocketMap extends Scanner
         WHERE :conditions";
 
         $query = str_replace(":select", $select, $query);
-        $query = str_replace(":conditions", '(' . join(" AND ", $conds) . ')' . $encSql, $query);
+        $query = str_replace(":conditions", '(' . join(" AND ", $conds) . ')' . $encSql . $zeroSql, $query);
         $pokemons = $db->query($query, $params)->fetchAll(\PDO::FETCH_ASSOC);
 
         $data = array();

--- a/pre-index.php
+++ b/pre-index.php
@@ -288,6 +288,14 @@ if (strtolower($map) === "rdm") {
                                             </div>
                                         <?php
                                         }
+                                        if (! $noZeroIvToggle) { ?>
+                                            <div class="dropdown-divider"></div>
+                                            <div class="form-check form-switch">
+                                                <input class="form-check-input" id="no-zero-iv-switch" type="checkbox" name="no-zero-iv-switch">
+                                                <label class="form-check-label"  for="no-zero-iv-switch"><?php echo i8ln('Show 0%IV (Override MinIV)') ?></label>
+                                            </div>
+                                        <?php
+                                        }
                                         if (! $noDespawnTimeType) { ?>
                                             <div class="dropdown-divider"></div>
                                             <div class="form-floating">
@@ -1614,6 +1622,7 @@ include('modals.php');
     var onlyTriggerGyms = <?php echo $onlyTriggerGyms === true ? 'true' : 'false' ?>;
     var showBigKarp = <?php echo $noBigKarp === true ? 'true' : 'false' ?>;
     var showTinyRat = <?php echo $noTinyRat === true ? 'true' : 'false' ?>;
+    var showZeroIv = <?php echo $noZeroIvToggle === true ? 'true' : 'false' ?>;
     var showDespawnTimeType = <?php echo $noDespawnTimeType ? 0 : $showDespawnTimeType ?>;
     var showPokemonGender = <?php echo $noPokemonGender ? 0 : $showPokemonGender ?>;
     var hidePokemonCoords = <?php echo $hidePokemonCoords === true ? 'true' : 'false' ?>;

--- a/raw_data.php
+++ b/raw_data.php
@@ -37,6 +37,7 @@ $prevMinLevel = !empty($_POST['prevMinLevel']) ? $_POST['prevMinLevel'] : false;
 $exMinIv = !empty($_POST['exMinIV']) ? $_POST['exMinIV'] : '';
 $bigKarp = !empty($_POST['bigKarp']) ? $_POST['bigKarp'] : false;
 $tinyRat = !empty($_POST['tinyRat']) ? $_POST['tinyRat'] : false;
+$zeroIv = !empty($_POST['zeroIv']) ? $_POST['zeroIv'] : false;
 $despawnTimeType = !empty($_POST['despawnTimeType']) ? $_POST['despawnTimeType'] : 0;
 $pokemonGender = !empty($_POST['pokemonGender']) ? $_POST['pokemonGender'] : 0;
 $lastpokemon = !empty($_POST['lastpokemon']) ? $_POST['lastpokemon'] : false;
@@ -152,12 +153,12 @@ if (!$noPokemon) {
             $eids = array_unique(array_merge($eids, $pokemonToExclude));
         }
         if ($lastpokemon != 'true') {
-            $d["pokemons"] = $scanner->get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $despawnTimeType, $pokemonGender, $swLat, $swLng, $neLat, $neLng, 0, 0, 0, 0, 0, $enc_id);
+            $d["pokemons"] = $scanner->get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $zeroIv, $despawnTimeType, $pokemonGender, $swLat, $swLng, $neLat, $neLng, 0, 0, 0, 0, 0, $enc_id);
         } else {
             if ($newarea) {
-                $d["pokemons"] = $scanner->get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $despawnTimeType, $pokemonGender, $swLat, $swLng, $neLat, $neLng, 0, $oSwLat, $oSwLng, $oNeLat, $oNeLng, $enc_id);
+                $d["pokemons"] = $scanner->get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $zeroIv, $despawnTimeType, $pokemonGender, $swLat, $swLng, $neLat, $neLng, 0, $oSwLat, $oSwLng, $oNeLat, $oNeLng, $enc_id);
             } else {
-                $d["pokemons"] = $scanner->get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $despawnTimeType, $pokemonGender, $swLat, $swLng, $neLat, $neLng, $timestamp, 0, 0, 0, 0, $enc_id);
+                $d["pokemons"] = $scanner->get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $zeroIv, $despawnTimeType, $pokemonGender, $swLat, $swLng, $neLat, $neLng, $timestamp, 0, 0, 0, 0, $enc_id);
             }
         }
         $d["preMinIV"] = $minIv;
@@ -167,7 +168,7 @@ if (!$noPokemon) {
 
             $reidsDiff = array_diff($reids, $eids);
             if (count($reidsDiff)) {
-                $d["pokemons"] = array_merge($d["pokemons"], $scanner->get_active_by_id($reidsDiff, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $despawnTimeType, $pokemonGender, $swLat, $swLng, $neLat, $neLng));
+                $d["pokemons"] = array_merge($d["pokemons"], $scanner->get_active_by_id($reidsDiff, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $zeroIv, $despawnTimeType, $pokemonGender, $swLat, $swLng, $neLat, $neLng));
             }
 
             $d["reids"] = $reids;

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -291,6 +291,11 @@ var StoreOptions = {
             default: showTinyRat,
             type: StoreTypes.Boolean
         },
+    'showZeroIv':
+        {
+            default: showZeroIv,
+            type: StoreTypes.Boolean
+        },
     'showDespawnTimeType':
         {
             default: showDespawnTimeType,

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1064,6 +1064,7 @@ function initSidebar() {
     $('#missing-iv-only-switch').prop('checked', Store.get('showMissingIVOnly'))
     $('#big-karp-switch').prop('checked', Store.get('showBigKarp'))
     $('#tiny-rat-switch').prop('checked', Store.get('showTinyRat'))
+    $('#no-zero-iv-switch').prop('checked', Store.get('showZeroIv'))
     $('#despawn-time-type-select').val(Store.get('showDespawnTimeType'))
     $('#pokemon-gender-select').val(Store.get('showPokemonGender'))
     $('#pokestops-switch').prop('checked', Store.get('showPokestops'))
@@ -3203,8 +3204,9 @@ function addListeners(marker) {
 function clearStaleMarkers() {
     $.each(mapData.pokemons, function (key, value) {
         var pvpFiltered = false
+        var isZeroIvMons = (mapData.pokemons[key]['individual_attack'] !== null && mapData.pokemons[key]['individual_attack'] === 0 && mapData.pokemons[key]['individual_defense'] !== null && mapData.pokemons[key]['individual_defense'] === 0 && mapData.pokemons[key]['individual_stamina'] !== null && mapData.pokemons[key]['individual_stamina'] === 0)
 
-        if (minLLRank > 0 || minGLRank > 0 || minULRank > 0) {
+        if ((minLLRank > 0 || minGLRank > 0 || minULRank > 0) && (Store.get('showZeroIv') === false || (Store.get('showZeroIv') === true && !isZeroIvMons))) {
             pvpFiltered = true
             if (minLLRank > 0 && pvpFiltered) {
                 var littleLeague = JSON.parse(mapData.pokemons[key]['pvp_rankings_little_league'])
@@ -3240,7 +3242,7 @@ function clearStaleMarkers() {
                 (excludedPokemon.indexOf(mapData.pokemons[key]['pokemon_id']) >= 0 ||
                     isTemporaryHidden(mapData.pokemons[key]['pokemon_id']) ||
                     (pvpFiltered) ||
-                    ((((mapData.pokemons[key]['individual_attack'] + mapData.pokemons[key]['individual_defense'] + mapData.pokemons[key]['individual_stamina']) / 45 * 100 < minIV) || ((mapType === 'rdm' && mapData.pokemons[key]['level'] < minLevel) || (mapType === 'rocketmap' && !isNaN(minLevel) && (mapData.pokemons[key]['cp_multiplier'] < cpMultiplier[minLevel - 1])))) && !excludedMinIV.includes(mapData.pokemons[key]['pokemon_id']) && Store.get('showMissingIVOnly') === false) ||
+                    (((((mapData.pokemons[key]['individual_attack'] + mapData.pokemons[key]['individual_defense'] + mapData.pokemons[key]['individual_stamina']) / 45 * 100) < minIV && (Store.get('showZeroIv') === false || (Store.get('showZeroIv') === true && !isZeroIvMons))) || (((mapType === 'rdm' && mapData.pokemons[key]['level'] < minLevel) || (mapType === 'rocketmap' && !isNaN(minLevel) && (mapData.pokemons[key]['cp_multiplier'] < cpMultiplier[minLevel - 1]))) && (Store.get('showZeroIv') === false || (Store.get('showZeroIv') === true && !isZeroIvMons)))) && !excludedMinIV.includes(mapData.pokemons[key]['pokemon_id']) && Store.get('showMissingIVOnly') === false) ||
                     (Store.get('showMissingIVOnly') === true && mapData.pokemons[key]['individual_attack'] !== null) ||
                     (Store.get('showBigKarp') === true && mapData.pokemons[key]['pokemon_id'] === 129 && (mapData.pokemons[key]['weight'] < 13.14 || mapData.pokemons[key]['weight'] === null)) ||
                     (Store.get('showTinyRat') === true && mapData.pokemons[key]['pokemon_id'] === 19 && (mapData.pokemons[key]['weight'] > 2.40 || mapData.pokemons[key]['weight'] === null)) ||
@@ -3384,6 +3386,7 @@ function loadRawData() {
     var loadMinLevel = Store.get('remember_text_min_level')
     var bigKarp = Boolean(Store.get('showBigKarp'))
     var tinyRat = Boolean(Store.get('showTinyRat'))
+    var zeroIv = Boolean(Store.get('showZeroIv'))
     var despawnTimeType = Store.get('showDespawnTimeType')
     var pokemonGender = Store.get('showPokemonGender')
     var exEligible = Boolean(Store.get('exEligible'))
@@ -3453,6 +3456,7 @@ function loadRawData() {
             'prevMinLevel': prevMinLevel,
             'bigKarp': bigKarp,
             'tinyRat': tinyRat,
+            'zeroIv': zeroIv,
             'despawnTimeType': despawnTimeType,
             'pokemonGender': pokemonGender,
             'swLat': swLat,
@@ -4812,7 +4816,7 @@ function processPokemons(i, item) {
             }
         }
         if (encounterId !== item['encounter_id']) {
-            if (minLLRank > 0 || minGLRank > 0 || minULRank > 0) {
+            if ((minLLRank > 0 || minGLRank > 0 || minULRank > 0) && (Store.get('showZeroIv') === false || (Store.get('showZeroIv') === true && !(item['individual_attack'] !== null && item['individual_attack'] === 0 && item['individual_defense'] !== null && item['individual_defense'] === 0 && item['individual_stamina'] !== null && item['individual_stamina'] === 0)))) {
                 var pvpFiltered = true
                 if (minLLRank > 0 && pvpFiltered) {
                     var littleLeague = JSON.parse(item['pvp_rankings_little_league'])
@@ -6788,6 +6792,11 @@ $(function () {
         })
         $('#big-karp-switch').on('change', function (e) {
             Store.set('showBigKarp', this.checked)
+            lastpokemon = false
+            updateMap()
+        })
+        $('#no-zero-iv-switch').on('change', function (e) {
+            Store.set('showZeroIv', this.checked)
             lastpokemon = false
             updateMap()
         })


### PR DESCRIPTION
- allows users to display 0%IV mons on the map regardless of the value used in the MinIV, MinLVL, MinLLR, MinGLR or MinULR filters.

new config variables
- `$noZeroIvToggle`. Default: `false` (enabled)