### PR TITLE
move incident deduping from left join to php

### DIFF
--- a/lib/RDM.php
+++ b/lib/RDM.php
@@ -379,7 +379,7 @@ class RDM extends Scanner
         $params[':neLat'] = $neLat;
         $params[':neLng'] = $neLng;
         global $noBoundaries, $boundaries, $hideDeleted, $showStopsOutsideBoundaries;
-        $ar_string = ($quests_with_ar === true) ? "" : "alternative_";
+        $questPrefix = ($quests_with_ar === true) ? "quest" : "alternative_quest";
         if (!$noBoundaries && !$showStopsOutsideBoundaries) {
             $conds[] = "(ST_WITHIN(point(lat, lon),ST_GEOMFROMTEXT('POLYGON(( " . $boundaries . " ))')))";
         }
@@ -397,9 +397,9 @@ class RDM extends Scanner
                     $p++;
                 }
                 $pkmn_in = substr($pkmn_in, 0, -1);
-                $pokemonSQL .= $ar_string."quest_pokemon_id NOT IN ( $pkmn_in ) AND ".$ar_string."quest_reward_type = 7";
+                $pokemonSQL .= "{$questPrefix}_pokemon_id NOT IN ( $pkmn_in ) AND {$questPrefix}_reward_type = 7";
             } else {
-                $pokemonSQL .= $ar_string."quest_reward_type = 7";
+                $pokemonSQL .= "{$questPrefix}_reward_type = 7";
             }
             $energySQL = '';
             if (count($qeeids)) {
@@ -411,9 +411,9 @@ class RDM extends Scanner
                     $p++;
                 }
                 $pkmn_in = substr($pkmn_in, 0, -1);
-                $energySQL .= $ar_string."quest_pokemon_id NOT IN ( $pkmn_in ) AND ".$ar_string."quest_reward_type = 12";
+                $energySQL .= "{$questPrefix}_pokemon_id NOT IN ( $pkmn_in ) AND {$questPrefix}_reward_type = 12";
             } else {
-                $energySQL .= $ar_string."quest_reward_type = 12";
+                $energySQL .= "{$questPrefix}_reward_type = 12";
             }
             $candySQL = '';
             if (count($qceids)) {
@@ -425,9 +425,9 @@ class RDM extends Scanner
                     $p++;
                 }
                 $pkmn_in = substr($pkmn_in, 0, -1);
-                $candySQL .= $ar_string."quest_pokemon_id NOT IN ( $pkmn_in ) AND ".$ar_string."quest_reward_type = 4";
+                $candySQL .= "{$questPrefix}_pokemon_id NOT IN ( $pkmn_in ) AND {$questPrefix}_reward_type = 4";
             } else {
-                $candySQL .= $ar_string."quest_reward_type = 4";
+                $candySQL .= "{$questPrefix}_reward_type = 4";
             }
             $itemSQL = '';
             if (count($qieids)) {
@@ -439,18 +439,18 @@ class RDM extends Scanner
                     $i++;
                 }
                 $item_in = substr($item_in, 0, -1);
-                $itemSQL .= $ar_string."quest_item_id NOT IN ( $item_in )";
+                $itemSQL .= "{$questPrefix}_item_id NOT IN ( $item_in )";
             } else {
-                $itemSQL .= $ar_string."quest_item_id IS NOT NULL";
+                $itemSQL .= "{$questPrefix}_item_id IS NOT NULL";
             }
             $dustSQL = '';
             if (!empty($dustamount) && !is_nan((float)$dustamount) && $dustamount > 0) {
-                $dustSQL .= " OR (".$ar_string."quest_reward_type = 3 AND ".$ar_string."quest_reward_amount >= :dustamount)";
+                $dustSQL .= " OR ({$questPrefix}_reward_type = 3 AND {$questPrefix}_reward_amount >= :dustamount)";
                 $params[':dustamount'] = intval($dustamount);
             }
             $xpSQL = '';
             if (!empty($xpamount) && !is_nan((float)$xpamount) && $xpamount > 0) {
-                $xpSQL .= " OR (".$ar_string."quest_reward_type = 1 AND ".$ar_string."quest_reward_amount >= :xpamount)";
+                $xpSQL .= " OR ({$questPrefix}_reward_type = 1 AND {$questPrefix}_reward_amount >= :xpamount)";
                 $params[':xpamount'] = intval($xpamount);
             }
             $conds[] = "((" . $pokemonSQL . ") OR (" . $itemSQL . ") OR (" . $energySQL . ") OR (" . $candySQL . ")" . $dustSQL . $xpSQL . ")";
@@ -502,7 +502,7 @@ class RDM extends Scanner
         $params[':neLng'] = $neLng;
 
         global $noBoundaries, $boundaries, $hideDeleted;
-        $ar_string = ($quests_with_ar === true) ? "" : "alternative_";
+        $questPrefix = ($quests_with_ar === true) ? "quest" : "alternative_quest";
         if (!$noBoundaries) {
             $conds[] = "(ST_WITHIN(point(lat, lon),ST_GEOMFROMTEXT('POLYGON(( " . $boundaries . " ))')))";
         }
@@ -520,7 +520,7 @@ class RDM extends Scanner
                     $p++;
                 }
                 $pkmn_in = substr($pkmn_in, 0, -1);
-                $tmpSQL .= $ar_string."quest_pokemon_id IN ( $pkmn_in ) AND ".$ar_string."quest_reward_type = 7";
+                $tmpSQL .= "{$questPrefix}_pokemon_id IN ( $pkmn_in ) AND {$questPrefix}_reward_type = 7";
             }
             if (count($qereids)) {
                 $pkmn_in = '';
@@ -531,7 +531,7 @@ class RDM extends Scanner
                     $p++;
                 }
                 $pkmn_in = substr($pkmn_in, 0, -1);
-                $tmpSQL .= $ar_string."quest_pokemon_id IN ( $pkmn_in ) AND ".$ar_string."quest_reward_type = 12";
+                $tmpSQL .= "{$questPrefix}_pokemon_id IN ( $pkmn_in ) AND {$questPrefix}_reward_type = 12";
             }
             if (count($qcreids)) {
                 $pkmn_in = '';
@@ -542,7 +542,7 @@ class RDM extends Scanner
                     $p++;
                 }
                 $pkmn_in = substr($pkmn_in, 0, -1);
-                $tmpSQL .= $ar_string."quest_pokemon_id IN ( $pkmn_in ) AND ".$ar_string."quest_reward_type = 4";
+                $tmpSQL .= "{$questPrefix}_pokemon_id IN ( $pkmn_in ) AND {$questPrefix}_reward_type = 4";
             }
             if (count($qireids)) {
                 $item_in = '';
@@ -553,14 +553,14 @@ class RDM extends Scanner
                     $i++;
                 }
                 $item_in = substr($item_in, 0, -1);
-                $tmpSQL .= $ar_string."quest_item_id IN ( $item_in )";
+                $tmpSQL .= "{$questPrefix}_item_id IN ( $item_in )";
             }
             if ($reloaddustamount == "true") {
-                $tmpSQL .= "(".$ar_string."quest_reward_type = 3 AND ".$ar_string."quest_reward_amount >= :dustamount)";
+                $tmpSQL .= "({$questPrefix}_reward_type = 3 AND {$questPrefix}_reward_amount >= :dustamount)";
                 $params[':dustamount'] = intval($dustamount);
             }
             if ($reloadxpamount == "true") {
-                $tmpSQL .= "(".$ar_string."quest_reward_type = 1 AND ".$ar_string."quest_reward_amount >= :xpamount)";
+                $tmpSQL .= "({$questPrefix}_reward_type = 1 AND {$questPrefix}_reward_amount >= :xpamount)";
                 $params[':xpamount'] = intval($xpamount);
             }
             $conds[] = $tmpSQL;

--- a/lib/RDM.php
+++ b/lib/RDM.php
@@ -617,7 +617,7 @@ class RDM extends Scanner
                 json_extract(json_extract(`{$questPrefix}_rewards`,'$[*].info.costume_id'),'$[0]') AS reward_pokemon_costumeid,
                 json_extract(json_extract(`{$questPrefix}_rewards`,'$[*].info.gender_id'),'$[0]') AS reward_pokemon_genderid,
                 json_extract(json_extract(`{$questPrefix}_rewards`,'$[*].info.shiny'),'$[0]') AS reward_pokemon_shiny
-            FROM pokestop AS p
+            FROM `pokestop` AS p
             LEFT JOIN `incident` AS i ON i.`pokestop_id` = p.`id` AND i.`expiration` > UNIX_TIMESTAMP()
             WHERE :conditions";
         } else {
@@ -648,7 +648,7 @@ class RDM extends Scanner
                 json_extract(json_extract(`{$questPrefix}_rewards`,'$[*].info.costume_id'),'$[0]') AS reward_pokemon_costumeid,
                 json_extract(json_extract(`{$questPrefix}_rewards`,'$[*].info.gender_id'),'$[0]') AS reward_pokemon_genderid,
                 json_extract(json_extract(`{$questPrefix}_rewards`,'$[*].info.shiny'),'$[0]') AS reward_pokemon_shiny
-            FROM pokestop AS p
+            FROM `pokestop` AS p
             WHERE :conditions";
         }
         

--- a/lib/stats/Stats.rdm.php
+++ b/lib/stats/Stats.rdm.php
@@ -81,7 +81,7 @@ class RDM extends Stats
     {
       global $db, $noBoundaries, $boundaries, $noQuestsARTaskToggle;
 
-      $rdmGrunts = ($this->columnExists("incident","pokestop_id")) ? " LEFT JOIN (SELECT `pokestop_id` AS pokestop_id_incident, MIN(`character`) AS grunt_type, IF(MIN(`character`) IN (41,42,43,44), MAX(`expiration`), MIN(`expiration`)) AS incident_expire_timestamp FROM `incident` WHERE `expiration` > UNIX_TIMESTAMP() GROUP BY `pokestop_id_incident`) AS i ON i.`pokestop_id_incident` = p.`id` " : "";
+      $rdmGrunts = ($this->columnExists("incident","pokestop_id")) ? "(SELECT COUNT(DISTINCT `pokestop_id`) FROM `incident` WHERE `expiration` > UNIX_TIMESTAMP()) AS rocket," : "SUM(incident_expire_timestamp > UNIX_TIMESTAMP()) AS rocket,";
       $alternative_quests = ($noQuestsARTaskToggle) ? "" : " SUM(alternative_quest_type IS NOT NULL) AS alternative_quest, ";
 
       $geofenceSQL = '';
@@ -93,14 +93,13 @@ class RDM extends Stats
         SELECT
           SUM(quest_type IS NOT NULL) AS quest,
           $alternative_quests
-          SUM(incident_expire_timestamp > UNIX_TIMESTAMP()) AS rocket,
+          $rdmGrunts
           SUM(lure_expire_timestamp > UNIX_TIMESTAMP() AND lure_id = 501) AS normal_lure,
           SUM(lure_expire_timestamp > UNIX_TIMESTAMP() AND lure_id = 502) AS glacial_lure,
           SUM(lure_expire_timestamp > UNIX_TIMESTAMP() AND lure_id = 503) AS mossy_lure,
           SUM(lure_expire_timestamp > UNIX_TIMESTAMP() AND lure_id = 504) AS magnetic_lure,
           SUM(lure_expire_timestamp > UNIX_TIMESTAMP() AND lure_id = 505) AS rainy_lure
         FROM pokestop p
-        $rdmGrunts
         $geofenceSQL"
       )->fetch();
 


### PR DESCRIPTION
- The left join worked as intended for raw_data refreshes on smaller setups but it was just too expansive and slow on larger setups for a query that runs every few seconds. The left join has been simplified to the minimum required to join the tables which improves backend performance on all setups (query+php).
- FullStats: the query to gather the stop statistics was slow due to the same left join. An alternate method is now used which allows the removal of the left join and make the query more performant.
