### PR TITLE
check existence of new column instead of old one (rdm incidents)

### DIFF
--- a/lib/RDM.php
+++ b/lib/RDM.php
@@ -583,7 +583,7 @@ class RDM extends Scanner
     public function query_stops($conds, $params, $quests_with_ar)
     {
         global $db;
-        $rdmGrunts = ($this->columnExists("pokestop","grunt_type")) ? "" : " LEFT JOIN (SELECT `pokestop_id` AS pokestop_id_incident, MIN(`character`) AS grunt_type, `expiration` AS incident_expire_timestamp FROM incident WHERE `expiration` > UNIX_TIMESTAMP() GROUP BY `pokestop_id_incident`) AS i ON i.`pokestop_id_incident` = p.`id` ";
+        $rdmGrunts = ($this->columnExists("incident","pokestop_id")) ? " LEFT JOIN (SELECT `pokestop_id` AS pokestop_id_incident, MIN(`character`) AS grunt_type, `expiration` AS incident_expire_timestamp FROM incident WHERE `expiration` > UNIX_TIMESTAMP() GROUP BY `pokestop_id_incident`) AS i ON i.`pokestop_id_incident` = p.`id` " : "";
 
         $ar_string = ($quests_with_ar === true) ? "" : "alternative_";
         $query = "SELECT id AS pokestop_id,
@@ -1036,10 +1036,10 @@ class RDM extends Scanner
                 $data[] = $pokestop['reward_item_id'];
             }
         } elseif ($type === 'gruntlist') {
-            if ($this->columnExists("pokestop","grunt_type")) {
-                $pokestops = $db->query("SELECT distinct grunt_type FROM pokestop WHERE grunt_type > 0 AND incident_expire_timestamp > UNIX_TIMESTAMP() order by grunt_type;")->fetchAll(\PDO::FETCH_ASSOC);
-            } else {
+            if ($this->columnExists("incident","pokestop_id")) {
                 $pokestops = $db->query("SELECT distinct `character` AS grunt_type FROM incident WHERE `expiration` > UNIX_TIMESTAMP() ORDER BY `character`;")->fetchAll(\PDO::FETCH_ASSOC);
+            } else {
+                $pokestops = $db->query("SELECT distinct grunt_type FROM pokestop WHERE grunt_type > 0 AND incident_expire_timestamp > UNIX_TIMESTAMP() order by grunt_type;")->fetchAll(\PDO::FETCH_ASSOC);
             }
             $data = array();
             foreach ($pokestops as $pokestop) {

--- a/lib/Scanner.php
+++ b/lib/Scanner.php
@@ -27,10 +27,10 @@ class Scanner
     public function columnExists($table = '', $column = '')
     {
         global $db;
-        if (empty($table) || empty($column)) {
-            return false;
+        if (!empty($table) && !empty($column) && (count($db->query("SHOW TABLES LIKE '$table';")->fetchAll(\PDO::FETCH_ASSOC)) > 0) && (count($db->query("SHOW COLUMNS FROM `$table` WHERE LOWER(`Field`) = LOWER('$column');")->fetchAll(\PDO::FETCH_ASSOC)) > 0)) {
+            return true;
         }
-        return (count($db->query("SHOW COLUMNS FROM `$table` WHERE LOWER(`Field`) = LOWER('$column');")->fetchAll(\PDO::FETCH_ASSOC)) > 0) ? true : false;
+        return false;
     }
 
     /**

--- a/lib/stats/Stats.php
+++ b/lib/stats/Stats.php
@@ -26,10 +26,10 @@ class Stats
     public function columnExists($table = '', $column = '')
     {
         global $db;
-        if (empty($table) || empty($column)) {
-            return false;
+        if (!empty($table) && !empty($column) && (count($db->query("SHOW TABLES LIKE '$table';")->fetchAll(\PDO::FETCH_ASSOC)) > 0) && (count($db->query("SHOW COLUMNS FROM `$table` WHERE LOWER(`Field`) = LOWER('$column');")->fetchAll(\PDO::FETCH_ASSOC)) > 0)) {
+            return true;
         }
-        return (count($db->query("SHOW COLUMNS FROM `$table` WHERE LOWER(`Field`) = LOWER('$column');")->fetchAll(\PDO::FETCH_ASSOC)) > 0) ? true : false;
+        return false;
     }
 
     /**

--- a/lib/stats/Stats.rdm.php
+++ b/lib/stats/Stats.rdm.php
@@ -81,7 +81,7 @@ class RDM extends Stats
     {
       global $db, $noBoundaries, $boundaries, $noQuestsARTaskToggle;
 
-      $rdmGrunts = ($this->columnExists("pokestop","grunt_type")) ? "" : " LEFT JOIN (SELECT `pokestop_id` AS pokestop_id_incident, MIN(`character`) AS grunt_type, `expiration` AS incident_expire_timestamp FROM incident WHERE `expiration` > UNIX_TIMESTAMP() GROUP BY `pokestop_id_incident`) AS i ON i.`pokestop_id_incident` = p.`id` ";
+      $rdmGrunts = ($this->columnExists("incident","pokestop_id")) ? " LEFT JOIN (SELECT `pokestop_id` AS pokestop_id_incident, MIN(`character`) AS grunt_type, `expiration` AS incident_expire_timestamp FROM incident WHERE `expiration` > UNIX_TIMESTAMP() GROUP BY `pokestop_id_incident`) AS i ON i.`pokestop_id_incident` = p.`id` " : "";
       $alternative_quests = ($noQuestsARTaskToggle) ? "" : " SUM(alternative_quest_type IS NOT NULL) AS alternative_quest, ";
 
       $geofenceSQL = '';


### PR DESCRIPTION
- solves issue that can occur when the `grunt_type` column is not deleted from the `pokestop` table during the rdm migration.
- improve `columnExists()`