### PR TITLE
add global per league pvp filter for cp and rank

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -252,6 +252,7 @@
     "processRewardStats": true,
     "processShinyStats": true,
     "noPvp": true,
+    "noPvpCapText": true,
     "noHideSingleMarker": true,
     "enableJSDebug": true
   }

--- a/config/default.php
+++ b/config/default.php
@@ -259,15 +259,20 @@ $pokemonToExclude = [];
 $pokemonGenSearchString = 'generation';                             // When custom string is used translations do not work.
 
 $noPvp = false;                                                     // true/false
-
-$excludeMinIV = '[]';                                               // [] for empty
-
-$minLLRank = '0';                                                   // "0" for empty or a number
-$minGLRank = '0';                                                   // "0" for empty or a number
-$minULRank = '0';                                                   // "0" for empty or a number
+$noPvpCapText = false;                                              // Add [Cap XX] text in popup. true/false
+$minLLRank = '0';                                                   // Default user interface filter value. '0' for empty or a number
+$minGLRank = '0';                                                   // Default user interface filter value. '0' for empty or a number
+$minULRank = '0';                                                   // Default user interface filter value. '0' for empty or a number
+$globalRankLimitLL = 4096;                                          // 0 = Dynamic limit according to active user filter, 1 to 4096(max) = Fixed limit
+$globalRankLimitGL = 4096;                                          // 0 = Dynamic limit according to active user filter, 1 to 4096(max) = Fixed limit
+$globalRankLimitUL = 4096;                                          // 0 = Dynamic limit according to active user filter, 1 to 4096(max) = Fixed limit
+$globalCpLimitLL = 0;                                               // 0 = no limit or a number like 450
+$globalCpLimitGL = 0;                                               // 0 = no limit or a number like 1400
+$globalCpLimitUL = 0;                                               // 0 = no limit or a number like 2400
 
 $minIV = '0';                                                       // "0" for empty or a number
 $minLevel = '0';                                                    // "0" for empty or a number
+$excludeMinIV = '[131, 143, 147, 148, 149, 248]';                   // [] for empty
 
 $noMissingIVOnly = true;                                            // true/false
 $noBigKarp = false;                                                 // true/false

--- a/config/example.config.php
+++ b/config/example.config.php
@@ -259,15 +259,20 @@ $pokemonToExclude = [];
 $pokemonGenSearchString = 'generation';                             // When custom string is used translations do not work.
 
 $noPvp = false;                                                     // true/false
-
-$excludeMinIV = '[131, 143, 147, 148, 149, 248]';                   // [] for empty
-
+$noPvpCapText = false;                                              // Add [Cap XX] text in popup. true/false
 $minLLRank = '0';                                                   // "0" for empty or a number
 $minGLRank = '0';                                                   // "0" for empty or a number
 $minULRank = '0';                                                   // "0" for empty or a number
+$globalRankLimitLL = 4096;                                          // 0 = Dynamic limit according to active user filter, 1 to 4096(max) = Fixed limit
+$globalRankLimitGL = 4096;                                          // 0 = Dynamic limit according to active user filter, 1 to 4096(max) = Fixed limit
+$globalRankLimitUL = 4096;                                          // 0 = Dynamic limit according to active user filter, 1 to 4096(max) = Fixed limit
+$globalCpLimitLL = 0;                                               // 0 = no limit or a number like 450
+$globalCpLimitGL = 0;                                               // 0 = no limit or a number like 1400
+$globalCpLimitUL = 0;                                               // 0 = no limit or a number like 2400
 
 $minIV = '0';                                                       // "0" for empty or a number
 $minLevel = '0';                                                    // "0" for empty or a number
+$excludeMinIV = '[131, 143, 147, 148, 149, 248]';                   // [] for empty
 
 $noMissingIVOnly = true;                                            // true/false
 $noBigKarp = false;                                                 // true/false

--- a/pre-index.php
+++ b/pre-index.php
@@ -1712,6 +1712,7 @@ include('modals.php');
     var noDarkMode = <?php echo $noDarkMode === true ? 'true' : 'false' ?>;
     var noCatchRates = <?php echo $noCatchRates === true ? 'true' : 'false' ?>;
     var noPvp = <?php echo $noPvp === true ? 'true' : 'false' ?>;
+    var noPvpCapText = <?php echo $noPvpCapText === true ? 'true' : 'false' ?>;
     var noHideSingleMarker = <?php echo $noHideSingleMarker === true ? 'true' : 'false' ?>;
     var enableJSDebug = <?php echo $enableJSDebug === true ? 'true' : 'false' ?>;
     // When A Setting Is Disabled, Ensure Filtering Is Also Disabled to Prevent Invisible Filtering

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1373,6 +1373,11 @@ function pokemonLabel(item) {
                 }
                 if (ranking.cp !== null) {
                     infoString += ' @' + ranking.cp + i8ln('CP') + ' (' + i8ln('Lvl') + ' ' + (ranking.level) + ')'
+                    if (!noPvpCapText) {
+                        infoString += ' [' + i8ln('Cap') + ' ' + (ranking.cap) + ']'
+                    }
+                }
+                if (ranking.cp !== null) {
                 }
 
                 let color = ''
@@ -1406,6 +1411,9 @@ function pokemonLabel(item) {
                 }
                 if (ranking.cp !== null) {
                     infoString += ' @' + ranking.cp + i8ln('CP') + ' (' + i8ln('Lvl') + ' ' + (ranking.level) + ')'
+                    if (!noPvpCapText) {
+                        infoString += ' [' + i8ln('Cap') + ' ' + (ranking.cap) + ']'
+                    }
                 }
 
                 let color = ''
@@ -1439,6 +1447,9 @@ function pokemonLabel(item) {
                 }
                 if (ranking.cp !== null) {
                     infoString += ' @' + ranking.cp + i8ln('CP') + ' (' + i8ln('Lvl') + ' ' + (ranking.level) + ')'
+                    if (!noPvpCapText) {
+                        infoString += ' [' + i8ln('Cap') + ' ' + (ranking.cap) + ']'
+                    }
                 }
 
                 let color = ''


### PR DESCRIPTION
- any pvp rankings that does not pass either of those global limits will be discarded. They will fail any pvp checks and will never be displayed to the user.
- if «$globalRankLimitXX» is set to 0, the limit will be the user’s current filter setting in his UI. Ex: user has his filter set to 3/3/3, it will only try to match ranks 1 to 3, only display ranks 1 to 3 and discard any rankings from 4 to 4096.
- if «$globalRankLimitXX» is set to 1000, it will only try to match ranks 1 to 1000, only display ranks 1 to 1000 and discard any rankings from 1001 to 4096.
- add optional «[Cap XX]» text in popup to provide clarity for different ranks with same cp, level and mons that can occur when using multiple level caps calculations.
- to preserve pmsf’s current behavior, the defaults are set to not filter anything but you probably want to set the CpLimit variables to something like 450/1400/2400 to weed out low cp mons.

__New Config Variables:__
`$noPvpCapText`. Default: `false` (Enabled)
`$globalRankLimitLL`. Default: `4096`
`$globalRankLimitGL`. Default: `4096`
`$globalRankLimitUL`. Default: `4096`
`$globalCpLimitLL`. Default `0`
`$globalCpLimitGL`. Default `0`
`$globalCpLimitUL`. Default: `0`