### PR TITLE
fix `quest_candy_pokemon_id` key not existing and remove unnecessary …

### DIFF
--- a/lib/stats/Stats.rdm.php
+++ b/lib/stats/Stats.rdm.php
@@ -213,7 +213,6 @@ class RDM extends Stats
               COUNT(*) as count,
               quest_item_id,
               quest_pokemon_id,
-              quest_pokemon_id AS quest_energy_pokemon_id,
               json_extract(json_extract(`quest_rewards`,'$[*].info.form_id'),'$[0]') AS quest_pokemon_form,
               json_extract(json_extract(`quest_rewards`,'$[*].info.costume_id'),'$[0]') AS quest_pokemon_costume,
               quest_reward_amount AS quest_reward_amount,
@@ -225,13 +224,12 @@ class RDM extends Stats
             $total = $db->query("SELECT COUNT(quest_reward_type) AS total FROM pokestop WHERE quest_reward_type IS NOT NULL $geofenceSQL")->fetch();
       } else {
           $rewards = $db->query("
-          SELECT COUNT(*) as count, quest_item_id, quest_pokemon_id,quest_energy_pokemon_id, quest_pokemon_form, quest_pokemon_costume, quest_reward_amount, quest_reward_type
+          SELECT COUNT(*) as count, quest_item_id, quest_pokemon_id, quest_pokemon_form, quest_pokemon_costume, quest_reward_amount, quest_reward_type
           FROM
           (
             SELECT
               quest_item_id,
               quest_pokemon_id,
-              quest_pokemon_id AS quest_energy_pokemon_id,
               json_extract(json_extract(`quest_rewards`,'$[*].info.form_id'),'$[0]') AS quest_pokemon_form,
               json_extract(json_extract(`quest_rewards`,'$[*].info.costume_id'),'$[0]') AS quest_pokemon_costume,
               quest_reward_amount AS quest_reward_amount,
@@ -242,7 +240,6 @@ class RDM extends Stats
             SELECT
               alternative_quest_item_id AS quest_item_id,
               alternative_quest_pokemon_id AS quest_pokemon_id,
-              alternative_quest_pokemon_id AS quest_energy_pokemon_id,
               json_extract(json_extract(`alternative_quest_rewards`,'$[*].info.form_id'),'$[0]') AS quest_pokemon_form,
               json_extract(json_extract(`alternative_quest_rewards`,'$[*].info.costume_id'),'$[0]') AS quest_pokemon_costume,
               alternative_quest_reward_amount AS quest_reward_amount,
@@ -258,7 +255,6 @@ class RDM extends Stats
       $data = array();
       foreach ($rewards as $reward) {
         $questReward["quest_pokemon_id"] = intval($reward["quest_pokemon_id"]);
-        $questReward["quest_energy_pokemon_id"] = intval($reward["quest_energy_pokemon_id"]);
         $questReward["quest_pokemon_form"] = intval($reward["quest_pokemon_form"]);
         $questReward["quest_pokemon_costume"] = intval($reward["quest_pokemon_costume"]);
         $questReward["quest_item_id"] = intval($reward["quest_item_id"]);
@@ -267,7 +263,7 @@ class RDM extends Stats
         $questReward["count"] = $reward["count"];
         $questReward["percentage"] = round(100 / $total["total"] * $reward["count"], 3) . '%';
         if ($reward["quest_reward_type"] == 12) {
-          $questReward["name"] = i8ln($this->data[$reward['quest_energy_pokemon_id']]["name"]);
+          $questReward["name"] = i8ln($this->data[$reward['quest_pokemon_id']]["name"]);
         } elseif ($reward["quest_reward_type"] == 7) {
           $questReward["name"] = i8ln($this->data[$reward['quest_pokemon_id']]["name"]);
         } elseif ($reward["quest_reward_type"] == 2) {

--- a/lib/stats/Stats.rocketmap_mad.php
+++ b/lib/stats/Stats.rocketmap_mad.php
@@ -207,7 +207,6 @@ class RocketMap_MAD extends Stats
           COUNT(GUID) as count,
           tq.quest_item_id, 
           tq.quest_pokemon_id, 
-          tq.quest_pokemon_id AS quest_energy_pokemon_id,
           tq.quest_pokemon_form_id AS quest_pokemon_form,
           tq.quest_pokemon_costume_id AS quest_pokemon_costume,
           tq.quest_item_amount AS quest_item_amount,
@@ -230,7 +229,6 @@ class RocketMap_MAD extends Stats
       $data = array();
       foreach ($rewards as $reward) {
         $questReward["quest_pokemon_id"] = intval($reward["quest_pokemon_id"]);
-        $questReward["quest_energy_pokemon_id"] = intval($reward["quest_energy_pokemon_id"]);
         $questReward["quest_pokemon_form"] = intval($reward["quest_pokemon_form"]);
         $questReward["quest_pokemon_costume"] = intval($reward["quest_pokemon_costume"]);
         $questReward["quest_item_id"] = intval($reward["quest_item_id"]);
@@ -239,7 +237,7 @@ class RocketMap_MAD extends Stats
         $questReward["quest_reward_type"] = intval($reward["quest_reward_type"]);
         
         if ($reward["quest_reward_type"] == 12) {
-          $questReward["name"] = i8ln($this->data[$reward['quest_energy_pokemon_id']]["name"]);
+          $questReward["name"] = i8ln($this->data[$reward['quest_pokemon_id']]["name"]);
           $questReward["quest_reward_amount"] = $reward["quest_item_amount"];
         } elseif ($reward["quest_reward_type"] == 7) {
           $questReward["name"] = i8ln($this->data[$reward['quest_pokemon_id']]["name"]);

--- a/static/js/stats.js
+++ b/static/js/stats.js
@@ -408,7 +408,7 @@ function processRewardStats(i, item) { // eslint-disable-line no-unused-vars
             type = i8ln('Stardust')
             break
         case 4:
-            reward = '<img src="' + getIcon(iconpath.reward, 'reward/candy', '.png', item['quest_candy_pokemon_id']) + '" style="width:40px;">' +
+            reward = '<img src="' + getIcon(iconpath.reward, 'reward/candy', '.png', item['quest_pokemon_id']) + '" style="width:40px;">' +
             hiddenName
             type = i8ln('Candy')
             break
@@ -418,7 +418,7 @@ function processRewardStats(i, item) { // eslint-disable-line no-unused-vars
             type = i8ln('Pokémon')
             break
         case 12:
-            reward = '<img src="' + getIcon(iconpath.reward, 'reward/mega_resource', '.png', item['quest_energy_pokemon_id'], item['quest_reward_amount']) + '" style="width:40px;">' +
+            reward = '<img src="' + getIcon(iconpath.reward, 'reward/mega_resource', '.png', item['quest_pokemon_id'], item['quest_reward_amount']) + '" style="width:40px;">' +
             hiddenName
             type = i8ln('Mega Energy')
             break


### PR DESCRIPTION
…`quest_energy_pokemon_id`

- `quest_candy_pokemon_id` was not set anywhere which resulted in `0.png` being used for the FullStats instead of the actual mon's candy if available. The correct information was always in `quest_pokemon_id` which is now used.
- `quest_pokemon_id AS quest_energy_pokemon_id` is wasteful when you are already asking for `quest_pokemon_id` in the same SQL query. `quest_energy_pokemon_id` is therefore removed and `quest_pokemon_id` used instead.