### PR TITLE
use columns instead of json_extract when possible

### DIFF
--- a/lib/RocketMap_MAD.php
+++ b/lib/RocketMap_MAD.php
@@ -640,7 +640,7 @@ class RocketMap_MAD extends RocketMap
             }
             $xpSQL = '';
             if (!empty($xpamount) && !is_nan((float)$xpamount) && $xpamount > 0) {
-                $xpSQL .= " OR (tq.quest_reward_type = 1 AND json_extract(json_extract(`tq.quest_reward`,'$[*].exp'),'$[0]') >= :xpamount)";
+                $xpSQL .= " OR (tq.quest_reward_type = 1 AND tq.quest_stardust >= :xpamount)";
                 $params[':xpamount'] = intval($xpamount);
             }
             $conds[] = "((" . $pokemonSQL . ") OR (" . $itemSQL . ") OR (" . $energySQL . ") OR (" . $candySQL . ")" . $dustSQL . $xpSQL . ")";
@@ -736,7 +736,7 @@ class RocketMap_MAD extends RocketMap
                 $params[':dustamount'] = intval($dustamount);
             }
             if ($reloadxpamount == "true") {
-                $tmpSQL .= "(tq.quest_reward_type = 1 AND json_extract(json_extract(`tq.quest_reward`,'$[*].exp'),'$[0]') > :xpamount)";
+                $tmpSQL .= "(tq.quest_reward_type = 1 AND tq.quest_stardust > :xpamount)";
                 $params[':xpamount'] = intval($xpamount);
             }
             $conds[] = $tmpSQL;
@@ -787,8 +787,7 @@ class RocketMap_MAD extends RocketMap
         tq.quest_item_amount AS reward_item_amount,
         tq.quest_stardust AS reward_dust_amount,
         json_extract(json_extract(`quest_reward`,'$[*].candy.amount'),'$[0]') AS reward_candy_amount,
-        json_extract(json_extract(`quest_reward`,'$[*].candy.pokemon_id'),'$[0]') AS reward_candy_pokemon_id,
-        json_extract(json_extract(`quest_reward`,'$[*].exp'),'$[0]') AS reward_xp_amount
+        json_extract(json_extract(`quest_reward`,'$[*].candy.pokemon_id'),'$[0]') AS reward_candy_pokemon_id
         FROM pokestop p
         LEFT JOIN trs_quest tq ON tq.GUID = p.pokestop_id
         WHERE :conditions";
@@ -817,7 +816,7 @@ class RocketMap_MAD extends RocketMap
             }
             switch ($pokestop["quest_reward_type"]) {
                 case 1:
-                    $pokestop["reward_amount"] = intval($pokestop["reward_xp_amount"]);
+                    $pokestop["reward_amount"] = intval($pokestop["reward_dust_amount"]);
                     break;
                 case 2:
                     $pokestop["reward_amount"] = intval($pokestop["reward_item_amount"]);

--- a/lib/search/Search.rdm.php
+++ b/lib/search/Search.rdm.php
@@ -47,7 +47,7 @@ class RDM extends Search
             }
         }
         if (!empty($presids)) {
-            $conds[] = "json_extract(json_extract(`".$ar_string."quest_rewards`,'$[*].info.pokemon_id'),'$[0]') IN (" . implode(',', $presids) . ")";
+            $conds[] = $ar_string."quest_pokemon_id IN (" . implode(',', $presids) . ")";
         }
         if (!empty($iresids)) {
             $conds[] = $ar_string."quest_item_id IN (" . implode(',', $iresids) . ")";
@@ -75,9 +75,9 @@ class RDM extends Search
         url,
         ".$ar_string."quest_type AS quest_type,
         ".$ar_string."quest_reward_type AS quest_reward_type,
-        json_extract(json_extract(`".$ar_string."quest_rewards`,'$[*].info.pokemon_id'),'$[0]') AS reward_pokemon_id,
+        ".$ar_string."quest_pokemon_id AS reward_pokemon_id,
         ".$ar_string."quest_item_id AS reward_item_id,
-        json_extract(json_extract(`".$ar_string."quest_rewards`,'$[*].info.amount'),'$[0]') AS reward_amount,
+        ".$ar_string."quest_reward_amount AS reward_amount,
         json_extract(json_extract(`".$ar_string."quest_rewards`,'$[*].info.form_id'),'$[0]') AS reward_pokemon_formid,
         json_extract(json_extract(`".$ar_string."quest_rewards`,'$[*].info.costume_id'),'$[0]') AS reward_pokemon_costumeid,
         json_extract(json_extract(`".$ar_string."quest_rewards`,'$[*].info.gender_id'),'$[0]') AS reward_pokemon_genderid,

--- a/lib/search/Search.rocketmap_mad.php
+++ b/lib/search/Search.rocketmap_mad.php
@@ -82,7 +82,6 @@ class RocketMap_MAD extends Search
         json_extract(json_extract(`quest_reward`,'$[*].pokemon_encounter.pokemon_display.is_shiny'),'$[0]') AS reward_pokemon_shiny,
         json_extract(json_extract(`quest_reward`,'$[*].candy.pokemon_id'),'$[0]') AS reward_candy_pokemon_id,
         json_extract(json_extract(`quest_reward`,'$[*].candy.amount'),'$[0]') AS reward_candy_amount,
-        json_extract(json_extract(`quest_reward`,'$[*].exp'),'$[0]') AS reward_xp_amount,
         ROUND(( 3959 * acos( cos( radians(:lat) ) * cos( radians( latitude ) ) * cos( radians( longitude ) - radians(:lon) ) + sin( radians(:lat) ) * sin( radians( latitude ) ) ) ),2) AS distance
         FROM pokestop p
         LEFT JOIN trs_quest tq ON tq.GUID = p.pokestop_id
@@ -99,7 +98,7 @@ class RocketMap_MAD extends Search
         foreach ($rewards as $reward) {
             switch ($reward["quest_reward_type"]) {
                 case 1:
-                    $reward["reward_amount"] = intval($reward["reward_xp_amount"]);
+                    $reward["reward_amount"] = intval($reward["reward_dust_amount"]);
                     break;
                 case 2:
                     $reward["reward_amount"] = intval($reward["reward_item_amount"]);

--- a/lib/stats/Stats.rdm.php
+++ b/lib/stats/Stats.rdm.php
@@ -208,51 +208,51 @@ class RDM extends Stats
       }
 
       if ($noQuestsARTaskToggle) {
-      $rewards = $db->query("
-        SELECT
-          COUNT(*) as count,
-          quest_item_id,
-          quest_pokemon_id,
-          json_extract(json_extract(`quest_rewards`,'$[*].info.pokemon_id'),'$[0]') AS quest_energy_pokemon_id,
-          json_extract(json_extract(`quest_rewards`,'$[*].info.form_id'),'$[0]') AS quest_pokemon_form,
-          json_extract(json_extract(`quest_rewards`,'$[*].info.costume_id'),'$[0]') AS quest_pokemon_costume,
-          json_extract(json_extract(`quest_rewards`,'$[*].info.amount'),'$[0]') AS quest_reward_amount,
-          quest_reward_type
-        FROM pokestop
-        WHERE quest_reward_type IS NOT NULL $geofenceSQL
-        GROUP BY quest_reward_type, quest_item_id, quest_reward_amount, quest_pokemon_id, quest_pokemon_form, quest_pokemon_costume
-        ORDER BY quest_reward_type, quest_item_id, CAST(quest_reward_amount AS UNSIGNED), quest_pokemon_id, quest_pokemon_form, quest_pokemon_costume;");
-        $total = $db->query("SELECT COUNT(quest_reward_type) AS total FROM pokestop WHERE quest_reward_type IS NOT NULL $geofenceSQL")->fetch();
+          $rewards = $db->query("
+            SELECT
+              COUNT(*) as count,
+              quest_item_id,
+              quest_pokemon_id,
+              quest_pokemon_id AS quest_energy_pokemon_id,
+              json_extract(json_extract(`quest_rewards`,'$[*].info.form_id'),'$[0]') AS quest_pokemon_form,
+              json_extract(json_extract(`quest_rewards`,'$[*].info.costume_id'),'$[0]') AS quest_pokemon_costume,
+              quest_reward_amount AS quest_reward_amount,
+              quest_reward_type
+            FROM pokestop
+            WHERE quest_reward_type IS NOT NULL $geofenceSQL
+            GROUP BY quest_reward_type, quest_item_id, quest_reward_amount, quest_pokemon_id, quest_pokemon_form, quest_pokemon_costume
+            ORDER BY quest_reward_type, quest_item_id, CAST(quest_reward_amount AS UNSIGNED), quest_pokemon_id, quest_pokemon_form, quest_pokemon_costume;");
+            $total = $db->query("SELECT COUNT(quest_reward_type) AS total FROM pokestop WHERE quest_reward_type IS NOT NULL $geofenceSQL")->fetch();
       } else {
-      $rewards = $db->query("
-      SELECT COUNT(*) as count, quest_item_id, quest_pokemon_id,quest_energy_pokemon_id, quest_pokemon_form, quest_pokemon_costume, quest_reward_amount, quest_reward_type
-      FROM
-      (
-        SELECT
-          quest_item_id,
-          quest_pokemon_id,
-          json_extract(json_extract(`quest_rewards`,'$[*].info.pokemon_id'),'$[0]') AS quest_energy_pokemon_id,
-          json_extract(json_extract(`quest_rewards`,'$[*].info.form_id'),'$[0]') AS quest_pokemon_form,
-          json_extract(json_extract(`quest_rewards`,'$[*].info.costume_id'),'$[0]') AS quest_pokemon_costume,
-          json_extract(json_extract(`quest_rewards`,'$[*].info.amount'),'$[0]') AS quest_reward_amount,
-          quest_reward_type
-        FROM pokestop
-        WHERE quest_reward_type IS NOT NULL $geofenceSQL
-      UNION ALL
-        SELECT
-          alternative_quest_item_id AS quest_item_id,
-          alternative_quest_pokemon_id AS quest_pokemon_id,
-          json_extract(json_extract(`alternative_quest_rewards`,'$[*].info.pokemon_id'),'$[0]') AS quest_energy_pokemon_id,
-          json_extract(json_extract(`alternative_quest_rewards`,'$[*].info.form_id'),'$[0]') AS quest_pokemon_form,
-          json_extract(json_extract(`alternative_quest_rewards`,'$[*].info.costume_id'),'$[0]') AS quest_pokemon_costume,
-          json_extract(json_extract(`alternative_quest_rewards`,'$[*].info.amount'),'$[0]') AS quest_reward_amount,
-          alternative_quest_reward_type AS quest_reward_type
-        FROM pokestop
-        WHERE alternative_quest_reward_type IS NOT NULL $geofenceSQL
-      ) combined
-      GROUP BY quest_reward_type, quest_item_id, quest_reward_amount, quest_pokemon_id, quest_pokemon_form, quest_pokemon_costume
-      ORDER BY quest_reward_type, quest_item_id, CAST(quest_reward_amount AS UNSIGNED), quest_pokemon_id, quest_pokemon_form, quest_pokemon_costume;");
-      $total = $db->query("SELECT (COUNT(quest_reward_type)+COUNT(alternative_quest_reward_type)) AS total FROM pokestop WHERE quest_reward_type IS NOT NULL OR alternative_quest_reward_type IS NOT NULL $geofenceSQL")->fetch();
+          $rewards = $db->query("
+          SELECT COUNT(*) as count, quest_item_id, quest_pokemon_id,quest_energy_pokemon_id, quest_pokemon_form, quest_pokemon_costume, quest_reward_amount, quest_reward_type
+          FROM
+          (
+            SELECT
+              quest_item_id,
+              quest_pokemon_id,
+              quest_pokemon_id AS quest_energy_pokemon_id,
+              json_extract(json_extract(`quest_rewards`,'$[*].info.form_id'),'$[0]') AS quest_pokemon_form,
+              json_extract(json_extract(`quest_rewards`,'$[*].info.costume_id'),'$[0]') AS quest_pokemon_costume,
+              quest_reward_amount AS quest_reward_amount,
+              quest_reward_type
+            FROM pokestop
+            WHERE quest_reward_type IS NOT NULL $geofenceSQL
+          UNION ALL
+            SELECT
+              alternative_quest_item_id AS quest_item_id,
+              alternative_quest_pokemon_id AS quest_pokemon_id,
+              alternative_quest_pokemon_id AS quest_energy_pokemon_id,
+              json_extract(json_extract(`alternative_quest_rewards`,'$[*].info.form_id'),'$[0]') AS quest_pokemon_form,
+              json_extract(json_extract(`alternative_quest_rewards`,'$[*].info.costume_id'),'$[0]') AS quest_pokemon_costume,
+              alternative_quest_reward_amount AS quest_reward_amount,
+              alternative_quest_reward_type AS quest_reward_type
+            FROM pokestop
+            WHERE alternative_quest_reward_type IS NOT NULL $geofenceSQL
+          ) combined
+          GROUP BY quest_reward_type, quest_item_id, quest_reward_amount, quest_pokemon_id, quest_pokemon_form, quest_pokemon_costume
+          ORDER BY quest_reward_type, quest_item_id, CAST(quest_reward_amount AS UNSIGNED), quest_pokemon_id, quest_pokemon_form, quest_pokemon_costume;");
+          $total = $db->query("SELECT (COUNT(quest_reward_type)+COUNT(alternative_quest_reward_type)) AS total FROM pokestop WHERE quest_reward_type IS NOT NULL OR alternative_quest_reward_type IS NOT NULL $geofenceSQL")->fetch();
       }
 
       $data = array();

--- a/lib/stats/Stats.rocketmap_mad.php
+++ b/lib/stats/Stats.rocketmap_mad.php
@@ -212,7 +212,6 @@ class RocketMap_MAD extends Stats
           tq.quest_pokemon_costume_id AS quest_pokemon_costume,
           tq.quest_item_amount AS quest_item_amount,
           tq.quest_stardust AS quest_dust_amount,
-          json_extract(json_extract(`tq.quest_reward`,'$[*].exp'),'$[0]') AS quest_xp_amount,
           tq.quest_reward_type AS quest_reward_type
         FROM trs_quest tq
         LEFT JOIN pokestop p ON p.pokestop_id = tq.GUID
@@ -253,7 +252,7 @@ class RocketMap_MAD extends Stats
           $questReward["quest_reward_amount"] = $reward["quest_dust_amount"];
         } elseif ($reward["quest_reward_type"] == 1) {
           $questReward["name"] = i8ln('XP');
-          $questReward["quest_reward_amount"] = $reward["quest_xp_amount"];
+          $questReward["quest_reward_amount"] = $reward["quest_dust_amount"];
         }
         
         $data[] = $questReward;


### PR DESCRIPTION
- better for query performance.
- rdm has had auto-generated columns for a while so json_extracts no longer make sense.
- mad now uses `quest_stardust` for xp and dust amounts in both master(PR#1273) and async(PR#1272).