### PR TITLE
DateTime -> Passing null to is deprecated in php 8.1

### DIFF
--- a/lib/RDM.php
+++ b/lib/RDM.php
@@ -1066,7 +1066,7 @@ class RDM extends Scanner
     public function generated_exclude_list($type)
     {
         global $db, $userTimezone, $noQuestsARTaskToggle;
-        $curdate = new \DateTime(null, new \DateTimeZone($userTimezone));
+        $curdate = new \DateTime('', new \DateTimeZone($userTimezone));
         if ($type === 'pokemonlist') {
             if ($noQuestsARTaskToggle) {
                 $pokestops = $db->query("SELECT distinct quest_pokemon_id AS reward_pokemon_id FROM pokestop WHERE quest_pokemon_id > 0 AND DATE(FROM_UNIXTIME(quest_timestamp)) = '" . $curdate->format('Y-m-d') . "' AND quest_reward_type = 7 order by quest_pokemon_id;")->fetchAll(\PDO::FETCH_ASSOC);

--- a/lib/RocketMap_MAD.php
+++ b/lib/RocketMap_MAD.php
@@ -886,7 +886,7 @@ class RocketMap_MAD extends RocketMap
     public function generated_exclude_list($type)
     {
         global $db, $userTimezone;
-        $curdate = new \DateTime(null, new \DateTimeZone($userTimezone));
+        $curdate = new \DateTime('', new \DateTimeZone($userTimezone));
         if ($type === 'pokemonlist') {
             $pokestops = $db->query("SELECT distinct quest_pokemon_id AS reward_pokemon_id FROM trs_quest WHERE quest_pokemon_id > 0 AND DATE(FROM_UNIXTIME(quest_timestamp)) = '" . $curdate->format('Y-m-d') . "' AND quest_reward_type = 7 order by quest_pokemon_id;")->fetchAll(\PDO::FETCH_ASSOC);
             $data = array();

--- a/utils.php
+++ b/utils.php
@@ -176,7 +176,7 @@ function createUserAccount($user, $password, $newExpireTimestamp)
 
             return true;
             $subject = "[{$title}] - " . i8ln('Welcome') . "";
-            $message .= i8ln('Dear') . " {$user},<br><br>";
+            $message = i8ln('Dear') . " {$user},<br><br>";
             $message .= i8ln('Your account has been created') . "<br>";
             if ($discordUrl) {
                 $message .= i8ln('For support, ask your questions in the ') . "<a href='{$discordUrl}'>" . i8ln('discord guild') . "</a>!<br><br>";
@@ -219,7 +219,7 @@ function resetUserPassword($user, $password, $resetType)
             "login_system" => 'native'
         ]);
         $subject = "[{$title}] - Password Reset";
-        $message .= i8ln('Dear') . " {$user},<br><br>";
+        $message = i8ln('Dear') . " {$user},<br><br>";
         $message .= i8ln('Your password has been reset') . "<br>";
         $message .= i8ln('If you haven\'t requested a new password you can ignore this email.') . "<br>";
         $message .= i8ln('Your old password is still working.') . "<br><br>";


### PR DESCRIPTION
- empty string works down to at least 7.4 which goes past End Of Life in Nov 2022
- also `$message` was declared properly before being `.=`