### PR TITLE
add 100%iv toggle to pokemon menu

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -92,6 +92,7 @@
     "showBigKarp": true,
     "showTinyRat": true,
     "showZeroIv": true,
+    "showHundoIv": true,
     "showDespawnTimeType": true,
     "showPokemonGender": true,
     "hidePokemonCoords": true,

--- a/config/default.php
+++ b/config/default.php
@@ -272,6 +272,7 @@ $noMissingIVOnly = true;                                            // true/fals
 $noBigKarp = false;                                                 // true/false
 $noTinyRat = false;                                                 // true/false
 $noZeroIvToggle = false;                                            // true/false
+$noHundoIvToggle = false;                                           // true/false
 $noDespawnTimeType = true;                                          // true/false
 $showDespawnTimeType = 0;                                           // 0 = All, 1 = Verified, 2 = Unverified, 3 = Unverified + Nearby (Nearby = no spawn point)
 $noPokemonGender = false;                                           // true/false

--- a/config/example.config.php
+++ b/config/example.config.php
@@ -272,6 +272,7 @@ $noMissingIVOnly = true;                                            // true/fals
 $noBigKarp = false;                                                 // true/false
 $noTinyRat = false;                                                 // true/false
 $noZeroIvToggle = false;                                            // true/false
+$noHundoIvToggle = false;                                           // true/false
 $noDespawnTimeType = true;                                          // true/false
 $showDespawnTimeType = 0;                                           // 0 = All, 1 = Verified, 2 = Unverified, 3 = Unverified + Nearby (Nearby = no spawn point)
 $noPokemonGender = false;                                           // true/false

--- a/lib/RDM.php
+++ b/lib/RDM.php
@@ -4,7 +4,7 @@ namespace Scanner;
 
 class RDM extends Scanner
 {
-    public function get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $zeroIv, $despawnTimeType, $gender, $swLat, $swLng, $neLat, $neLng, $tstamp = 0, $oSwLat = 0, $oSwLng = 0, $oNeLat = 0, $oNeLng = 0, $encId = 0)
+    public function get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $zeroIv, $hundoIv, $despawnTimeType, $gender, $swLat, $swLng, $neLat, $neLng, $tstamp = 0, $oSwLat = 0, $oSwLng = 0, $oNeLat = 0, $oNeLng = 0, $encId = 0)
     {
         global $db;
         $conds = array();
@@ -125,14 +125,19 @@ class RDM extends Scanner
         if ($encId != 0) {
             $encSql = " OR (id = " . $encId . " AND lat > '" . $swLat . "' AND lon > '" . $swLng . "' AND lat < '" . $neLat . "' AND lon < '" . $neLng . "' AND expire_timestamp > '" . $params[':time'] . "')";
         }
+        $tmpSQL = ($tstamp > 0) ? " AND updated > " . $params[':lastUpdated'] : '';
         $zeroSql = '';
         if (!$noHighLevelData && !empty($zeroIv) && $zeroIv === 'true') {
-            $zeroSql = " OR (atk_iv = 0 AND def_iv = 0 AND sta_iv = 0 AND expire_timestamp > '" . $params[':time'] . "')";
+            $zeroSql = " OR (atk_iv = 0 AND def_iv = 0 AND sta_iv = 0 AND expire_timestamp > '" . $params[':time'] . "'" . $tmpSQL . ")";
         }
-        return $this->query_active($select, $conds, $params, $encSql, $zeroSql);
+        $hundoSql = '';
+        if (!$noHighLevelData && !empty($hundoIv) && $hundoIv === 'true') {
+            $hundoSql = " OR (atk_iv = 15 AND def_iv = 15 AND sta_iv = 15 AND expire_timestamp > '" . $params[':time'] . "'" . $tmpSQL . ")";
+        }
+        return $this->query_active($select, $conds, $params, $encSql, $zeroSql, $hundoSql);
     }
 
-    public function get_active_by_id($ids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $zeroIv, $despawnTimeType, $gender, $swLat, $swLng, $neLat, $neLng)
+    public function get_active_by_id($ids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $zeroIv, $hundoIv, $despawnTimeType, $gender, $swLat, $swLng, $neLat, $neLng)
     {
         global $db;
         $conds = array();
@@ -246,10 +251,14 @@ class RDM extends Scanner
         if (!$noHighLevelData && !empty($zeroIv) && $zeroIv === 'true') {
             $zeroSql = " OR (atk_iv = 0 AND def_iv = 0 AND sta_iv = 0 AND expire_timestamp > '" . $params[':time'] . "')";
         }
-        return $this->query_active($select, $conds, $params, '', $zeroSql);
+        $hundoSql = '';
+        if (!$noHighLevelData && !empty($hundoIv) && $hundoIv === 'true') {
+            $hundoSql = " OR (atk_iv = 15 AND def_iv = 15 AND sta_iv = 15 AND expire_timestamp > '" . $params[':time'] . "')";
+        }
+        return $this->query_active($select, $conds, $params, '', $zeroSql, $hundoSql);
     }
 
-    public function query_active($select, $conds, $params, $encSql = '', $zeroSql = '')
+    public function query_active($select, $conds, $params, $encSql = '', $zeroSql = '', $hundoSql = '')
     {
         global $db;
 
@@ -258,7 +267,7 @@ class RDM extends Scanner
         WHERE :conditions ORDER BY lat, lon ";
 
         $query = str_replace(":select", $select, $query);
-        $query = str_replace(":conditions", '(' . join(" AND ", $conds) . ')' . $encSql . $zeroSql, $query);
+        $query = str_replace(":conditions", '(' . join(" AND ", $conds) . ')' . $encSql . $zeroSql . $hundoSql, $query);
         $pokemons = $db->query($query, $params)->fetchAll(\PDO::FETCH_ASSOC);
         $data = array();
         $i = 0;

--- a/lib/RocketMap.php
+++ b/lib/RocketMap.php
@@ -12,7 +12,7 @@ class RocketMap extends Scanner
         $this->setCpMultiplier();
     }
 
-    public function get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $zeroIv, $despawnTimeType, $gender, $swLat, $swLng, $neLat, $neLng, $tstamp = 0, $oSwLat = 0, $oSwLng = 0, $oNeLat = 0, $oNeLng = 0, $encId = 0)
+    public function get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $zeroIv, $hundoIv, $despawnTimeType, $gender, $swLat, $swLng, $neLat, $neLng, $tstamp = 0, $oSwLat = 0, $oSwLng = 0, $oNeLat = 0, $oNeLng = 0, $encId = 0)
     {
         global $db;
         $conds = array();
@@ -90,14 +90,19 @@ class RocketMap extends Scanner
         if ($encId != 0) {
             $encSql = " OR (encounter_id = " . $encId . " AND latitude > '" . $swLat . "' AND longitude > '" . $swLng . "' AND latitude < '" . $neLat . "' AND longitude < '" . $neLng . "' AND disappear_time > '" . $params[':time'] . "')";
         }
+        $tmpSQL = ($tstamp > 0) ? " AND last_modified > '" . $params[':lastUpdated'] . "'" : "";
         $zeroSql = '';
         if (!$noHighLevelData && !empty($zeroIv) && $zeroIv === 'true') {
-            $zeroSql = " OR (individual_attack = 0 AND individual_defense = 0 AND individual_stamina = 0 AND disappear_time > '" . $params[':time'] . "')";
+            $zeroSql = " OR (individual_attack = 0 AND individual_defense = 0 AND individual_stamina = 0 AND disappear_time > '" . $params[':time'] . "'" . $tmpSQL . ")";
         }
-        return $this->query_active($select, $conds, $params, $encSql, $zeroSql);
+        $hundoSql = '';
+        if (!$noHighLevelData && !empty($hundoIv) && $hundoIv === 'true') {
+            $hundoSql = " OR (individual_attack = 15 AND individual_defense = 15 AND individual_stamina = 15 AND disappear_time > '" . $params[':time'] . "'" . $tmpSQL . ")";
+        }
+        return $this->query_active($select, $conds, $params, $encSql, $zeroSql, $hundoSql);
     }
 
-    public function get_active_by_id($ids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $zeroIv, $despawnTimeType, $gender, $swLat, $swLng, $neLat, $neLng)
+    public function get_active_by_id($ids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $zeroIv, $hundoIv, $despawnTimeType, $gender, $swLat, $swLng, $neLat, $neLng)
     {
         global $db;
         $conds = array();
@@ -169,10 +174,14 @@ class RocketMap extends Scanner
         if (!$noHighLevelData && !empty($zeroIv) && $zeroIv === 'true') {
             $zeroSql = " OR (individual_attack = 0 AND individual_defense = 0 AND individual_stamina = 0 AND disappear_time > '" . $params[':time'] . "')";
         }
-        return $this->query_active($select, $conds, $params, '', $zeroSql);
+        $hundoSql = '';
+        if (!$noHighLevelData && !empty($hundoIv) && $hundoIv === 'true') {
+            $hundoSql = " OR (individual_attack = 15 AND individual_defense = 15 AND individual_stamina = 15 AND disappear_time > '" . $params[':time'] . "')";
+        }
+        return $this->query_active($select, $conds, $params, '', $zeroSql, $hundoSql);
     }
 
-    public function query_active($select, $conds, $params, $encSql = '', $zeroSql = '')
+    public function query_active($select, $conds, $params, $encSql = '', $zeroSql = '', $hundoSql = '')
     {
         global $db;
 
@@ -181,7 +190,7 @@ class RocketMap extends Scanner
         WHERE :conditions";
 
         $query = str_replace(":select", $select, $query);
-        $query = str_replace(":conditions", '(' . join(" AND ", $conds) . ')' . $encSql . $zeroSql, $query);
+        $query = str_replace(":conditions", '(' . join(" AND ", $conds) . ')' . $encSql . $zeroSql . $hundoSql, $query);
         $pokemons = $db->query($query, $params)->fetchAll(\PDO::FETCH_ASSOC);
 
         $data = array();

--- a/lib/RocketMap_MAD.php
+++ b/lib/RocketMap_MAD.php
@@ -4,7 +4,7 @@ namespace Scanner;
 
 class RocketMap_MAD extends RocketMap
 {
-    public function get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $zeroIv, $despawnTimeType, $gender, $swLat, $swLng, $neLat, $neLng, $tstamp = 0, $oSwLat = 0, $oSwLng = 0, $oNeLat = 0, $oNeLng = 0, $encId = 0)
+    public function get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $zeroIv, $hundoIv, $despawnTimeType, $gender, $swLat, $swLng, $neLat, $neLng, $tstamp = 0, $oSwLat = 0, $oSwLng = 0, $oNeLat = 0, $oNeLng = 0, $encId = 0)
     {
         global $db;
         $conds = array();
@@ -116,14 +116,19 @@ class RocketMap_MAD extends RocketMap
         if ($encId != 0) {
             $encSql = " OR (encounter_id = " . $encId . " AND p.latitude > '" . $swLat . "' AND p.longitude > '" . $swLng . "' AND p.latitude < '" . $neLat . "' AND p.longitude < '" . $neLng . "' AND disappear_time > '" . $params[':time'] . "')";
         }
+        $tmpSQL = ($tstamp > 0) ? " AND last_modified > '" . $params[':lastUpdated'] . "'" : "";
         $zeroSql = '';
         if (!$noHighLevelData && !empty($zeroIv) && $zeroIv === 'true') {
-            $zeroSql = " OR (individual_attack = 0 AND individual_defense = 0 AND individual_stamina = 0 AND disappear_time > '" . $params[':time'] . "')";
+            $zeroSql = " OR (individual_attack = 0 AND individual_defense = 0 AND individual_stamina = 0 AND disappear_time > '" . $params[':time'] . "'" . $tmpSQL . ")";
         }
-        return $this->query_active($select, $conds, $params, $encSql, $zeroSql);
+        $hundoSql = '';
+        if (!$noHighLevelData && !empty($hundoIv) && $hundoIv === 'true') {
+            $hundoSql = " OR (individual_attack = 15 AND individual_defense = 15 AND individual_stamina = 15 AND disappear_time > '" . $params[':time'] . "'" . $tmpSQL . ")";
+        }
+        return $this->query_active($select, $conds, $params, $encSql, $zeroSql, $hundoSql);
     }
 
-    public function get_active_by_id($ids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $zeroIv, $despawnTimeType, $gender, $swLat, $swLng, $neLat, $neLng)
+    public function get_active_by_id($ids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $zeroIv, $hundoIv, $despawnTimeType, $gender, $swLat, $swLng, $neLat, $neLng)
     {
         global $db;
         $conds = array();
@@ -229,10 +234,14 @@ class RocketMap_MAD extends RocketMap
         if (!$noHighLevelData && !empty($zeroIv) && $zeroIv === 'true') {
             $zeroSql = " OR (individual_attack = 0 AND individual_defense = 0 AND individual_stamina = 0 AND disappear_time > '" . $params[':time'] . "')";
         }
-        return $this->query_active($select, $conds, $params, '', $zeroSql);
+        $hundoSql = '';
+        if (!$noHighLevelData && !empty($hundoIv) && $hundoIv === 'true') {
+            $hundoSql = " OR (individual_attack = 15 AND individual_defense = 15 AND individual_stamina = 15 AND disappear_time > '" . $params[':time'] . "')";
+        }
+        return $this->query_active($select, $conds, $params, '', $zeroSql, $hundoSql);
     }
 
-    public function query_active($select, $conds, $params, $encSql = '', $zeroSql = '')
+    public function query_active($select, $conds, $params, $encSql = '', $zeroSql = '', $hundoSql = '')
     {
         global $db;
 
@@ -242,7 +251,7 @@ class RocketMap_MAD extends RocketMap
         WHERE :conditions ORDER BY p.latitude, p.longitude";
 
         $query = str_replace(":select", $select, $query);
-        $query = str_replace(":conditions", '(' . join(" AND ", $conds) . ')' . $encSql . $zeroSql, $query);
+        $query = str_replace(":conditions", '(' . join(" AND ", $conds) . ')' . $encSql . $zeroSql . $hundoSql, $query);
         $pokemons = $db->query($query, $params)->fetchAll(\PDO::FETCH_ASSOC);
 
         $data = array();

--- a/pre-index.php
+++ b/pre-index.php
@@ -268,7 +268,7 @@ if (strtolower($map) === "rdm") {
                                             <div class="dropdown-divider"></div>
                                             <div class="form-check form-switch">
                                                 <input class="form-check-input" id="missing-iv-only-switch" type="checkbox" name="missing-iv-only-switch">
-                                                <label class="form-check-label"  for="missing-iv-only-switch"><?php echo i8ln('Only Missing IV') ?></label>
+                                                <label class="form-check-label" for="missing-iv-only-switch"><?php echo i8ln('Only Missing IV') ?></label>
                                             </div>
                                         <?php
                                         }
@@ -284,7 +284,7 @@ if (strtolower($map) === "rdm") {
                                             <div class="dropdown-divider"></div>
                                             <div class="form-check form-switch">
                                                 <input class="form-check-input" id="big-karp-switch" type="checkbox" name="big-karp-switch">
-                                                <label class="form-check-label"  for="big-karp-switch"><?php echo i8ln('Only Big Magikarp') ?></label>
+                                                <label class="form-check-label" for="big-karp-switch"><?php echo i8ln('Only Big Magikarp') ?></label>
                                             </div>
                                         <?php
                                         }
@@ -292,7 +292,15 @@ if (strtolower($map) === "rdm") {
                                             <div class="dropdown-divider"></div>
                                             <div class="form-check form-switch">
                                                 <input class="form-check-input" id="no-zero-iv-switch" type="checkbox" name="no-zero-iv-switch">
-                                                <label class="form-check-label"  for="no-zero-iv-switch"><?php echo i8ln('Show 0%IV (Ignore Filters)') ?></label>
+                                                <label class="form-check-label" for="no-zero-iv-switch"><?php echo i8ln('Show 0%IV (Ignore Filters)') ?></label>
+                                            </div>
+                                        <?php
+                                        }
+                                        if (! $noHundoIvToggle) { ?>
+                                            <div class="dropdown-divider"></div>
+                                            <div class="form-check form-switch">
+                                                <input class="form-check-input" id="no-hundo-iv-switch" type="checkbox" name="no-hundo-iv-switch">
+                                                <label class="form-check-label" for="no-hundo-iv-switch"><?php echo i8ln('Show 100%IV (Ignore Filters)') ?></label>
                                             </div>
                                         <?php
                                         }
@@ -1623,6 +1631,7 @@ include('modals.php');
     var showBigKarp = <?php echo $noBigKarp === true ? 'true' : 'false' ?>;
     var showTinyRat = <?php echo $noTinyRat === true ? 'true' : 'false' ?>;
     var showZeroIv = <?php echo $noZeroIvToggle === true ? 'true' : 'false' ?>;
+    var showHundoIv = <?php echo $noHundoIvToggle === true ? 'true' : 'false' ?>;
     var showDespawnTimeType = <?php echo $noDespawnTimeType ? 0 : $showDespawnTimeType ?>;
     var showPokemonGender = <?php echo $noPokemonGender ? 0 : $showPokemonGender ?>;
     var hidePokemonCoords = <?php echo $hidePokemonCoords === true ? 'true' : 'false' ?>;

--- a/raw_data.php
+++ b/raw_data.php
@@ -38,6 +38,7 @@ $exMinIv = !empty($_POST['exMinIV']) ? $_POST['exMinIV'] : '';
 $bigKarp = !empty($_POST['bigKarp']) ? $_POST['bigKarp'] : false;
 $tinyRat = !empty($_POST['tinyRat']) ? $_POST['tinyRat'] : false;
 $zeroIv = !empty($_POST['zeroIv']) ? $_POST['zeroIv'] : false;
+$hundoIv = !empty($_POST['hundoIv']) ? $_POST['hundoIv'] : false;
 $despawnTimeType = !empty($_POST['despawnTimeType']) ? $_POST['despawnTimeType'] : 0;
 $pokemonGender = !empty($_POST['pokemonGender']) ? $_POST['pokemonGender'] : 0;
 $lastpokemon = !empty($_POST['lastpokemon']) ? $_POST['lastpokemon'] : false;
@@ -153,12 +154,12 @@ if (!$noPokemon) {
             $eids = array_unique(array_merge($eids, $pokemonToExclude));
         }
         if ($lastpokemon != 'true') {
-            $d["pokemons"] = $scanner->get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $zeroIv, $despawnTimeType, $pokemonGender, $swLat, $swLng, $neLat, $neLng, 0, 0, 0, 0, 0, $enc_id);
+            $d["pokemons"] = $scanner->get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $zeroIv, $hundoIv, $despawnTimeType, $pokemonGender, $swLat, $swLng, $neLat, $neLng, 0, 0, 0, 0, 0, $enc_id);
         } else {
             if ($newarea) {
-                $d["pokemons"] = $scanner->get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $zeroIv, $despawnTimeType, $pokemonGender, $swLat, $swLng, $neLat, $neLng, 0, $oSwLat, $oSwLng, $oNeLat, $oNeLng, $enc_id);
+                $d["pokemons"] = $scanner->get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $zeroIv, $hundoIv, $despawnTimeType, $pokemonGender, $swLat, $swLng, $neLat, $neLng, 0, $oSwLat, $oSwLng, $oNeLat, $oNeLng, $enc_id);
             } else {
-                $d["pokemons"] = $scanner->get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $zeroIv, $despawnTimeType, $pokemonGender, $swLat, $swLng, $neLat, $neLng, $timestamp, 0, 0, 0, 0, $enc_id);
+                $d["pokemons"] = $scanner->get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $zeroIv, $hundoIv, $despawnTimeType, $pokemonGender, $swLat, $swLng, $neLat, $neLng, $timestamp, 0, 0, 0, 0, $enc_id);
             }
         }
         $d["preMinIV"] = $minIv;
@@ -168,7 +169,7 @@ if (!$noPokemon) {
 
             $reidsDiff = array_diff($reids, $eids);
             if (count($reidsDiff)) {
-                $d["pokemons"] = array_merge($d["pokemons"], $scanner->get_active_by_id($reidsDiff, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $zeroIv, $despawnTimeType, $pokemonGender, $swLat, $swLng, $neLat, $neLng));
+                $d["pokemons"] = array_merge($d["pokemons"], $scanner->get_active_by_id($reidsDiff, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $zeroIv, $hundoIv, $despawnTimeType, $pokemonGender, $swLat, $swLng, $neLat, $neLng));
             }
 
             $d["reids"] = $reids;

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -296,6 +296,11 @@ var StoreOptions = {
             default: showZeroIv,
             type: StoreTypes.Boolean
         },
+    'showHundoIv':
+        {
+            default: showHundoIv,
+            type: StoreTypes.Boolean
+        },
     'showDespawnTimeType':
         {
             default: showDespawnTimeType,

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1065,6 +1065,7 @@ function initSidebar() {
     $('#big-karp-switch').prop('checked', Store.get('showBigKarp'))
     $('#tiny-rat-switch').prop('checked', Store.get('showTinyRat'))
     $('#no-zero-iv-switch').prop('checked', Store.get('showZeroIv'))
+    $('#no-hundo-iv-switch').prop('checked', Store.get('showHundoIv'))
     $('#despawn-time-type-select').val(Store.get('showDespawnTimeType'))
     $('#pokemon-gender-select').val(Store.get('showPokemonGender'))
     $('#pokestops-switch').prop('checked', Store.get('showPokestops'))
@@ -3204,9 +3205,9 @@ function addListeners(marker) {
 function clearStaleMarkers() {
     $.each(mapData.pokemons, function (key, value) {
         var pvpFiltered = false
-        var isZeroIvMons = (mapData.pokemons[key]['individual_attack'] !== null && mapData.pokemons[key]['individual_attack'] === 0 && mapData.pokemons[key]['individual_defense'] !== null && mapData.pokemons[key]['individual_defense'] === 0 && mapData.pokemons[key]['individual_stamina'] !== null && mapData.pokemons[key]['individual_stamina'] === 0)
+        var monsIgnoreFilters = ((mapData.pokemons[key]['individual_attack'] !== null && mapData.pokemons[key]['individual_defense'] !== null && mapData.pokemons[key]['individual_stamina'] !== null) && ((Store.get('showZeroIv') === true && mapData.pokemons[key]['individual_attack'] === 0 && mapData.pokemons[key]['individual_defense'] === 0 && mapData.pokemons[key]['individual_stamina'] === 0) || (Store.get('showHundoIv') === true && mapData.pokemons[key]['individual_attack'] === 15 && mapData.pokemons[key]['individual_defense'] === 15 && mapData.pokemons[key]['individual_stamina'] === 15)))
 
-        if ((minLLRank > 0 || minGLRank > 0 || minULRank > 0) && (Store.get('showZeroIv') === false || (Store.get('showZeroIv') === true && !isZeroIvMons))) {
+        if ((minLLRank > 0 || minGLRank > 0 || minULRank > 0) && !monsIgnoreFilters) {
             pvpFiltered = true
             if (minLLRank > 0 && pvpFiltered) {
                 var littleLeague = JSON.parse(mapData.pokemons[key]['pvp_rankings_little_league'])
@@ -3242,7 +3243,7 @@ function clearStaleMarkers() {
                 (excludedPokemon.indexOf(mapData.pokemons[key]['pokemon_id']) >= 0 ||
                     isTemporaryHidden(mapData.pokemons[key]['pokemon_id']) ||
                     (pvpFiltered) ||
-                    (((((mapData.pokemons[key]['individual_attack'] + mapData.pokemons[key]['individual_defense'] + mapData.pokemons[key]['individual_stamina']) / 45 * 100) < minIV && (Store.get('showZeroIv') === false || (Store.get('showZeroIv') === true && !isZeroIvMons))) || (((mapType === 'rdm' && mapData.pokemons[key]['level'] < minLevel) || (mapType === 'rocketmap' && !isNaN(minLevel) && (mapData.pokemons[key]['cp_multiplier'] < cpMultiplier[minLevel - 1]))) && (Store.get('showZeroIv') === false || (Store.get('showZeroIv') === true && !isZeroIvMons)))) && !excludedMinIV.includes(mapData.pokemons[key]['pokemon_id']) && Store.get('showMissingIVOnly') === false) ||
+                    (((((mapData.pokemons[key]['individual_attack'] + mapData.pokemons[key]['individual_defense'] + mapData.pokemons[key]['individual_stamina']) / 45 * 100) < minIV && !monsIgnoreFilters) || (((mapType === 'rdm' && mapData.pokemons[key]['level'] < minLevel) || (mapType === 'rocketmap' && !isNaN(minLevel) && (mapData.pokemons[key]['cp_multiplier'] < cpMultiplier[minLevel - 1]))) && !monsIgnoreFilters)) && !excludedMinIV.includes(mapData.pokemons[key]['pokemon_id']) && Store.get('showMissingIVOnly') === false) ||
                     (Store.get('showMissingIVOnly') === true && mapData.pokemons[key]['individual_attack'] !== null) ||
                     (Store.get('showBigKarp') === true && mapData.pokemons[key]['pokemon_id'] === 129 && (mapData.pokemons[key]['weight'] < 13.14 || mapData.pokemons[key]['weight'] === null)) ||
                     (Store.get('showTinyRat') === true && mapData.pokemons[key]['pokemon_id'] === 19 && (mapData.pokemons[key]['weight'] > 2.40 || mapData.pokemons[key]['weight'] === null)) ||
@@ -3387,6 +3388,7 @@ function loadRawData() {
     var bigKarp = Boolean(Store.get('showBigKarp'))
     var tinyRat = Boolean(Store.get('showTinyRat'))
     var zeroIv = Boolean(Store.get('showZeroIv'))
+    var hundoIv = Boolean(Store.get('showHundoIv'))
     var despawnTimeType = Store.get('showDespawnTimeType')
     var pokemonGender = Store.get('showPokemonGender')
     var exEligible = Boolean(Store.get('exEligible'))
@@ -3457,6 +3459,7 @@ function loadRawData() {
             'bigKarp': bigKarp,
             'tinyRat': tinyRat,
             'zeroIv': zeroIv,
+            'hundoIv': hundoIv,
             'despawnTimeType': despawnTimeType,
             'pokemonGender': pokemonGender,
             'swLat': swLat,
@@ -4816,7 +4819,8 @@ function processPokemons(i, item) {
             }
         }
         if (encounterId !== item['encounter_id']) {
-            if ((minLLRank > 0 || minGLRank > 0 || minULRank > 0) && (Store.get('showZeroIv') === false || (Store.get('showZeroIv') === true && !(item['individual_attack'] !== null && item['individual_attack'] === 0 && item['individual_defense'] !== null && item['individual_defense'] === 0 && item['individual_stamina'] !== null && item['individual_stamina'] === 0)))) {
+            var monsIgnoreFilters = ((item['individual_attack'] !== null && item['individual_defense'] !== null && item['individual_stamina'] !== null) && ((Store.get('showZeroIv') === true && item['individual_attack'] === 0 && item['individual_defense'] === 0 && item['individual_stamina'] === 0) || (Store.get('showHundoIv') === true && item['individual_attack'] === 15 && item['individual_defense'] === 15 && item['individual_stamina'] === 15)))
+            if ((minLLRank > 0 || minGLRank > 0 || minULRank > 0) && !monsIgnoreFilters) {
                 var pvpFiltered = true
                 if (minLLRank > 0 && pvpFiltered) {
                     var littleLeague = JSON.parse(item['pvp_rankings_little_league'])
@@ -6797,6 +6801,11 @@ $(function () {
         })
         $('#no-zero-iv-switch').on('change', function (e) {
             Store.set('showZeroIv', this.checked)
+            lastpokemon = false
+            updateMap()
+        })
+        $('#no-hundo-iv-switch').on('change', function (e) {
+            Store.set('showHundoIv', this.checked)
             lastpokemon = false
             updateMap()
         })


### PR DESCRIPTION
- allows users to display 100%IV mons on the map regardless of the value used in the MinIV, MinLVL, MinLLR, MinGLR or MinULR filters.

new config variables
- `$noHundoIvToggle`. Default: `false` (enabled)