### PR TITLE
better solution than #749

### DIFF
--- a/lib/RDM.php
+++ b/lib/RDM.php
@@ -585,7 +585,7 @@ class RDM extends Scanner
     public function query_stops($conds, $params, $quests_with_ar)
     {
         global $db, $noQuests, $noQuestsPokemon, $noQuestsItems, $noQuestsEnergy, $noQuestsCandy, $noQuestsStardust, $noQuestsXP;
-        $rdmGrunts = ($this->columnExists("incident","pokestop_id")) ? " LEFT JOIN (SELECT `pokestop_id` AS pokestop_id_incident, MIN(`character`) AS grunt_type, `expiration` AS incident_expire_timestamp FROM `incident` WHERE `expiration` > UNIX_TIMESTAMP() GROUP BY `pokestop_id_incident`, `expiration`) AS i ON i.`pokestop_id_incident` = p.`id` " : "";
+        $rdmGrunts = ($this->columnExists("incident","pokestop_id")) ? " LEFT JOIN (SELECT `pokestop_id` AS pokestop_id_incident, MIN(`character`) AS grunt_type, IF(MIN(`character`) IN (41,42,43,44), MAX(`expiration`), MIN(`expiration`)) AS incident_expire_timestamp FROM `incident` WHERE `expiration` > UNIX_TIMESTAMP() GROUP BY `pokestop_id_incident`) AS i ON i.`pokestop_id_incident` = p.`id` " : "";
 
         $ar_string = ($quests_with_ar === true) ? "" : "alternative_";
         $query = "SELECT id AS pokestop_id,

--- a/lib/stats/Stats.rdm.php
+++ b/lib/stats/Stats.rdm.php
@@ -81,7 +81,7 @@ class RDM extends Stats
     {
       global $db, $noBoundaries, $boundaries, $noQuestsARTaskToggle;
 
-      $rdmGrunts = ($this->columnExists("incident","pokestop_id")) ? " LEFT JOIN (SELECT `pokestop_id` AS pokestop_id_incident, MIN(`character`) AS grunt_type, `expiration` AS incident_expire_timestamp FROM `incident` WHERE `expiration` > UNIX_TIMESTAMP() GROUP BY `pokestop_id_incident`, `expiration`) AS i ON i.`pokestop_id_incident` = p.`id` " : "";
+      $rdmGrunts = ($this->columnExists("incident","pokestop_id")) ? " LEFT JOIN (SELECT `pokestop_id` AS pokestop_id_incident, MIN(`character`) AS grunt_type, IF(MIN(`character`) IN (41,42,43,44), MAX(`expiration`), MIN(`expiration`)) AS incident_expire_timestamp FROM `incident` WHERE `expiration` > UNIX_TIMESTAMP() GROUP BY `pokestop_id_incident`) AS i ON i.`pokestop_id_incident` = p.`id` " : "";
       $alternative_quests = ($noQuestsARTaskToggle) ? "" : " SUM(alternative_quest_type IS NOT NULL) AS alternative_quest, ";
 
       $geofenceSQL = '';


### PR DESCRIPTION
- #749 may not work as intended in some scenarios (duplicates).
- this should work as intended based the current knowledge about multiple invasion.
- the better solution is a more complex subquery or 2 queries processed in php but the performance impact of either solution is too big on larger incident tables while providing no benefit if current knowledge doesn’t change.
- the final solution would be full support for multiple invasions but it’s not possible right now.